### PR TITLE
Add linux replacement of $-variables

### DIFF
--- a/source/Nuke.Common/EnvironmentInfo.Others.cs
+++ b/source/Nuke.Common/EnvironmentInfo.Others.cs
@@ -31,7 +31,9 @@ namespace Nuke.Common
             string ExpandUnixEnvironmentVariables()
             {
                 var regex = new Regex(@"\$([a-z_][a-z0-9_]*)", RegexOptions.IgnoreCase);
-                return regex.Replace(value, x => Environment.GetEnvironmentVariable(x.Groups[1].Value));
+                return regex.Replace(
+                    value.ReplaceRegex("^~", x => Environment.GetEnvironmentVariable("HOME")),
+                    x => Environment.GetEnvironmentVariable(x.Groups[1].Value));
             }
 
             return IsWin

--- a/source/Nuke.Common/EnvironmentInfo.Others.cs
+++ b/source/Nuke.Common/EnvironmentInfo.Others.cs
@@ -30,10 +30,9 @@ namespace Nuke.Common
         {
             string ExpandUnixEnvironmentVariables()
             {
-                var regex = new Regex(@"\$([a-z_][a-z0-9_]*)", RegexOptions.IgnoreCase);
-                return regex.Replace(
-                    value.ReplaceRegex("^~", x => Environment.GetEnvironmentVariable("HOME")),
-                    x => Environment.GetEnvironmentVariable(x.Groups[1].Value));
+                return value
+                    .ReplaceRegex("^~", x => Environment.GetEnvironmentVariable("HOME"))
+                    .ReplaceRegex(@"\$([a-z_][a-z0-9_]*)",x => Environment.GetEnvironmentVariable(x.Groups[1].Value), RegexOptions.IgnoreCase);
             }
 
             return IsWin

--- a/source/Nuke.Common/EnvironmentInfo.Others.cs
+++ b/source/Nuke.Common/EnvironmentInfo.Others.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
@@ -27,8 +28,15 @@ namespace Nuke.Common
 
         public static string ExpandVariables(string value)
         {
-            // TODO: Expand unix style variables $var (https://github.com/dotnet/corefx/issues/28890)
-            return Environment.ExpandEnvironmentVariables(value);
+            string ExpandUnixEnvironmentVariables()
+            {
+                var regex = new Regex(@"\$([a-z_][a-z0-9_]*)", RegexOptions.IgnoreCase);
+                return regex.Replace(value, x => Environment.GetEnvironmentVariable(x.Groups[1].Value));
+            }
+
+            return IsWin
+                ? Environment.ExpandEnvironmentVariables(value)
+                : ExpandUnixEnvironmentVariables();
         }
 
         internal static Dictionary<string, string> GetVariables()


### PR DESCRIPTION
Fixes #165 

Uses a regex of `\$([a-z0-9_\-]+)` to locate `$VARIABLES` and replace them using regex's replacer.