### PR TITLE
Fix Glob version to 0.3.2

### DIFF
--- a/source/Nuke.Common/Nuke.Common.csproj
+++ b/source/Nuke.Common/Nuke.Common.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="6.0.2" />
     <PackageReference Include="Colorful.Console" Version="1.2.9" />
-    <PackageReference Include="Glob" Version="0.3.2" />
+    <PackageReference Include="Glob" Version="[0.3.2]" />
     <PackageReference Include="JetBrains.Annotations" Version="2018.2.1" />
     <PackageReference Include="Microsoft.Build.Framework" Version="15.5.180" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.5.180" />


### PR DESCRIPTION
Fixes Glob version to 0.3.2 in Nuke.Common.

@matkoch 