### PR TITLE
GitRepository: git url parsing update

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -130,11 +130,11 @@ class Build : NukeBuild
     Target Generate => _ => _
             .Executes(() =>
             {
-                var metadataRepository = GitRepository.TryParse(MetadataDirectory).NotNull();
+                var metadataRepository = GitRepository.FromLocalDirectory(MetadataDirectory).NotNull();
                 GenerateCode(
                     MetadataDirectory,
                     GenerationDirectory,
-                    repositoryBaseUrl: $"{metadataRepository.SvnUrl}/blob/{metadataRepository.Branch}",
+                    repositoryBaseUrl: metadataRepository.GetGitHubBrowseUrl("", itemType: GitHubItemType.File),
                     baseNamespace: "Nuke.Common.Tools",
                     useNestedNamespaces: true);
             });

--- a/source/Nuke.Common.Tests/GitRepositoryTest.cs
+++ b/source/Nuke.Common.Tests/GitRepositoryTest.cs
@@ -1,0 +1,79 @@
+﻿// Copyright Matthias Koch 2017.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Nuke.Common.Git;
+using Nuke.Core.IO;
+using Nuke.Core.Utilities;
+using Xunit;
+
+namespace Nuke.Common.Tests
+{
+    public class GitRepositoryTest
+    {
+        [Theory]
+        [InlineData("https://github.com/nuke-build", "github.com", "nuke-build")]
+        [InlineData("https://github.com/nuke-build", "github.com", "nuke-build")]
+        [InlineData("https://github.com/nuke-build/", "github.com", "nuke-build")]
+        [InlineData("https://github.com/nuke-build/nuke", "github.com", "nuke-build/nuke")]
+        [InlineData("https://github.com/nuke-build/nuke.git", "github.com", "nuke-build/nuke")]
+        [InlineData(" https://github.com/TdMxm/nuke.git", "github.com", "TdMxm/nuke")]
+        [InlineData("git@git.test.org:test", "git.test.org", "test")]
+        [InlineData("git@git.test.org/test", "git.test.org", "test")]
+        [InlineData("git@git.test.org/test/", "git.test.org", "test")]
+        [InlineData("git@git.test.org/test.git", "git.test.org", "test")]
+        [InlineData("ssh://git@git.test.org/test.git", "git.test.org", "test")]
+        public void FromUrlTest (string url, string endpoint, string identifier)
+        {
+            var repository = GitRepository.FromUrl(url);
+            repository.Endpoint.Should().Be(endpoint);
+            repository.Identifier.Should().Be(identifier);
+        }
+
+        [Fact]
+        public void FromDirectoryTest ()
+        {
+            var repository = GitRepository.FromLocalDirectory(Directory.GetCurrentDirectory());
+            repository.Endpoint.Should().NotBeNullOrEmpty();
+            repository.Identifier.Should().NotBeNullOrEmpty();
+            repository.LocalDirectory.Should().NotBeNullOrEmpty();
+            repository.Head.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public void GitHubRepositoryFromLocalDirectoryTest ()
+        {
+            var rootDirectory = (PathConstruction.AbsolutePath) Directory.GetCurrentDirectory() / ".." / ".." / ".." / ".." / "..";
+            var repository = GitRepository.FromLocalDirectory(rootDirectory);
+            var httpsUrl = repository.HttpsUrl.TrimEnd(".git");
+            var branch = repository.Branch ?? "master";
+
+            repository.GetGitHubBrowseUrl("LICENSE").Should().Be($"{httpsUrl}/blob/{branch}/LICENSE");
+            repository.GetGitHubBrowseUrl("bootstrapping").Should().Be($"{httpsUrl}/tree/{branch}/bootstrapping");
+
+            repository.GetGitHubBrowseUrl(rootDirectory / "LICENSE").Should().Be($"{httpsUrl}/blob/{branch}/LICENSE");
+            repository.GetGitHubBrowseUrl(rootDirectory / "bootstrapping").Should().Be($"{httpsUrl}/tree/{branch}/bootstrapping");
+
+            repository.GetGitHubBrowseUrl("directory", itemType: GitHubItemType.Directory).Should().Be($"{httpsUrl}/tree/{branch}/directory");
+            repository.GetGitHubBrowseUrl("dir/file", itemType: GitHubItemType.File).Should().Be($"{httpsUrl}/blob/{branch}/dir/file");
+
+            var rawUrl = $"https://raw.githubusercontent.com/{repository.Identifier}";
+            repository.GetGitHubDownloadUrl(rootDirectory / "LICENSE").Should().Be($"{rawUrl}/blob/master/LICENSE");
+        }
+
+        [Fact]
+        public void GitHubRepositoryFromUrlTest ()
+        {
+            var repository = GitRepository.FromUrl("https://github.com/nuke-build/nuke");
+            var httpsUrl = repository.HttpsUrl.TrimEnd(".git");
+            var branch = "dev";
+
+            repository.GetGitHubBrowseUrl("LICENSE", branch, GitHubItemType.File).Should().Be($"{httpsUrl}/blob/{branch}/LICENSE");
+            repository.GetGitHubBrowseUrl("bootstrapping", branch, GitHubItemType.Directory).Should().Be($"{httpsUrl}/tree/{branch}/bootstrapping");
+        }
+    }
+}

--- a/source/Nuke.Common/Git/GitRepositoryAttribute.cs
+++ b/source/Nuke.Common/Git/GitRepositoryAttribute.cs
@@ -22,7 +22,7 @@ namespace Nuke.Common.Git
         {
             return Value = Value
                            ?? ControlFlow.SuppressErrors(() =>
-                               GitRepository.TryParse(NukeBuild.Instance.RootDirectory));
+                               GitRepository.FromLocalDirectory(NukeBuild.Instance.RootDirectory));
         }
     }
 }

--- a/source/Nuke.Common/Git/GitRepositoryExtensions.cs
+++ b/source/Nuke.Common/Git/GitRepositoryExtensions.cs
@@ -1,0 +1,79 @@
+﻿// Copyright Matthias Koch 2017.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.IO;
+using System.Linq;
+using JetBrains.Annotations;
+using Nuke.Core;
+using Nuke.Core.IO;
+
+namespace Nuke.Common.Git
+{
+    public enum GitHubItemType
+    {
+        Automatic,
+        File,
+        Directory
+    }
+
+    public static class GitRepositoryExtensions
+    {
+        /// <summary>Url in the form of <c>https://raw.githubusercontent.com/{identifier}/blob/{branch}/{file}</c>.</summary>
+        public static string GetGitHubDownloadUrl (this GitRepository repository, string file, string branch = null)
+        {
+            branch = branch ?? repository.Branch.NotNull("repository.Branch != null");
+            var fileRelative = GetRepositoryRelativePath(file, repository);
+            return $"https://raw.githubusercontent.com/{repository.Identifier}/blob/{branch}/{fileRelative}";
+        }
+
+        /// <summary>
+        /// Url in the form of <c>https://github.com/{identifier}/tree/{branch}/directory</c> or
+        /// <c>https://github.com/{identifier}/blob/{branch}/file</c> depending on the item type.
+        /// </summary>
+        public static string GetGitHubBrowseUrl (
+            this GitRepository repository,
+            string path = null,
+            string branch = null,
+            GitHubItemType itemType = GitHubItemType.Automatic)
+        {
+            branch = branch ?? repository.Branch.NotNull("repository.Branch != null");
+            var relativePath = GetRepositoryRelativePath(path, repository);
+            var method = GetMethod(relativePath, itemType, repository);
+            ControlFlow.Assert(path == null || method != null, "Could not determine item type.");
+
+            return $"https://github.com/{repository.Identifier}/{method}/{branch}/{relativePath}";
+        }
+
+        [CanBeNull]
+        private static string GetMethod ([CanBeNull] string relativePath, GitHubItemType itemType, GitRepository repository)
+        {
+            var absolutePath = repository.LocalDirectory != null && relativePath != null
+                ? Path.Combine(repository.LocalDirectory, relativePath)
+                : null;
+
+            if (itemType == GitHubItemType.Directory || Directory.Exists(absolutePath) || relativePath == null)
+                return "tree";
+
+            if (itemType == GitHubItemType.File || File.Exists(absolutePath))
+                return "blob";
+
+            return null;
+        }
+
+        [ContractAnnotation("path: null => null; path: notnull => notnull")]
+        private static string GetRepositoryRelativePath ([CanBeNull] string path, GitRepository repository)
+        {
+            if (path == null)
+                return null;
+
+            if (!Path.IsPathRooted(path))
+                return path;
+
+            ControlFlow.Assert(PathConstruction.IsDescendantPath(repository.LocalDirectory.NotNull("repository.LocalDirectory != null"), path),
+                $"PathConstruction.IsDescendantPath({repository.LocalDirectory}, {path})");
+            return PathConstruction.GetRelativePath(repository.LocalDirectory, path);
+        }
+    }
+}

--- a/source/Nuke.Common/Tools/GitLink/GitLinkTasks.cs
+++ b/source/Nuke.Common/Tools/GitLink/GitLinkTasks.cs
@@ -18,12 +18,12 @@ namespace Nuke.Common.Tools.GitLink
                 .SetSolutionDirectory(NukeBuild.Instance.SolutionDirectory)
                 .SetConfiguration(NukeBuild.Instance.Configuration)
                 .SetBranchName(GitVersionAttribute.Value?.BranchName)
-                .SetRepositoryUrl(GitRepositoryAttribute.Value?.SvnUrl);
+                .SetRepositoryUrl(GitRepositoryAttribute.Value?.ToString());
 
         public static GitLink3Settings DefaultGitLink3 => new GitLink3Settings()
                 .SetWorkingDirectory(NukeBuild.Instance.RootDirectory)
                 .SetBaseDirectory(NukeBuild.Instance.RootDirectory)
-                .SetRepositoryUrl(GitRepositoryAttribute.Value?.SvnUrl);
+                .SetRepositoryUrl(GitRepositoryAttribute.Value?.ToString());
 
         static partial void PreProcess (GitLink2Settings toolSettings)
         {

--- a/source/Nuke.Core/IO/PathConstruction.cs
+++ b/source/Nuke.Core/IO/PathConstruction.cs
@@ -49,6 +49,12 @@ namespace Nuke.Core.IO
         {
             return Uri.UnescapeDataString(new Uri($@"{basePath}\").MakeRelativeUri(new Uri(destinationPath)).ToString());
         }
+        
+        [Pure]
+        public static bool IsDescendantPath (string basePath, string destinationPath)
+        {
+            return new Uri(basePath).IsBaseOf(new Uri(destinationPath));
+        }
 
         [Pure]
         public static IEnumerable<string> GlobFiles (string directory, params string[] globPatterns)

--- a/source/Nuke.Core/Utilities/StringExtensions.cs
+++ b/source/Nuke.Core/Utilities/StringExtensions.cs
@@ -126,5 +126,15 @@ namespace Nuke.Core.Utilities
         {
             return values.Join(Environment.NewLine);
         }
+
+        public static string TrimEnd (this string str, string trim)
+        {
+            return str.EndsWith(trim) ? str.Substring(startIndex: 0, length: str.Length - trim.Length) : str;
+        }
+
+        public static string TrimStart (this string str, string trim)
+        {
+            return str.StartsWith(trim) ? str.Substring(trim.Length) : str;
+        }
     }
 }


### PR DESCRIPTION
-Git url parsing regex patch to support nongithub repositories
-Added some GitRepository extension methods
-GitRepository minimum required fields ctor
-Tests for Git url parsing regex