### PR TITLE
 Fix a warning about bundled dotCover

### DIFF
--- a/source/Nuke.Common/CI/TeamCity/TeamCity.cs
+++ b/source/Nuke.Common/CI/TeamCity/TeamCity.cs
@@ -151,7 +151,7 @@ namespace Nuke.Common.CI.TeamCity
                 {
                     "Configuration parameter 'teamcity.dotCover.home' is set to the bundled version.",
                     $"Adding the '{nameof(TeamCitySetDotCoverHomePathAttribute)}' will automatically set " +
-                    $"it to '{nameof(DotCoverTasks)}.{DotCoverTasks.DotCoverPath}'."
+                    $"it to '{nameof(DotCoverTasks)}.{nameof(DotCoverTasks.DotCoverPath)}'."
                 }.JoinNewLine());
 
             Write("importData",


### PR DESCRIPTION
This pull request fixes #381. I suppose the original intention was to output property name, not a value, so I just added `nameof()`.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer