### PR TITLE
Fix double evaluation of conditions

### DIFF
--- a/source/Nuke.Common.Tests/Execution/BuildExecutorTest.cs
+++ b/source/Nuke.Common.Tests/Execution/BuildExecutorTest.cs
@@ -1,0 +1,158 @@
+﻿// Copyright 2018 Maintainers and Contributors of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Nuke.Common.Execution;
+using Xunit;
+
+namespace Nuke.Common.Tests.Execution
+{
+    public class BuildExecutorTest
+    {
+        [Fact]
+        public void SkipAllTargetsWhenConditionFalseAndBehaviorSkip()
+        {
+            var build = ExecutionTestUtility.CreateBuildAndExecuteDefaultTarget<TestBuild>(x => x.Execute,
+                x =>
+                {
+                    x.OnlyWhenCondition = false;
+                    x.SwitchConditionInDependency = false;
+                    x.DependencyBehavior = DependencyBehavior.Skip;
+                });
+
+            AssertExecutionStatus(build, ExecutionStatus.Skipped, ExecutionStatus.Skipped);
+        }
+
+        [Fact]
+        public void SkipAllTargetsWhenConditionFalseAndBehaviorSkip_SwitchCondition()
+        {
+            var build = ExecutionTestUtility.CreateBuildAndExecuteDefaultTarget<TestBuild>(x => x.Execute,
+                x =>
+                {
+                    x.OnlyWhenCondition = false;
+                    x.SwitchConditionInDependency = true;
+                    x.DependencyBehavior = DependencyBehavior.Skip;
+                });
+
+            AssertExecutionStatus(build, ExecutionStatus.Skipped, ExecutionStatus.Skipped);
+        }
+
+        [Fact]
+        public void ExecuteAllTargetsWhenConditionTrueAndBehaviorSkip()
+        {
+            var build = ExecutionTestUtility.CreateBuildAndExecuteDefaultTarget<TestBuild>(x => x.Execute,
+                x =>
+                {
+                    x.OnlyWhenCondition = true;
+                    x.SwitchConditionInDependency = false;
+                    x.DependencyBehavior = DependencyBehavior.Skip;
+                });
+
+            AssertExecutionStatus(build, ExecutionStatus.Executed, ExecutionStatus.Executed);
+        }
+
+        [Fact]
+        public void ExecuteAllTargetsWhenConditionTrueAndBehaviorSkip_SwitchCondition()
+        {
+            var build = ExecutionTestUtility.CreateBuildAndExecuteDefaultTarget<TestBuild>(x => x.Execute,
+                x =>
+                {
+                    x.OnlyWhenCondition = true;
+                    x.SwitchConditionInDependency = true;
+                    x.DependencyBehavior = DependencyBehavior.Skip;
+                });
+
+            AssertExecutionStatus(build, ExecutionStatus.Executed, ExecutionStatus.Executed);
+        }
+
+        [Fact]
+        public void SkipExecuteTargetWhenConditionTrueAndBehaviorExecute_SwitchCondition()
+        {
+            var build = ExecutionTestUtility.CreateBuildAndExecuteDefaultTarget<TestBuild>(x => x.Execute,
+                x =>
+                {
+                    x.OnlyWhenCondition = true;
+                    x.SwitchConditionInDependency = true;
+                    x.DependencyBehavior = DependencyBehavior.Execute;
+                });
+
+            AssertExecutionStatus(build, ExecutionStatus.Executed, ExecutionStatus.Skipped);
+        }
+
+        [Fact]
+        public void ExecuteAllTargetsWhenConditionTrueAndBehaviorExecute()
+        {
+            var build = ExecutionTestUtility.CreateBuildAndExecuteDefaultTarget<TestBuild>(x => x.Execute,
+                x =>
+                {
+                    x.OnlyWhenCondition = true;
+                    x.SwitchConditionInDependency = false;
+                    x.DependencyBehavior = DependencyBehavior.Execute;
+                });
+
+            AssertExecutionStatus(build, ExecutionStatus.Executed, ExecutionStatus.Executed);
+        }
+
+        [Fact]
+        public void ExecuteDependencyTargetWhenConditionFalseAndBehaviorExecute()
+        {
+            var build = ExecutionTestUtility.CreateBuildAndExecuteDefaultTarget<TestBuild>(x => x.Execute,
+                x =>
+                {
+                    x.OnlyWhenCondition = false;
+                    x.SwitchConditionInDependency = false;
+                    x.DependencyBehavior = DependencyBehavior.Execute;
+                });
+
+            AssertExecutionStatus(build, ExecutionStatus.Executed, ExecutionStatus.Skipped);
+        }
+
+        [Fact]
+        public void ExecuteAllTargetsWhenConditionFalseAndBehaviorExecute_SwitchCondition()
+        {
+            var build = ExecutionTestUtility.CreateBuildAndExecuteDefaultTarget<TestBuild>(x => x.Execute,
+                x =>
+                {
+                    x.OnlyWhenCondition = false;
+                    x.SwitchConditionInDependency = true;
+                    x.DependencyBehavior = DependencyBehavior.Execute;
+                });
+
+            AssertExecutionStatus(build, ExecutionStatus.Executed, ExecutionStatus.Executed);
+        }
+
+        [CustomAssertion]
+        private void AssertExecutionStatus(TestBuild build, ExecutionStatus dependencyTargetStatus, ExecutionStatus executeTargetStatus)
+        {
+            using (new AssertionScope())
+            {
+                build.Should().HaveTargetWithExecutionStatus<TestBuild>(x => x.Dependency, dependencyTargetStatus);
+                build.Should().HaveTargetWithExecutionStatus<TestBuild>(x => x.Execute, executeTargetStatus);
+            }
+        }
+
+        private class TestBuild : NukeBuild
+        {
+            public bool OnlyWhenCondition;
+            public bool SwitchConditionInDependency;
+            public DependencyBehavior DependencyBehavior = DependencyBehavior.Execute;
+
+            public Target Dependency => _ => _
+                .Executes(() =>
+                {
+                    if (SwitchConditionInDependency)
+                        OnlyWhenCondition = !OnlyWhenCondition;
+                });
+
+            public Target Execute => _ => _
+                .DependsOn(Dependency)
+                .OnlyWhen(() => OnlyWhenCondition)
+                .WhenSkipped(DependencyBehavior)
+                .Executes(() => { });
+        }
+    }
+}

--- a/source/Nuke.Common.Tests/Execution/ExecutionTestUtility.cs
+++ b/source/Nuke.Common.Tests/Execution/ExecutionTestUtility.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2018 Maintainers and Contributors of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Nuke.Common.Execution;
+
+namespace Nuke.Common.Tests.Execution
+{
+    internal static class ExecutionTestUtility
+    {
+        public static T CreateBuild<T>(string defaultTarget = null, Action<T> configure = null)
+            where T : NukeBuild
+        {
+            if (string.IsNullOrEmpty(defaultTarget))
+            {
+                defaultTarget = typeof(T).GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                    .First(x => x.PropertyType == typeof(Target)).Name;
+            }
+
+            var targetExpression = CreateTargetExpressionByTargetName<T>(defaultTarget);
+            return CreateBuild(targetExpression, configure);
+        }
+
+        public static T CreateBuild<T>(Expression<Func<T, Target>> defaultTargetExpression, Action<T> configure = null)
+            where T : NukeBuild
+        {
+            var instance = Activator.CreateInstance<T>();
+            configure?.Invoke(instance);
+            instance.TargetDefinitions = instance.GetTargetDefinitions(defaultTargetExpression);
+            return instance;
+        }
+
+        public static T CreateBuildAndExecuteDefaultTarget<T>(Expression<Func<T, Target>> targetExpression, Action<T> configure = null)
+            where T : NukeBuild
+        {
+            var build = CreateBuild(targetExpression, configure);
+            ExecuteDefaultTarget(build);
+            return build;
+        }
+
+        public static void ExecuteDefaultTarget<T>(T build)
+            where T : NukeBuild
+        {
+            var executingTargets = TargetDefinitionLoader.GetExecutingTargets(build, new[] { BuildExecutor.DefaultTarget });
+            BuildExecutor.Execute(executingTargets);
+        }
+
+        private static Expression<Func<T, Target>> CreateTargetExpressionByTargetName<T>(string target)
+            where T : NukeBuild
+        {
+            var param = Expression.Parameter(typeof(T));
+            var body = Expression.PropertyOrField(param, target);
+            return Expression.Lambda<Func<T, Target>>(body, param);
+        }
+    }
+}

