### PR TITLE
_build.csproj: links to GitLab CI and Atlassian Bamboo yaml specifications

### DIFF
--- a/source/Nuke.Common/Nuke.Common.targets
+++ b/source/Nuke.Common/Nuke.Common.targets
@@ -32,6 +32,8 @@
     <None Include="$(NukeRootDirectory)\Jenkinsfile" LinkBase="ci" Condition="Exists('$(NukeRootDirectory)\Jenkinsfile')" />
     <None Include="$(NukeRootDirectory)\appveyor.yml" LinkBase="ci" Condition="Exists('$(NukeRootDirectory)\appveyor.yml')" />
     <None Include="$(NukeRootDirectory)\.travis.yml" LinkBase="ci" Condition="Exists('$(NukeRootDirectory)\.travis.yml')" />
+    <None Include="$(NukeRootDirectory)\bamboo-specs\bamboo.yml" LinkBase="ci" Condition="Exists('$(NukeRootDirectory)\bamboo-specs\bamboo.yml')" />
+    <None Include="$(NukeRootDirectory)\bamboo-specs\bamboo.yaml" LinkBase="ci" Condition="Exists('$(NukeRootDirectory)\bamboo-specs\bamboo.yaml')" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.Common/Nuke.Common.targets
+++ b/source/Nuke.Common/Nuke.Common.targets
@@ -34,6 +34,7 @@
     <None Include="$(NukeRootDirectory)\.travis.yml" LinkBase="ci" Condition="Exists('$(NukeRootDirectory)\.travis.yml')" />
     <None Include="$(NukeRootDirectory)\bamboo-specs\bamboo.yml" LinkBase="ci" Condition="Exists('$(NukeRootDirectory)\bamboo-specs\bamboo.yml')" />
     <None Include="$(NukeRootDirectory)\bamboo-specs\bamboo.yaml" LinkBase="ci" Condition="Exists('$(NukeRootDirectory)\bamboo-specs\bamboo.yaml')" />
+    <None Include="$(NukeRootDirectory)\.gitlab-ci.yml" LinkBase="ci" Condition="Exists('$(NukeRootDirectory)\.gitlab-ci.yml')" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
After accepting this pull request the generated *_build.csproj* will support showing links to Atlassian Bamboo build specifications and GitLab CI pipeline specifications (both in yaml format).

- Atlassian Bamboo documentation: [https://confluence.atlassian.com/bamboo/bamboo-yaml-specs-938844479.html](https://confluence.atlassian.com/bamboo/bamboo-yaml-specs-938844479.html)
- GitLab CI documentation: [https://docs.gitlab.com/ee/ci/yaml/README.html](https://docs.gitlab.com/ee/ci/yaml/README.html)

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer