### PR TITLE
Prevent loading of PowerShell-Profile

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell %0\..\build.ps1 %*
+powershell -ExecutionPolicy ByPass -NoProfile %0\..\build.ps1 %*

--- a/source/Nuke.GlobalTool/Program.cs
+++ b/source/Nuke.GlobalTool/Program.cs
@@ -80,7 +80,7 @@ namespace Nuke.GlobalTool
             var process = Process.Start(
                 ScriptHost,
                 EnvironmentInfo.IsWin
-                    ? $"-NoProfile -File {buildScript} {arguments}"
+                    ? $"-ExecutionPolicy ByPass -NoProfile -File {buildScript} {arguments}"
                     : $"{buildScript} {arguments}").NotNull();
 
             process.WaitForExit();

--- a/source/Nuke.GlobalTool/Program.cs
+++ b/source/Nuke.GlobalTool/Program.cs
@@ -17,7 +17,7 @@ namespace Nuke.GlobalTool
     {
         private static string ScriptHost => EnvironmentInfo.IsWin ? "powershell" : "bash";
         private static string ScriptExtension => EnvironmentInfo.IsWin ? "ps1" : "sh";
-        
+
         private const char c_commandPrefix = ':';
 
         private static void Main(string[] args)
@@ -38,7 +38,7 @@ namespace Nuke.GlobalTool
             var rootDirectory = FileSystemTasks.FindParentDirectory(
                 Directory.GetCurrentDirectory(),
                 x => x.GetFiles(NukeBuild.ConfigurationFile).Any());
-            
+
             var hasCommand = args.FirstOrDefault()?.StartsWithOrdinalIgnoreCase(c_commandPrefix.ToString()) ?? false;
             if (hasCommand)
             {
@@ -80,7 +80,7 @@ namespace Nuke.GlobalTool
             var process = Process.Start(
                 ScriptHost,
                 EnvironmentInfo.IsWin
-                    ? $"-File {buildScript} {arguments}"
+                    ? $"-NoProfile -File {buildScript} {arguments}"
                     : $"{buildScript} {arguments}").NotNull();
 
             process.WaitForExit();


### PR DESCRIPTION
This PR prevents loading of the PowerShell profile in the spawned PowerShell process by the GlobalTool.

As long as Nuke doesn't need any imported modules within the PowerShell profile, no profile should be loaded.

In my case it broke the build, because my Profile has a hardcoded `Set-Location` at the end, which switched away from the working directory of my project.

Also this made my builds faster :-)