### PR TITLE
When parsing git repository URLs allow for http URLs

### DIFF
--- a/source/Nuke.Common/Git/GitRepository.cs
+++ b/source/Nuke.Common/Git/GitRepository.cs
@@ -45,7 +45,8 @@ namespace Nuke.Common.Git
                 .Skip(count: 1)
                 .TakeWhile(x => !x.StartsWith("["))
                 .SingleOrDefault(x => x.StartsWithOrdinalIgnoreCase("url = "))
-                ?.Split('=')[1];
+                ?.Split('=')[1]
+                .Trim();
             ControlFlow.Assert(url != null, $"Could not parse remote URL for '{remote}'.");
 
             var (endpoint, identifier) = ParseUrl(url);
@@ -63,7 +64,7 @@ namespace Nuke.Common.Git
             var match = new[]
                         {
                             @"git@(?<endpoint>[^:/]+?)(:|/)(?<identifier>.+?)/?(\.git)?$",
-                            @"^https://([^:]+:[^:@]+@)?(?<endpoint>[^/]+?)/(?<identifier>.+?)/?(\.git)?$"
+                            @"^https?://([^:]+:[^:@]+@)?(?<endpoint>[^/]+?)/(?<identifier>.+?)/?(\.git)?$"
                         }
                 .Select(x => Regex.Match(url.Trim(), x))
                 .FirstOrDefault(x => x.Success);


### PR DESCRIPTION
Hi, first of all, thank you for building this great tool.

While looking at the build output on our build server I noticed a warning about a URL that cannot be parsed. Upon inspection of the Nuke code I found that the issue is that we are accessing the git repository via http instead of https. In addition the URL in the warning had a leading whitespace since the whitespace is only trimmed just before applying the regexes.

This PR fixes both issues by making the _s_ in _https_ optional and trimming the whitespace immediately after extracting the URL from the git config file.

Sadly I did not see any way to add tests for this change.