### PR TITLE
Add ./test as an option to basic setup

### DIFF
--- a/source/Nuke.GlobalTool/Program.Setup.cs
+++ b/source/Nuke.GlobalTool/Program.Setup.cs
@@ -130,7 +130,7 @@ namespace Nuke.GlobalTool
 
                 definitions.Add(
                     ConsoleHelper.PromptForChoice("Where do test projects go?",
-                        ("TESTS_DIR", "./tests"),
+                        ("TESTS_DIR", "./test","./tests"),
                         (null, "Same as source")));
 
                 if (Directory.Exists(Path.Combine(rootDirectory, ".git")))


### PR DESCRIPTION
Using `test` (and not `tests`) is also fairly common as far as i know. Its convenient to include it as a choice for basic setup.