### PR TITLE
Support for default implementations of interfaces

### DIFF
--- a/source/Nuke.Common.Tests/Execution/DefaultInterfaceExecutionTest.cs
+++ b/source/Nuke.Common.Tests/Execution/DefaultInterfaceExecutionTest.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using FluentAssertions;
+using Nuke.Common.Execution;
+using Xunit;
+
+namespace Nuke.Common.Tests.Execution
+{
+    public class DefaultInterfaceExecutionTest
+    {
+        public static string Description = "description";
+        public static Action Action = () => { };
+        public static Expression<Func<bool>> Requirement = () => true;
+        public static Expression<Func<bool>> StaticCondition = () => true;
+        public static Expression<Func<bool>> DynamicCondition = () => false;
+
+        [Fact]
+        public void Test()
+        {
+            var build = new TestBuild();
+            var targets = ExecutableTargetFactory.CreateAll(build, x => x.E);
+
+            var a = targets.Single(x => x.Name == nameof(ITestBuild.A));
+            var b = targets.Single(x => x.Name == nameof(ITestBuild.B));
+            var c = targets.Single(x => x.Name == nameof(ITestBuild.C));
+            var d = targets.Single(x => x.Name == nameof(ITestBuild.D));
+            var e = targets.Single(x => x.Name == nameof(TestBuild.E));
+
+            targets.Single(x => x.IsDefault).Should().Be(e);
+
+            a.Description.Should().Be(Description);
+            a.Requirements.Should().Equal(Requirement);
+            a.Actions.Should().Equal(Action);
+            a.AllDependencies.Should().BeEmpty();
+
+            b.DependencyBehavior.Should().Be(DependencyBehavior.Execute);
+            b.StaticConditions.Should().Equal(StaticCondition);
+            b.ExecutionDependencies.Should().Equal(d);
+            b.TriggerDependencies.Should().Equal(c);
+            b.AllDependencies.Should().NotBeEmpty();
+
+            c.Triggers.Should().Equal(b);
+            c.TriggerDependencies.Should().Equal(d);
+            c.ExecutionDependencies.Should().Equal(b);
+            c.OrderDependencies.Should().Equal(d);
+            c.AllDependencies.Should().NotBeEmpty();
+
+            d.DependencyBehavior.Should().Be(DependencyBehavior.Skip);
+            d.DynamicConditions.Should().Equal(DynamicCondition);
+            d.OrderDependencies.Should().Equal(b);
+            d.Triggers.Should().Equal(c);
+            d.AllDependencies.Should().NotBeEmpty();
+
+            e.ExecutionDependencies.Should().Equal(a);
+        }
+
+        [Fact]
+        public void TestMultipleInheritance()
+        {
+            var build = new MultipleInheritanceTestBuild();
+            var targets = ExecutableTargetFactory.CreateAll(build, x => x.Default);
+
+            var a = targets.Single(x => x.Name == nameof(ITestBuild.A));
+            var b = targets.Single(x => x.Name == nameof(ITestBuild.B));
+            var c = targets.Single(x => x.Name == nameof(ITestBuild.C));
+            var d = targets.Single(x => x.Name == nameof(ITestBuild.D));
+            var f = targets.Single(x => x.Name == nameof(IInheritedTestBuild.F));
+
+            f.Triggers.Should().Equal(a);
+
+            b.DependencyBehavior.Should().Be(DependencyBehavior.Execute);
+            b.StaticConditions.Should().Equal(StaticCondition);
+            b.ExecutionDependencies.Should().Equal(d);
+            b.TriggerDependencies.Should().Equal(c);
+            b.AllDependencies.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void TestInvalidDependencyType()
+        {
+            var build = new InvalidDependencyTypeTestBuild();
+            Assert.Throws<InvalidCastException>(() => ExecutableTargetFactory.CreateAll(build, x => x.E));
+        }
+
+        private class TestBuild : NukeBuild, ITestBuild
+        {
+            public Target E => _ => _
+                .DependsOn<ITestBuild>(x => x.A)
+                .Executes(() => { });
+        }
+
+        private class MultipleInheritanceTestBuild : NukeBuild, IInheritedTestBuild
+        {
+            public Target Default => _ => _
+                .DependsOn<ITestBuild>(x => x.A)
+                .Executes(() => { });
+        }
+
+        private class InvalidDependencyTypeTestBuild : NukeBuild
+        {
+            public Target E => _ => _
+                .DependsOn<ITestBuild>(x => x.A)
+                .Executes(() => { });
+        }
+
+        private interface ITestBuild
+        {
+            public string Description => DefaultInterfaceExecutionTest.Description;
+            public Action Action => DefaultInterfaceExecutionTest.Action;
+            public Expression<Func<bool>> Requirement => DefaultInterfaceExecutionTest.Requirement;
+            public Expression<Func<bool>> StaticCondition => DefaultInterfaceExecutionTest.StaticCondition;
+            public Expression<Func<bool>> DynamicCondition => DefaultInterfaceExecutionTest.DynamicCondition;
+
+            public Target A => _ => _
+                .Description(Description)
+                .Requires(Requirement)
+                .Executes(Action);
+
+            public Target B => _ => _
+                .WhenSkipped(DependencyBehavior.Execute)
+                .OnlyWhenStatic(StaticCondition)
+                .DependsOn(D)
+                .DependentFor(C);
+
+            public Target C => _ => _
+                .Triggers(B)
+                .TriggeredBy(D);
+
+            public Target D => _ => _
+                .WhenSkipped(DependencyBehavior.Skip)
+                .OnlyWhenDynamic(DynamicCondition)
+                .After(B)
+                .Before(C);
+        }
+
+        private interface IInheritedTestBuild : ITestBuild
+        {
+            public Target F => _ => _
+                .Triggers<ITestBuild>(x => x.A);
+        }
+    }
+}

--- a/source/Nuke.Common/Execution/ExecutableTargetFactory.cs
+++ b/source/Nuke.Common/Execution/ExecutableTargetFactory.cs
@@ -1,4 +1,4 @@
-// Copyright 2019 Maintainers of NUKE.
+﻿// Copyright 2019 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -22,7 +22,8 @@ namespace Nuke.Common.Execution
         {
             var defaultTargets = defaultTargetExpressions.Select(x => x.Compile().Invoke(build)).ToList();
             var properties = build.GetType()
-                .GetProperties(ReflectionService.Instance)
+                .GetProperties(ReflectionService.Instance) // TODO: static targets?
+                .Concat(build.GetType().GetInterfaces().SelectMany(x => x.GetProperties(ReflectionService.Instance)))
                 .Where(x => x.PropertyType == typeof(Target)).ToList();
 
             var executables = new List<ExecutableTarget>();
@@ -30,7 +31,7 @@ namespace Nuke.Common.Execution
             foreach (var property in properties)
             {
                 var factory = (Target) property.GetValue(build);
-                var definition = new TargetDefinition();
+                var definition = new TargetDefinition(build);
                 factory.Invoke(definition);
 
                 var target = new ExecutableTarget

--- a/source/Nuke.Common/Execution/TargetDefinition.cs
+++ b/source/Nuke.Common/Execution/TargetDefinition.cs
@@ -12,9 +12,14 @@ namespace Nuke.Common.Execution
 {
     internal class TargetDefinition : ITargetDefinition
     {
+        public TargetDefinition(NukeBuild build)
+        {
+            Build = build;
+        }
+
+        public NukeBuild Build { get; }
+
         internal string Description { get; set; }
-        internal bool IsDefault { get; set; }
-        internal TimeSpan Duration { get; set; }
         internal ExecutionStatus Status { get; set; }
         internal List<Expression<Func<bool>>> DynamicConditions { get; } = new List<Expression<Func<bool>>>();
         internal List<Expression<Func<bool>>> StaticConditions { get; } = new List<Expression<Func<bool>>>();
@@ -59,10 +64,20 @@ namespace Nuke.Common.Execution
             return this;
         }
 
+        public ITargetDefinition DependsOn<T>(params Func<T, Target>[] targets)
+        {
+            return DependsOn(targets.Select(x => x((T) (object) Build)).ToArray());
+        }
+
         public ITargetDefinition DependentFor(params Target[] targets)
         {
             DependentForTargets.AddRange(targets);
             return this;
+        }
+
+        public ITargetDefinition DependentFor<T>(params Func<T, Target>[] targets)
+        {
+            return DependentFor(targets.Select(x => x((T) (object) Build)).ToArray());
         }
 
         public ITargetDefinition OnlyWhenDynamic(params Expression<Func<bool>>[] conditions)
@@ -109,10 +124,20 @@ namespace Nuke.Common.Execution
             return this;
         }
 
+        public ITargetDefinition Before<T>(params Func<T, Target>[] targets)
+        {
+            return Before(targets.Select(x => x((T) (object) Build)).ToArray());
+        }
+
         public ITargetDefinition After(params Target[] targets)
         {
             AfterTargets.AddRange(targets);
             return this;
+        }
+
+        public ITargetDefinition After<T>(params Func<T, Target>[] targets)
+        {
+            return After(targets.Select(x => x((T) (object) Build)).ToArray());
         }
 
         public ITargetDefinition Triggers(params Target[] targets)
@@ -121,10 +146,20 @@ namespace Nuke.Common.Execution
             return this;
         }
 
+        public ITargetDefinition Triggers<T>(params Func<T, Target>[] targets)
+        {
+            return Triggers(targets.Select(x => x((T) (object) Build)).ToArray());
+        }
+
         public ITargetDefinition TriggeredBy(params Target[] targets)
         {
             TriggeredByTargets.AddRange(targets);
             return this;
+        }
+
+        public ITargetDefinition TriggeredBy<T>(params Func<T, Target>[] targets)
+        {
+            return TriggeredBy(targets.Select(x => x((T) (object) Build)).ToArray());
         }
 
         public ITargetDefinition AssuredAfterFailure()

--- a/source/Nuke.Common/ITargetDefinition.cs
+++ b/source/Nuke.Common/ITargetDefinition.cs
@@ -1,4 +1,4 @@
-// Copyright 2019 Maintainers of NUKE.
+﻿// Copyright 2019 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -42,9 +42,19 @@ namespace Nuke.Common
         ITargetDefinition DependsOn(params Target[] targets);
 
         /// <summary>
+        ///   Adds a set of dependent targets that will be executed before this target.
+        /// </summary>
+        ITargetDefinition DependsOn<T>(params Func<T, Target>[] targets);
+
+        /// <summary>
         ///   Adds a set of targets that are dependent for this target.
         /// </summary>
         ITargetDefinition DependentFor(params Target[] targets);
+
+        /// <summary>
+        ///   Adds a set of targets that are dependent for this target.
+        /// </summary>
+        ITargetDefinition DependentFor<T>(params Func<T, Target>[] targets);
 
         /// <summary>
         ///   Adds a set of conditions that will be checked before executing this target.
@@ -84,9 +94,19 @@ namespace Nuke.Common
         ITargetDefinition Before(params Target[] targets);
 
         /// <summary>
+        ///  Defines if this target should run before other targets.
+        /// </summary>
+        ITargetDefinition Before<T>(params Func<T, Target>[] targets);
+
+        /// <summary>
         ///  Defines if this target should run after other targets.
         /// </summary>
         ITargetDefinition After(params Target[] targets);
+
+        /// <summary>
+        ///  Defines if this target should run after other targets.
+        /// </summary>
+        ITargetDefinition After<T>(params Func<T, Target>[] targets);
 
         /// <summary>
         ///  Defines targets that will be triggered after this target.
@@ -94,9 +114,19 @@ namespace Nuke.Common
         ITargetDefinition Triggers(params Target[] targets);
 
         /// <summary>
+        ///  Defines targets that will be triggered after this target.
+        /// </summary>
+        ITargetDefinition Triggers<T>(params Func<T, Target>[] targets);
+
+        /// <summary>
         ///  Defines targets that will trigger this target.
         /// </summary>
         ITargetDefinition TriggeredBy(params Target[] targets);
+
+        /// <summary>
+        ///  Defines targets that will trigger this target.
+        /// </summary>
+        ITargetDefinition TriggeredBy<T>(params Func<T, Target>[] targets);
 
         /// <summary>
         ///  Defines that this target is guaranteed to be executed, even if other targets fail.


### PR DESCRIPTION
This might be an exotic proposal, but let me explain my line of thinking. I am curious about your opinion.

I want to create a library in my company providing targets for different use cases, like uniform versioning or pushing to Octopus. Right now I created a new abstract class combining all these targets, but I feel like this is overblown for some projects where they want to use only parts of the targets I provide.

So I thought, what about the new C#8 default implementations of interfaces? Utilizing them like "traits" where you can add the functionality you want. It turned out there were not many changes necessary in NUKE. Even parameter injection works (however, you can't set them interactively because you can only provide get-properties in interfaces). I needed to add a helper method to be able to reference targets in interfaces (because they are hidden in the implementing type).

You can now do something like this:

```csharp
interface IUseInterface
{
    [Parameter] string InterfaceParameter => EnvironmentInfo.GetParameter<string>(nameof(InterfaceParameter));

    public Target InterfaceTarget => _ => _
           .Requires(() => InterfaceParameter)
           .Executes(() =>
           {
               Logger.Info($"I am using parameter value {InterfaceParameter} ...");
           });
}

partial class Build : NukeBuild, IUseInterface
{
    Target DependOnInterfaceTarget => _ => _
        .DependsOn(FromInterface<IUseInterface>(_ => _.InterfaceTarget))
        .Executes(() => { Logger.Info("I run after the interface target."); });
}
```

What do you think?

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer