### PR TITLE
Cache candidate packages

### DIFF
--- a/source/Nuke.Common.Tests/Nuke.Common.Tests.csproj
+++ b/source/Nuke.Common.Tests/Nuke.Common.Tests.csproj
@@ -5,6 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="Tooling\NuGetPackageResolverCacheTest.csproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Nuke.Common\Nuke.Common.csproj" />
   </ItemGroup>
   

--- a/source/Nuke.Common.Tests/Tooling/NuGetPackageResolverCacheTest.csproj
+++ b/source/Nuke.Common.Tests/Tooling/NuGetPackageResolverCacheTest.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="1.2.0" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.104.17" />
+    <PackageReference Include="AWSSDK.ECR" Version="3.3.103.9" />
+    <PackageReference Include="AWSSDK.ECS" Version="3.3.114" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.104.28" />
+    <PackageReference Include="JetBrains.dotCover.CommandLineTools" Version="2019.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="JetBrains.dotCover.DotNetCliTool" Version="2019.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/source/Nuke.Common.Tests/Tooling/NuGetPackageResolverTest.cs
+++ b/source/Nuke.Common.Tests/Tooling/NuGetPackageResolverTest.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Nuke.Common.IO;
+using Nuke.Common.Tooling;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Nuke.Common.Tests.Tooling
+{
+    public class NuGetPackageResolverTest
+    {
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public NuGetPackageResolverTest(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public void NuGetPackageResolverCacheTest()
+        {
+            AbsolutePath configFile = (AbsolutePath)new FileInfo(Assembly.GetExecutingAssembly().Location).DirectoryName / "Tooling" / "NuGetPackageResolverCacheTest.csproj";
+
+            var sw = new Stopwatch();
+            sw.Restart();
+            NuGetPackageResolver.GetLocalInstalledPackages(configFile).ToArray();
+            sw.Stop();
+            _testOutputHelper.WriteLine($"Cached first run {sw.Elapsed}");
+
+            sw.Restart();
+            NuGetPackageResolver.GetLocalInstalledPackages(configFile).ToArray();
+            sw.Stop();
+            _testOutputHelper.WriteLine($"Cached second run {sw.Elapsed}");
+
+            NuGetPackageResolver.EnableCache = false;
+            sw.Restart();
+            NuGetPackageResolver.GetLocalInstalledPackages(configFile).ToArray();
+            sw.Stop();
+            _testOutputHelper.WriteLine($"No cache run {sw.Elapsed}");
+        }
+    }
+}

--- a/source/Nuke.Common/Tooling/NuGetPackageResolver.cs
+++ b/source/Nuke.Common/Tooling/NuGetPackageResolver.cs
@@ -24,6 +24,8 @@ namespace Nuke.Common.Tooling
         private const int c_defaultTimeout = 2000;
         private static Dictionary<string, InstalledPackage[]> s_candidatePackageCache = new Dictionary<string, InstalledPackage[]>();
 
+        public static bool EnableCache { get; set; } = true;
+        
         [ItemCanBeNull]
         public static async Task<string> GetLatestPackageVersion(string packageId, bool includePrereleases, int? timeout = null)
         {
@@ -200,7 +202,7 @@ namespace Nuke.Common.Tooling
         {
             var key = $"{packageId}-{packagesConfigFile}-{includePrereleases}";
 
-            if (s_candidatePackageCache.TryGetValue(key, out var candidatePackages))
+            if (EnableCache && s_candidatePackageCache.TryGetValue(key, out var candidatePackages))
             {
                 return candidatePackages;
             }
@@ -227,7 +229,10 @@ namespace Nuke.Common.Tooling
                 .OrderByDescending(x => x.Version)
                 .ToArray();
 
-            s_candidatePackageCache.Add(key, candidatePackages);
+            if (EnableCache)
+            {
+                s_candidatePackageCache.Add(key, candidatePackages);
+            }
 
             return candidatePackages;
         }


### PR DESCRIPTION
After [Fix NuGetPackageResolver to resolve dependencies by default](https://github.com/nuke-build/nuke/commit/039405d5bd34b7ba569c5d32f81091b7b81325d1#diff-ff1356e2ed38bc7bc09f93075cb7c46d) commit, looking up packages has been really slow (minutes in my case)

So I have introduces caching to speed things up.

Test performance.
Before 19.3892537 sec
After 1.4985964 sec
After, 2. lookup 0.0635239 sec

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer