### PR TITLE
Fix exception in `ChangelogTasks.ReadChangelog` when `vNext` section is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [vNext]
+- Fixed exception in `ChangelogTasks.ReadChangelog` when `vNext` section was empty
 
 ## [0.7.0] / 2018-08-29
 - Changed assertion of `DataClass` properties print out value on failure

--- a/source/Nuke.Common/ChangeLog/ChangeLog.cs
+++ b/source/Nuke.Common/ChangeLog/ChangeLog.cs
@@ -11,6 +11,32 @@ namespace Nuke.Common.ChangeLog
     [PublicAPI]
     public class ChangeLog
     {
+        /// <summary>
+        /// The path to the changelog file.
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// The unreleased release notes section.
+        /// </summary>
+        [CanBeNull] public ReleaseNotes Unreleased { get; }
+        
+        /// <summary>
+        /// Release notes sorted by version.
+        /// </summary>
+        public IReadOnlyList<ReleaseNotes> ReleaseNotes { get; }
+
+        /// <summary>
+        /// The latest release notes section. Returns null if the changelog does not contain a release section.
+        /// </summary>
+        [CanBeNull] public NuGetVersion LatestVersion => ReleaseNotes.FirstOrDefault()?.Version;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangeLog"/> class.
+        /// </summary>
+        /// <param name="path">The path to the changelog file.</param>
+        /// <param name="unreleased">The unreleased notes sectioon.</param>
+        /// <param name="releaseNotes">The release notes of the changelog.</param>
         public ChangeLog(string path, [CanBeNull] ReleaseNotes unreleased, IReadOnlyList<ReleaseNotes> releaseNotes)
         {
             Path = path;
@@ -18,18 +44,14 @@ namespace Nuke.Common.ChangeLog
             ReleaseNotes = releaseNotes.Where(x => !x.Unreleased).OrderBy(x => x.Version).ToList().AsReadOnly();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChangeLog"/> class.
+        /// </summary>
+        /// <param name="path">The path to the changelog file.</param>
+        /// <param name="releaseNotes">The release notes of the changelog.</param>
         public ChangeLog(string path, IReadOnlyList<ReleaseNotes> releaseNotes)
             : this(path, unreleased: null, releaseNotes)
         {
         }
-
-        public string Path { get; }
-        [CanBeNull] public ReleaseNotes Unreleased { get; }
-        
-        /// <summary>
-        /// Release notes sorted by version.
-        /// </summary>
-        public IReadOnlyList<ReleaseNotes> ReleaseNotes { get; }
-        public NuGetVersion LatestVersion => ReleaseNotes.First().Version.NotNull();
     }
 }

--- a/source/Nuke.Common/ChangeLog/ReleaseNotes.cs
+++ b/source/Nuke.Common/ChangeLog/ReleaseNotes.cs
@@ -11,24 +11,62 @@ namespace Nuke.Common.ChangeLog
     [PublicAPI]
     public class ReleaseNotes
     {
+        /// <summary>
+        /// Gets a value indicating whether this release notes section contains notes.
+        /// </summary>
         public bool IsEmpty => Notes.Count == 0;
+
+        /// <summary>
+        /// Gets a value indicating whether this release notes section is unreleased (vNext).
+        /// </summary>
         public bool Unreleased => Version == null;
+
+        /// <summary>
+        /// The version of the release notes. Null if unreleased (vNext).
+        /// </summary>
         [CanBeNull] public NuGetVersion Version { get; }
+        
+        /// <summary>
+        /// The release notes in this release notes section.
+        /// </summary>
         public IReadOnlyList<string> Notes { get; }
+
+        /// <summary>
+        /// The start index of this section in the changelog file.
+        /// </summary>
         public int StartIndex { get; }
+
+        /// <summary>
+        /// The end index of this section in the changelog file.
+        /// </summary>
         public int EndIndex { get; }
 
-        public ReleaseNotes([CanBeNull] NuGetVersion version, IReadOnlyList<string> notes, int startIndex, int endIndex)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReleaseNotes"/> class.
+        /// </summary>
+        /// <param name="version">The version of the release notes section.</param>
+        /// <param name="notes">The release notes.</param>
+        /// <param name="startIndex">The start index of the section in the changelog file.</param>
+        /// <param name="endIndex">The end index of the section in the changelog file.</param>
+        public ReleaseNotes(NuGetVersion version, IReadOnlyList<string> notes, int startIndex, int endIndex) : this(notes, startIndex, endIndex)
         {
             Version = version;
-            ControlFlow.Assert(notes != null && notes.Count > 0, "Release Notes should not be empty");
+            ControlFlow.Assert(notes.Count > 0, "Release Notes should not be empty");
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReleaseNotes"/> class.
+        /// </summary>
+        /// <param name="notes">The release notes.</param>
+        /// <param name="startIndex">The start index of the section in the changelog file.</param>
+        /// <param name="endIndex">The end index of the section in the changelog file.</param>
+        public ReleaseNotes(IReadOnlyList<string> notes, int startIndex, int endIndex)
+        {
             Notes = notes;
             StartIndex = startIndex;
             EndIndex = endIndex;
         }
-        
-        public ReleaseNotes(IReadOnlyList<string> notes, int startIndex, int endIndex) : this(version: null, notes, startIndex, endIndex) { }
-        
+      
         public override string ToString()
         {
             return string.Join(EnvironmentInfo.NewLine, Notes);


### PR DESCRIPTION
- `ChangeLog.LatestVersion` now returns null if no release section is available.
- Add xml documentation to `ChangelogTasks` and all related classes.