### PR TITLE
TeamCity errors should not fail entire build

### DIFF
--- a/source/Nuke.Common/CI/TeamCity/TeamCityOutputSink.cs
+++ b/source/Nuke.Common/CI/TeamCity/TeamCityOutputSink.cs
@@ -63,9 +63,9 @@ namespace Nuke.Common.CI.TeamCity
 
         protected override void ReportError(string text, string details = null)
         {
-            _teamCity.AddBuildProblem(text);
+            _teamCity.WriteError(text);
             if (details != null)
-                base.WriteError(details);
+                _teamCity.WriteError(details);
         }
     }
 }


### PR DESCRIPTION
When using AddBuildProblem, the build is marked as failed [see documentation](https://www.jetbrains.com/help/teamcity/build-script-interaction-with-teamcity.html#BuildScriptInteractionwithTeamCity-ReportingBuildProblems), while Nuke sees the build as a success.

According to @matkoch what he wanted to achieve was to show errors on TeamCity build result page and in the build log. I have done some testing and found that this is not possible without failing the entire build.

The solution I made will not fail the build, but only output the error in the build log. But if you enable 
`an error message is logged by build runner` on `Common Failure Conditions` then the build will display the error on the build log.

I think there are places where TeamCity/Nuke should fail when getting an error message, but that should be implemented so both fails on the same place.

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer