### PR TITLE
Fix missing ampersand when printing NuGet version.

### DIFF
--- a/bootstrapping/build.netfx.ps1
+++ b/bootstrapping/build.netfx.ps1
@@ -39,7 +39,7 @@ if (!(Test-Path $env:NUGET_EXE)) {
 elseif ($NuGetVersion -eq "latest") {
     ExecSafe { & $env:NUGET_EXE update -Self }
 }
-Write-Output $($env:NUGET_EXE help | select -First 1)
+Write-Output $(& $env:NUGET_EXE help | select -First 1)
 
 ExecSafe { & $env:NUGET_EXE install Nuke.MSBuildLocator -ExcludeVersion -OutputDirectory $TempDirectory -SolutionDirectory $SolutionDirectory }
 $MSBuildFile = & "$TempDirectory\Nuke.MSBuildLocator\tools\Nuke.MSBuildLocator.exe"


### PR DESCRIPTION
Missing ampersand. Here's the error without it:

```
PS > .\build.ps1
At build.ps1:42 char:31
+ Write-Output $($env:NUGET_EXE help | select -First 1)
+                               ~~~~
Unexpected token 'help' in expression or statement.
    + CategoryInfo          : ParserError: (:) [], ParseException
    + FullyQualifiedErrorId : UnexpectedToken
```

<!-- For non-trivial pull-requests, please create an issue for discussions first -->