### PR TITLE
Change build.ps1 behaviour to use exit rather than SetShouldExit

### DIFF
--- a/source/Nuke.GlobalTool/templates/build.netcore.ps1
+++ b/source/Nuke.GlobalTool/templates/build.netcore.ps1
@@ -7,7 +7,7 @@ Param(
 
 Write-Output "Windows PowerShell $($Host.Version)"
 
-Set-StrictMode -Version 2.0; $ErrorActionPreference = "Stop"; $ConfirmPreference = "None"; trap { $host.SetShouldExit(1) }
+Set-StrictMode -Version 2.0; $ErrorActionPreference = "Stop"; $ConfirmPreference = "None"; trap { exit 1; }
 $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 
 ###########################################################################

--- a/source/Nuke.GlobalTool/templates/build.netfx.ps1
+++ b/source/Nuke.GlobalTool/templates/build.netfx.ps1
@@ -7,7 +7,7 @@ Param(
 
 Write-Output "Windows PowerShell $($Host.Version)"
 
-Set-StrictMode -Version 2.0; $ErrorActionPreference = "Stop"; $ConfirmPreference = "None"; trap { $host.SetShouldExit(1) }
+Set-StrictMode -Version 2.0; $ErrorActionPreference = "Stop"; $ConfirmPreference = "None"; trap { exit 1; }
 $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 
 ###########################################################################


### PR DESCRIPTION
Fixes #173 

Uses `exit` rather than `$host.SetShouldExit(1)` to set the exit code. Given [this SO answer](https://stackoverflow.com/questions/4391553/how-to-return-an-exit-code-from-a-powershell-script-only-when-run-non-interactiv), I gather one should use `exit 1` rather than `$host.SetShouldExit(1)`. 

I've run a modified build.ps1 on a project of mine, and found that if I use `exit`, the `$LASTEXITCODE` is `0` when the build completes, and `1` when I cancel it with Ctrl+C. The shell does _not_ close when using `exit`.