### PR TITLE
Add using in Build.cs template

### DIFF
--- a/source/Nuke.GlobalTool/templates/Build.cs
+++ b/source/Nuke.GlobalTool/templates/Build.cs
@@ -2,8 +2,8 @@ using System;
 using System.Linq;
 using Nuke.Common;
 using Nuke.Common.Execution;
-using Nuke.Common.IO;
 using Nuke.Common.Git;                                                                          // GIT
+using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;                                                                 // DOTNET

--- a/source/Nuke.GlobalTool/templates/Build.cs
+++ b/source/Nuke.GlobalTool/templates/Build.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using Nuke.Common;
 using Nuke.Common.Execution;
+using Nuke.Common.IO;
 using Nuke.Common.Git;                                                                          // GIT
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;


### PR DESCRIPTION
I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

This fixes #433 (and #403).

The `Build.cs` template was missing a `using Nuke.Common.IO` which caused a compilation error.