### PR TITLE
Add build number when using Gitversion and AppVeyor

### DIFF
--- a/source/Nuke.Common/Tools/GitVersion/GitVersionAttribute.cs
+++ b/source/Nuke.Common/Tools/GitVersion/GitVersionAttribute.cs
@@ -48,7 +48,7 @@ namespace Nuke.Common.Tools.GitVersion
             {
                 AzurePipelines.Instance?.UpdateBuildNumber(gitVersion.FullSemVer);
                 TeamCity.Instance?.SetBuildNumber(gitVersion.FullSemVer);
-                AppVeyor.Instance?.UpdateBuildNumber(gitVersion.FullSemVer);
+                AppVeyor.Instance?.UpdateBuildNumber($"{gitVersion.FullSemVer}.build.{AppVeyor.Instance.BuildNumber}");
             }
 
             return gitVersion;


### PR DESCRIPTION
I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer

---
When using `GitVersion.UpdateBuildNumber = true`, only the FullSemVer is used for the AppVeyor version and it can generate duplicate version numbers. 

I added the suffix `.buid.{buildnumber}` as it's done by GitVersion (https://github.com/GitTools/GitVersion/blob/master/src/GitVersionCore/BuildServers/AppVeyor.cs#L28 / GitTools/GitVersion@90d268b71e778ebb596775b1eebfbfc55920cc04)