### PR TITLE
Add Task 'returnType' to tool generator.

### DIFF
--- a/source/Nuke.ToolGenerator/Generators/ModelExtensions.cs
+++ b/source/Nuke.ToolGenerator/Generators/ModelExtensions.cs
@@ -9,6 +9,8 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using Nuke.ToolGenerator.Model;
 
+
+
 namespace Nuke.ToolGenerator.Generators
 {
     public static class ModelExtensions
@@ -100,6 +102,16 @@ namespace Nuke.ToolGenerator.Generators
         public static string GetTaskMethodName (this Task task)
         {
             return $"{task.Tool.Name}{task.Postfix}";
+        }
+
+        public static string GetReturnType (this Task task)
+        {
+            return task.ReturnType ?? "void";
+        }
+
+        public static bool HasReturnType (this Task task)
+        {
+            return task.GetReturnType() != "void";
         }
     }
 }

--- a/source/Nuke.ToolGenerator/Generators/TaskGenerator.cs
+++ b/source/Nuke.ToolGenerator/Generators/TaskGenerator.cs
@@ -72,7 +72,7 @@ namespace Nuke.ToolGenerator.Generators
                                 "ProcessSettings processSettings = null"
                             });
 
-            return $"public static void {task.GetTaskMethodName()} ({parameterDeclarations.Join()})";
+            return $"public static {task.GetReturnType()} {task.GetTaskMethodName()} ({parameterDeclarations.Join()})";
         }
 
         private static void WriteMainTaskBlock (TaskWriter writer)
@@ -82,7 +82,8 @@ namespace Nuke.ToolGenerator.Generators
                     .WriteLine($"PreProcess(toolSettings);")
                     .WriteLine($"var process = {GetProcessStart(writer.Task)};")
                     .WriteLine(GetProcessAssertion(writer.Task))
-                    .WriteLine($"PostProcess(toolSettings);");
+                    .WriteLine($"PostProcess(toolSettings);")
+                    .WriteLineIfTrue(writer.Task.HasReturnType(), "return GetResult(process, toolSettings);");
         }
 
         private static string GetProcessStart (Task task)

--- a/source/Nuke.ToolGenerator/Model/Task.cs
+++ b/source/Nuke.ToolGenerator/Model/Task.cs
@@ -19,6 +19,8 @@ namespace Nuke.ToolGenerator.Model
         public string Help { get; set; }
         [CanBeNull]
         public string Postfix { get; set; }
+        [CanBeNull]
+        public string ReturnType { get; set; }
         public bool CustomStart { get; set; }
         public bool CustomAssertion { get; set; }
         public string DefiniteArgument { get; set; }


### PR DESCRIPTION
Adds the 'returnType' property to the tool generator. This allows the generation of tasks which return a value of the given type.
If the return type is used `GetResult(process, toolsettings)` must be implemented.