### PR TITLE
Add executable search when using Paket

### DIFF
--- a/source/Nuke.Common.Tests/PathConstructionTest.cs
+++ b/source/Nuke.Common.Tests/PathConstructionTest.cs
@@ -22,6 +22,7 @@ namespace Nuke.Common.Tests
         public void TestParent(string path, string expected)
         {
             ((AbsolutePath) path).Parent.Should().Be((AbsolutePath) expected);
+            ((string) ((AbsolutePath) path).Parent).Should().Be(expected);
         }
         
         [Theory]

--- a/source/Nuke.Common/IO/PathConstruction.cs
+++ b/source/Nuke.Common/IO/PathConstruction.cs
@@ -266,17 +266,20 @@ namespace Nuke.Common.IO
 
             public static explicit operator RelativePath([CanBeNull] string path)
             {
+                if (path is null)
+                    return null;
+                
                 return new RelativePath(NormalizePath(path));
             }
 
-            public static implicit operator string(RelativePath path)
+            public static implicit operator string([CanBeNull] RelativePath path)
             {
-                return path._path;
+                return path?._path;
             }
 
-            public static RelativePath operator /(RelativePath path1, string path2)
+            public static RelativePath operator /(RelativePath path1, [CanBeNull] string path2)
             {
-                var separator = path1._separator;
+                var separator = path1.NotNull("path1 != null")._separator;
                 return new RelativePath(NormalizePath(Combine(path1, (RelativePath) path2, separator), separator), separator);
             }
 
@@ -352,9 +355,9 @@ namespace Nuke.Common.IO
                 return new AbsolutePath(path);
             }
 
-            public static implicit operator string(AbsolutePath path)
+            public static implicit operator string([CanBeNull] AbsolutePath path)
             {
-                return path.ToString();
+                return path?.ToString();
             }
 
             public AbsolutePath Parent =>
@@ -362,9 +365,9 @@ namespace Nuke.Common.IO
                     ? this / ".."
                     : null;
 
-            public static AbsolutePath operator /(AbsolutePath path1, string path2)
+            public static AbsolutePath operator /(AbsolutePath path1, [CanBeNull] string path2)
             {
-                return new AbsolutePath(Combine(path1, path2));
+                return new AbsolutePath(Combine(path1.NotNull("path1 != null"), path2));
             }
 
             protected bool Equals(AbsolutePath other)
@@ -386,7 +389,7 @@ namespace Nuke.Common.IO
 
             public override int GetHashCode()
             {
-                return _path != null ? _path.GetHashCode() : 0;
+                return _path?.GetHashCode() ?? 0;
             }
 
             public override string ToString()

--- a/source/Nuke.Common/Tooling/NuGetPackageResolver.cs
+++ b/source/Nuke.Common/Tooling/NuGetPackageResolver.cs
@@ -42,15 +42,24 @@ namespace Nuke.Common.Tooling
             }
         }
 
-        public static InstalledPackage GetLocalInstalledPackage(
+        [CanBeNull]
+        public static InstalledPackage TryGetLocalInstalledPackage(
             string packageId,
             string packagesConfigFile = null,
             bool includeDependencies = false)
         {
             packagesConfigFile = packagesConfigFile ?? DefaultPackagesConfigFile;
-            
+
             return GetLocalInstalledPackages(packagesConfigFile, includeDependencies)
-                .FirstOrDefault(x => x.Id.EqualsOrdinalIgnoreCase(packageId))
+                .FirstOrDefault(x => x.Id.EqualsOrdinalIgnoreCase(packageId));
+        }
+        
+        public static InstalledPackage GetLocalInstalledPackage(
+            string packageId,
+            string packagesConfigFile = null,
+            bool includeDependencies = false)
+        {
+            return TryGetLocalInstalledPackage(packageId, packagesConfigFile, includeDependencies)
                 .NotNull($"Could not find package '{packageId}' via '{packagesConfigFile}'.");
         }
 

--- a/source/Nuke.Common/Tooling/PaketPackageResolver.cs
+++ b/source/Nuke.Common/Tooling/PaketPackageResolver.cs
@@ -1,0 +1,23 @@
+// Copyright 2018 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.IO;
+using System.Linq;
+using JetBrains.Annotations;
+
+namespace Nuke.Common.Tooling
+{
+    // TODO: Add similar methods to NuGetPackageResolver
+    [PublicAPI]
+    public static class PaketPackageResolver
+    {
+        [CanBeNull]
+        public static string TryGetLocalInstalledPackageDirectory(string packageId)
+        {
+            var packageDirectory = NukeBuild.RootDirectory / "packages" / packageId;
+            return Directory.Exists(packageDirectory) ? packageDirectory : null;
+        }
+    }
+}

--- a/source/Nuke.Common/Tooling/ToolPathResolver.cs
+++ b/source/Nuke.Common/Tooling/ToolPathResolver.cs
@@ -1,4 +1,4 @@
-// Copyright 2018 Maintainers of NUKE.
+﻿// Copyright 2018 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -29,12 +29,13 @@ namespace Nuke.Common.Tooling
         {
             ControlFlow.Assert(packageId != null && packageExecutable != null, "packageId != null && packageExecutable != null");
 
-            var packageDirectory = (string) (NukeBuild.BuildAssemblyDirectory / packageId);
-            if (!Directory.Exists(packageDirectory))
-            {
-                var installedPackage = NuGetPackageResolver.GetLocalInstalledPackage(packageId);
-                packageDirectory = Path.GetDirectoryName(installedPackage.FileName).NotNull("packageDirectory != null");
-            }
+            var packageDirectory =
+                new[]
+                {
+                    NukeBuild.BuildAssemblyDirectory / packageId,
+                    PaketPackageResolver.TryGetLocalInstalledPackageDirectory(packageId),
+                    NuGetPackageResolver.TryGetLocalInstalledPackage(packageId)?.Directory
+                }.FirstOrDefault(Directory.Exists).NotNull("packageDirectory != null");
 
             var executables = Directory.GetFiles(packageDirectory, packageExecutable, SearchOption.AllDirectories);
             ControlFlow.Assert(executables.Length > 0, $"Could not find '{packageExecutable}' inside '{packageDirectory}'.");


### PR DESCRIPTION
Hi, I recently tried nuke with [paket](https://fsprojects.github.io/Paket/) manager and it seems like there is an issue with executable resoultion when using paket (`GitVersion.exe` from nuke install wizard in my case) . This adds search in paket packages folder if paket is installed. Paket stores packages like `packages/<packageId>/..`. I tried to test the code myself on test solution, but I couldn't find the correct way to test the local nuke build without errors :) Though, during debug exe path lookup worked correctly.

![image](https://user-images.githubusercontent.com/10695322/47962720-057f1000-e032-11e8-8720-87851b2e9198.png)