--- a/source/Nuke.Common.Tests/Execution/NukeBuildAssertions.cs
+++ b/source/Nuke.Common.Tests/Execution/NukeBuildAssertions.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2018 Maintainers and Contributors of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using Nuke.Common.Execution;
+
+namespace Nuke.Common.Tests.Execution
+{
+    internal class NukeBuildAssertions : ReferenceTypeAssertions<NukeBuild, NukeBuildAssertions>
+    {
+        public NukeBuildAssertions(NukeBuild subject)
+        {
+            Subject = subject;
+        }
+
+        [CustomAssertion]
+        public AndConstraint<NukeBuildAssertions> HaveTargetWithExecutionStatus<T>(
+            Expression<Func<T, Target>> targetSelector,
+            ExecutionStatus status,
+            string because = null,
+            params object[] becauseArgs)
+            where T : NukeBuild
+        {
+            var member = targetSelector.Body as MemberExpression;
+            var prop = member?.Member as PropertyInfo;
+            var name = prop?.Name;
+
+            return HaveTargetWithExecutionStatus(name, status, because, becauseArgs);
+        }
+
+        [CustomAssertion]
+        public AndConstraint<NukeBuildAssertions> HaveTargetWithExecutionStatus(
+            string targetName,
+            ExecutionStatus expectedStatus,
+            string because = null,
+            params object[] becauseArgs)
+        {
+            var target = Subject.TargetDefinitions.SingleOrDefault(x => x.Name == targetName);
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(target != null)
+                .FailWith("Expected {context:build} to have a target with the name {0}{reason}, but found {1}.",
+                    targetName,
+                    Subject.TargetDefinitions.Select(x => x.Name))
+                .Then
+                .ForCondition(target.Status == expectedStatus)
+                .FailWith("Expected {context:build} to have a target with the name {0} and status {1}{reason}, but found status {2}.",
+                    targetName,
+                    expectedStatus,
+                    target.Status);
+
+            return new AndConstraint<NukeBuildAssertions>(this);
+        }
+
+        protected override string Identifier => "nukeBuild";
+    }
+
+    internal static class NukeBuildAssertionExtensions
+    {
+        public static NukeBuildAssertions Should(this NukeBuild build)
+        {
+            return new NukeBuildAssertions(build);
+        }
+    }
+}

--- a/source/Nuke.Common.Tests/Execution/TargetDefinitionLoaderTest.cs
+++ b/source/Nuke.Common.Tests/Execution/TargetDefinitionLoaderTest.cs
@@ -4,13 +4,11 @@
 
 using System;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
 using FluentAssertions;
 using Nuke.Common.Execution;
 using Xunit;
 
-namespace Nuke.Common.Tests
+namespace Nuke.Common.Tests.Execution
 {
     public class TargetDefinitionLoaderTest
     {
@@ -38,30 +36,10 @@ namespace Nuke.Common.Tests
             new[] { nameof(TestBuild.Dependency) })]
         public void Test(string[] invokedTargets, string[] expectedTargets)
         {
-            TargetDefinitionLoader.GetExecutingTargets(CreateBuild<TestBuild>(), invokedTargets)
+            TargetDefinitionLoader.GetExecutingTargets(ExecutionTestUtility.CreateBuild<TestBuild>(), invokedTargets)
                 .Where(x => !x.Skip && x.Conditions.All(y => y()))
                 .Select(x => x.Name)
                 .Should().BeEquivalentTo(expectedTargets);
-        }
-
-        private static NukeBuild CreateBuild<T>()
-            where T : NukeBuild
-        {
-            var instance = Activator.CreateInstance<T>();
-            var firstTarget = typeof(T).GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                .First(x => x.PropertyType == typeof(Target)).Name;
-
-            var targetExpression = CreateTargetExpressionByTargetName<T>(firstTarget);
-            instance.TargetDefinitions = instance.GetTargetDefinitions(targetExpression);
-            return instance;
-        }
-
-        private static Expression<Func<TIn, Target>> CreateTargetExpressionByTargetName<TIn>(string target)
-            where TIn : NukeBuild
-        {
-            var param = Expression.Parameter(typeof(TIn));
-            var body = Expression.PropertyOrField(param, target);
-            return Expression.Lambda<Func<TIn, Target>>(body, param);
         }
 
         internal class TestBuild : NukeBuild

--- a/source/Nuke.Common/Execution/BuildExecutor.cs
+++ b/source/Nuke.Common/Execution/BuildExecutor.cs
@@ -62,7 +62,7 @@ namespace Nuke.Common.Execution
             }
         }
 
-        private static void Execute(IEnumerable<TargetDefinition> executionList)
+        internal static void Execute(IEnumerable<TargetDefinition> executionList)
         {
             foreach (var target in executionList)
             {

--- a/source/Nuke.Common/Execution/BuildExecutor.cs
+++ b/source/Nuke.Common/Execution/BuildExecutor.cs
@@ -72,7 +72,7 @@ namespace Nuke.Common.Execution
                     continue;
                 }
 
-                if (target.Skip || target.Conditions.Any(x => !x()))
+                if (target.Skip || target.DependencyBehavior == DependencyBehavior.Execute && target.Conditions.Any(x => !x()))
                 {
                     target.Status = ExecutionStatus.Skipped;
                     continue;

--- a/source/Nuke.Common/Execution/TargetDefinition.cs
+++ b/source/Nuke.Common/Execution/TargetDefinition.cs
@@ -30,6 +30,7 @@ namespace Nuke.Common.Execution
             TargetDefinitionDependencies = new List<TargetDefinition>();
             RunBeforeTargets = new List<Target>();
             RunAfterTargets = new List<Target>();
+            DependencyBehavior = DependencyBehavior.Execute;
 
             factory?.Invoke(this);
         }


### PR DESCRIPTION
Fix that conditions for targets with `DependencyBehavior.Skip` were evaluated twice.