### PR TITLE
UnityTasks improvements

### DIFF
--- a/source/Nuke.Common/Tools/Unity/UnityTasks.cs
+++ b/source/Nuke.Common/Tools/Unity/UnityTasks.cs
@@ -35,31 +35,28 @@ namespace Nuke.Common.Tools.Unity
         {
             return EnvironmentInfo.Platform switch
             {
-                PlatformFamily.Windows => $@"{EnvironmentInfo.SpecialFolder(
-                    EnvironmentInfo.Is32Bit
-                        ? SpecialFolders.ProgramFilesX86
-                        : SpecialFolders.ProgramFiles)}\Unity\Editor\Unity.exe",
+                PlatformFamily.Windows => $@"{GetProgramFiles()}\Unity\Editor\Unity.exe",
                 PlatformFamily.OSX => "/Applications/Unity/Unity.app/Contents/MacOS/Unity",
-                PlatformFamily.Linux => null,
-                PlatformFamily.Unknown => null,
                 _ => null
             };
         }
 
         private static string GetToolPathViaHubVersion(string version)
         {
-            static string GetProgramFiles()
-                => EnvironmentInfo.SpecialFolder(
-                    EnvironmentInfo.Is32Bit
-                        ? SpecialFolders.ProgramFilesX86
-                        : SpecialFolders.ProgramFiles);
-
             return EnvironmentInfo.Platform switch
             {
                 PlatformFamily.Windows => $@"{GetProgramFiles()}\Unity\Hub\Editor\{version}\Editor\Unity.exe",
                 PlatformFamily.OSX => $"/Applications/Unity/Hub/Editor/{version}/Unity.app/Contents/MacOS/Unity",
                 _ => throw new Exception($"Cannot determine Unity Hub installation path for '{version}'.")
             };
+        }
+
+        private static string GetProgramFiles()
+        {
+            return EnvironmentInfo.SpecialFolder(
+                    EnvironmentInfo.Is32Bit
+                        ? SpecialFolders.ProgramFilesX86
+                        : SpecialFolders.ProgramFiles);
         }
 
         private static void PreProcess(ref UnitySettings unitySettings)

--- a/source/Nuke.Common/Tools/Unity/UnityTasks.cs
+++ b/source/Nuke.Common/Tools/Unity/UnityTasks.cs
@@ -61,7 +61,10 @@ namespace Nuke.Common.Tools.Unity
 
         private static void PreProcess(ref UnitySettings unitySettings)
         {
-            ControlFlow.AssertWarn(unitySettings.ProjectPath != null, "unitySettings.ProjectPath != null");
+            ControlFlow.AssertWarn(
+                unitySettings.ProjectPath != null,
+                "ProjectPath is not set in UnitySettings. This will cause Unity to build the last " +
+                "opened/built project. Use .SetProjectPath() to override this behavior.");
             PreProcess<UnitySettings>(ref unitySettings);
         }
 


### PR DESCRIPTION
This PR:

- Synchronizes the path resolving code making it more consistent. This includes throwing an exception in `GetToolPathViaManualInstallation` on unsupported platforms like `GetToolPathViaHubVersion` does
- Improves assertion warning message when `ProjectPath` is not set, giving the user a hint on a possible fix

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer