### PR TITLE
Chose GitVersion package based on target framework.

### DIFF
--- a/source/Nuke.GlobalTool/templates/_build.sdk.csproj
+++ b/source/Nuke.GlobalTool/templates/_build.sdk.csproj
@@ -12,7 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="_NUKE_VERSION_" />
     <PackageReference Include="Nuke.CodeGeneration" Version="_NUKE_VERSION_" />                  // GENERATION
-    <PackageReference Include="GitVersion.CommandLine.DotNetCore" Version="4.0.1-beta1-49" />    // GITVERSION
+    <PackageReference Include="GitVersion.CommandLine.DotNetCore" Version="4.0.1-beta1-49" />    // GITVERSION && DOTNET
+    <PackageReference Include="GitVersion.CommandLine" Version="4.0.0" />                        // GITVERSION && MSBUILD
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fixes #200 

There is a lot of potential to clean this up I guess.

I wasn't able to determine the target platform based on the bootstrapping (`!ParameterService.Instance.GetParameter<bool>("boot")`) which would be way cleaner, because in my test the setup always skipped the prompt