### PR TITLE
Add ReportType argument to dotcover cover

### DIFF
--- a/build/specifications/DotCover.json
+++ b/build/specifications/DotCover.json
@@ -59,7 +59,13 @@
             "type": "string",
             "format": "/Output={value}",
             "help": "Path to the resulting coverage snapshot."
-          }
+          },
+          {
+            "name": "ReportType",
+            "type": "DotCoverReportType",
+            "format": "/ReportType={value}",
+            "help": "A type of the report. The default value is <c>XML</c>."
+          }        
         ]
       }
     },
@@ -289,7 +295,8 @@
         "Html",
         "Json",
         "Xml",
-        "DetailedXml"
+        "DetailedXml",
+        "NDependXML"
       ]
     }
   ]


### PR DESCRIPTION
This just adds the ReportType argument to dotcover cover as specified here: 
https://www.jetbrains.com/help/dotcover/dotCover__Console_Runner_Commands.html#cover

I confirm that the pull-request:

- [ x ] Follows the contribution guidelines
- [ x ] Is based on my own work
- [ x ] Is in compliance with my employer