### PR TITLE
Make it possible to use reserved keywords as properties in the nuke metadata definition.

### DIFF
--- a/source/Nuke.CodeGeneration/Generators/DataClassExtensionGenerator.cs
+++ b/source/Nuke.CodeGeneration/Generators/DataClassExtensionGenerator.cs
@@ -43,7 +43,7 @@ namespace Nuke.CodeGeneration.Generators
                     .WriteMethod(
                         $"Set{property.Name}",
                         property,
-                        $"toolSettings.{property.Name} = {property.Name.ToInstance()};")
+                        $"toolSettings.{property.Name} = {property.Name.ToInstance().EscapeParameter()};")
                     .WriteSummaryExtension($"Resets {property.GetCrefTag()}", property)
                     .WriteMethod(
                         $"Reset{property.Name}",
@@ -80,7 +80,7 @@ namespace Nuke.CodeGeneration.Generators
         private static void WriteListExtensions(DataClassWriter writer, Property property)
         {
             var propertyInternal = $"{property.Name}Internal";
-            var propertyInstance = property.Name.ToInstance();
+            var propertyInstance = property.Name.ToInstance().EscapeParameter();
             var valueType = property.GetListValueType();
             var propertyAccess = $"toolSettings.{propertyInternal}";
 
@@ -120,7 +120,7 @@ namespace Nuke.CodeGeneration.Generators
 
         private static void WriteDictionaryExtensions(DataClassWriter writer, Property property)
         {
-            var propertyInstance = property.Name.ToInstance();
+            var propertyInstance = property.Name.ToInstance().EscapeParameter();
             var (keyType, valueType) = property.GetDictionaryKeyValueTypes();
             var propertySingular = property.Name.ToSingular();
             var propertySingularInstance = property.Name.ToSingular().ToInstance();
@@ -264,7 +264,7 @@ namespace Nuke.CodeGeneration.Generators
         private static DataClassWriter WriteMethod(this DataClassWriter writer, string name, Property property, string modification)
         {
             return writer.WriteMethod(name,
-                $"{property.GetNullabilityAttribute()}{property.GetNullableType()} {property.Name.ToInstance()}",
+                $"{property.GetNullabilityAttribute()}{property.GetNullableType()} {property.Name.ToInstance().EscapeParameter()}",
                 modification);
         }
 

--- a/source/Nuke.CodeGeneration/Generators/EnumerationGenerator.cs
+++ b/source/Nuke.CodeGeneration/Generators/EnumerationGenerator.cs
@@ -32,7 +32,7 @@ namespace Nuke.CodeGeneration.Generators
                 .WriteLine($"public partial class {enumeration.Name} : Enumeration")
                 .WriteBlock(w => w.ForEach(enumeration.Values,
                     x => w.WriteLine(
-                        $"public static {enumeration.Name} {GetIdentifier(x)} = new {enumeration.Name} {{ Value = {x.DoubleQuote()} }};")))
+                        $"public static {enumeration.Name} {GetIdentifier(x)} = new {enumeration.Name.EscapeProperty()} {{ Value = {x.DoubleQuote()} }};")))
                 .WriteLine("#endregion");
         }
     }

--- a/source/Nuke.CodeGeneration/Generators/StringExtensions.cs
+++ b/source/Nuke.CodeGeneration/Generators/StringExtensions.cs
@@ -14,6 +14,86 @@ namespace Nuke.CodeGeneration.Generators
 {
     public static class StringExtensions
     {
+        private static readonly string[] s_reservedWords = {
+                                                               "abstract",
+                                                               "as",
+                                                               "base",
+                                                               "bool",
+                                                               "break",
+                                                               "byte",
+                                                               "case",
+                                                               "catch",
+                                                               "char",
+                                                               "checked",
+                                                               "class",
+                                                               "const",
+                                                               "continue",
+                                                               "decimal",
+                                                               "default",
+                                                               "delegate",
+                                                               "do",
+                                                               "double",
+                                                               "else",
+                                                               "enum",
+                                                               "event",
+                                                               "explicit",
+                                                               "extern",
+                                                               "false",
+                                                               "finally",
+                                                               "fixed",
+                                                               "float",
+                                                               "for",
+                                                               "foreach",
+                                                               "goto",
+                                                               "if",
+                                                               "implicit",
+                                                               "in",
+                                                               "int",
+                                                               "interface",
+                                                               "internal",
+                                                               "is",
+                                                               "lock",
+                                                               "long",
+                                                               "namespace",
+                                                               "new",
+                                                               "null",
+                                                               "object",
+                                                               "operator",
+                                                               "out",
+                                                               "override",
+                                                               "params",
+                                                               "private",
+                                                               "protected",
+                                                               "public",
+                                                               "readonly",
+                                                               "ref",
+                                                               "return",
+                                                               "sbyte",
+                                                               "sealed",
+                                                               "short",
+                                                               "sizeof",
+                                                               "stackalloc",
+                                                               "static",
+                                                               "string",
+                                                               "struct",
+                                                               "switch",
+                                                               "this",
+                                                               "throw",
+                                                               "true",
+                                                               "try",
+                                                               "typeof",
+                                                               "uint",
+                                                               "ulong",
+                                                               "unchecked",
+                                                               "unsafe",
+                                                               "ushort",
+                                                               "using",
+                                                               "virtual",
+                                                               "void",
+                                                               "volatile",
+                                                               "while"
+                                                           };
+
         public static string ToInstance(this string text)
         {
             var firstLowerCaseIndex = text.TakeWhile(char.IsUpper).Count();
@@ -21,9 +101,14 @@ namespace Nuke.CodeGeneration.Generators
                    text.Substring(firstLowerCaseIndex);
         }
 
-        public static string Escape(this string text)
+        public static string EscapeParameter(this string parameterName)
         {
-            return new[] { "namespace", "class" }.Contains(text) ? "@" + text : text;
+            return s_reservedWords.Contains(parameterName) ? "@" + parameterName : parameterName;
+        }
+
+        public static string EscapeProperty(this string propertyName)
+        {
+            return s_reservedWords.Contains(propertyName) ? propertyName + "_" : propertyName;
         }
 
         public static string ToMember(this string text)
@@ -72,3 +157,4 @@ namespace Nuke.CodeGeneration.Generators
         }
     }
 }
+


### PR DESCRIPTION
- Add escaping of the parameter name in generated extension if the name equals a reserved C# keyword.
- Add appending of an underscore if an enumeration value equals a reserved C# keyword.