### PR TITLE
Treat an empty CI-specific environment variable as non-existing

### DIFF
--- a/source/Nuke.Common/CI/AppVeyor/AppVeyor.cs
+++ b/source/Nuke.Common/CI/AppVeyor/AppVeyor.cs
@@ -40,7 +40,7 @@ namespace Nuke.Common.CI.AppVeyor
 
         public static AppVeyor Instance => NukeBuild.Host == HostType.AppVeyor ? s_instance.Value : null;
 
-        internal static bool IsRunningAppVeyor => Environment.GetEnvironmentVariable("APPVEYOR") != null;
+        internal static bool IsRunningAppVeyor => !Environment.GetEnvironmentVariable("APPVEYOR").IsNullOrEmpty();
 
         internal AppVeyor()
         {

--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelines.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelines.cs
@@ -25,7 +25,7 @@ namespace Nuke.Common.CI.AzurePipelines
 
         public static AzurePipelines Instance => NukeBuild.Host == HostType.AzurePipelines ? s_instance.Value : null;
 
-        internal static bool IsRunningAzurePipelines => Environment.GetEnvironmentVariable("TF_BUILD") != null;
+        internal static bool IsRunningAzurePipelines => !Environment.GetEnvironmentVariable("TF_BUILD").IsNullOrEmpty();
 
         private readonly Action<string> _messageSink;
 

--- a/source/Nuke.Common/CI/Bamboo/Bamboo.cs
+++ b/source/Nuke.Common/CI/Bamboo/Bamboo.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
+using Nuke.Common.Utilities;
 
 namespace Nuke.Common.CI.Bamboo
 {
@@ -20,7 +21,7 @@ namespace Nuke.Common.CI.Bamboo
 
         public static Bamboo Instance => NukeBuild.Host == HostType.Bamboo ? s_instance.Value : null;
 
-        internal static bool IsRunningBamboo => Environment.GetEnvironmentVariable("BAMBOO_SERVER") != null;
+        internal static bool IsRunningBamboo => !Environment.GetEnvironmentVariable("BAMBOO_SERVER").IsNullOrEmpty();
 
         internal Bamboo()
         {

--- a/source/Nuke.Common/CI/Bitrise/Bitrise.cs
+++ b/source/Nuke.Common/CI/Bitrise/Bitrise.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
+using Nuke.Common.Utilities;
 
 namespace Nuke.Common.CI.Bitrise
 {
@@ -21,7 +22,7 @@ namespace Nuke.Common.CI.Bitrise
 
         public static Bitrise Instance => NukeBuild.Host == HostType.Bitrise ? s_instance.Value : null;
 
-        internal static bool IsRunningBitrise => Environment.GetEnvironmentVariable("BITRISE_BUILD_URL") != null;
+        internal static bool IsRunningBitrise => !Environment.GetEnvironmentVariable("BITRISE_BUILD_URL").IsNullOrEmpty();
 
         private static DateTime ConvertUnixTimestamp(long timestamp)
         {

--- a/source/Nuke.Common/CI/GitLab/GitLab.cs
+++ b/source/Nuke.Common/CI/GitLab/GitLab.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
+using Nuke.Common.Utilities;
 
 namespace Nuke.Common.CI.GitLab
 {
@@ -21,7 +22,7 @@ namespace Nuke.Common.CI.GitLab
 
         public static GitLab Instance => NukeBuild.Host == HostType.GitLab ? s_instance.Value : null;
 
-        internal static bool IsRunningGitLab => Environment.GetEnvironmentVariable("GITLAB_CI") != null;
+        internal static bool IsRunningGitLab => !Environment.GetEnvironmentVariable("GITLAB_CI").IsNullOrEmpty();
 
         internal GitLab()
         {

--- a/source/Nuke.Common/CI/Jenkins/Jenkins.cs
+++ b/source/Nuke.Common/CI/Jenkins/Jenkins.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
+using Nuke.Common.Utilities;
 
 namespace Nuke.Common.CI.Jenkins
 {
@@ -21,7 +22,7 @@ namespace Nuke.Common.CI.Jenkins
 
         public static Jenkins Instance => NukeBuild.Host == HostType.Jenkins ? s_instance.Value : null;
 
-        internal static bool IsRunningJenkins => Environment.GetEnvironmentVariable("JENKINS_HOME") != null;
+        internal static bool IsRunningJenkins => !Environment.GetEnvironmentVariable("JENKINS_HOME").IsNullOrEmpty();
 
         internal Jenkins()
         {

--- a/source/Nuke.Common/CI/TeamCity/TeamCity.cs
+++ b/source/Nuke.Common/CI/TeamCity/TeamCity.cs
@@ -32,7 +32,7 @@ namespace Nuke.Common.CI.TeamCity
 
         public static TeamCity Instance => NukeBuild.Host == HostType.TeamCity ? s_instance.Value : null;
 
-        internal static bool IsRunningTeamCity => Environment.GetEnvironmentVariable("TEAMCITY_VERSION") != null;
+        internal static bool IsRunningTeamCity => !Environment.GetEnvironmentVariable("TEAMCITY_VERSION").IsNullOrEmpty();
 
         public static T CreateRestClient<T>(string serverUrl, string username, string password)
         {

--- a/source/Nuke.Common/CI/TravisCI/TravisCI.cs
+++ b/source/Nuke.Common/CI/TravisCI/TravisCI.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
+using Nuke.Common.Utilities;
 
 namespace Nuke.Common.CI.TravisCI
 {
@@ -21,7 +22,7 @@ namespace Nuke.Common.CI.TravisCI
 
         public static TravisCI Instance => NukeBuild.Host == HostType.Travis ? s_instance.Value : null;
 
-        internal static bool IsRunningTravis => Environment.GetEnvironmentVariable("TRAVIS") != null;
+        internal static bool IsRunningTravis => !Environment.GetEnvironmentVariable("TRAVIS").IsNullOrEmpty();
 
         internal TravisCI()
         {

--- a/source/Nuke.Common/Utilities/String.Emptiness.cs
+++ b/source/Nuke.Common/Utilities/String.Emptiness.cs
@@ -1,0 +1,14 @@
+// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+namespace Nuke.Common.Utilities
+{
+    public static partial class StringExtensions
+    {
+        public static bool IsNullOrEmpty(this string str)
+        {
+            return string.IsNullOrEmpty(str);
+        }
+    }
+}


### PR DESCRIPTION
When running Nuke from inside a LINUX docker container, we tend to pass the TEAMCITY_VERSION from the host to the container. However, that will set the value to an empty string, even though the variable did not exist on the host. This is fixed for Team City and all the other CI providers.

There were no tests that I could update/amend

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer