### PR TITLE
Implement trigger branches, tags, and paths config for Azure Pipelines attribute

### DIFF
--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2019 Maintainers of NUKE.
+﻿// Copyright 2020 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -41,6 +41,7 @@ namespace Nuke.Common.CI.AzurePipelines
 
         public string[] InvokedTargets { get; set; } = new string[0];
 
+        public bool TriggerDisabled { get; set; }
         public bool TriggerBatch { get; set; }
         public string[] TriggerBranchesInclude { get; set; } = new string[0];
         public string[] TriggerBranchesExclude { get; set; } = new string[0];
@@ -64,7 +65,23 @@ namespace Nuke.Common.CI.AzurePipelines
         {
             return new AzurePipelinesConfiguration
                    {
+                       VcsPushTrigger = GetVcsPushTrigger(),
                        Stages = _images.Select(x => GetStage(x, relevantTargets)).ToArray()
+                   };
+        }
+
+        protected AzurePipelinesVcsPushTrigger GetVcsPushTrigger()
+        {
+            return new AzurePipelinesVcsPushTrigger
+                   {
+                       Disabled = TriggerDisabled,
+                       Batch = TriggerBatch,
+                       BranchesInclude = TriggerBranchesInclude,
+                       BranchesExclude = TriggerBranchesExclude,
+                       TagsInclude = TriggerTagsInclude,
+                       TagsExclude = TriggerTagsExclude,
+                       PathsInclude = TriggerPathsInclude,
+                       PathsExclude = TriggerPathsExclude,
                    };
         }
 

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesConfiguration.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesConfiguration.cs
@@ -1,3 +1,7 @@
+﻿// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
 
@@ -5,10 +9,21 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
 {
     public class AzurePipelinesConfiguration : ConfigurationEntity
     {
+        public AzurePipelinesVcsPushTrigger VcsPushTrigger { get; set; }
+
         public AzurePipelinesStage[] Stages { get; set; }
 
         public override void Write(CustomFileWriter writer)
         {
+            if (VcsPushTrigger != null)
+            {
+                using (writer.WriteBlock("trigger:"))
+                {
+                    VcsPushTrigger.Write(writer);
+                    writer.WriteLine();
+                }
+            }
+
             using (writer.WriteBlock("stages:"))
             {
                 Stages.ForEach(x => x.Write(writer));

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesVcsPushTrigger.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesVcsPushTrigger.cs
@@ -1,0 +1,79 @@
+﻿// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System.Collections.Generic;
+using Nuke.Common.Utilities;
+using Nuke.Common.Utilities.Collections;
+
+namespace Nuke.Common.CI.AzurePipelines.Configuration
+{
+    public class AzurePipelinesVcsPushTrigger : ConfigurationEntity
+    {
+        public bool Disabled { get; set; }
+        public bool Batch { get; set; }
+        public string[] BranchesInclude { get; set; }
+        public string[] BranchesExclude { get; set; }
+        public string[] TagsInclude { get; set; }
+        public string[] TagsExclude { get; set; }
+        public string[] PathsInclude { get; set; }
+        public string[] PathsExclude { get; set; }
+
+        public override void Write(CustomFileWriter writer)
+        {
+            if (Disabled)
+            {
+                writer.WriteLine("none");
+                return;
+            }
+
+            writer.WriteLine($"batch: {Batch.ToString().ToLower()}");
+
+            if (BranchesInclude.Length > 0 || BranchesExclude.Length > 0)
+            {
+                using (writer.WriteBlock("branches:"))
+                {
+                    WriteInclusionsAndExclusions(writer, BranchesInclude, BranchesExclude);
+                }
+            }
+
+            if (TagsInclude.Length > 0 || TagsExclude.Length > 0)
+            {
+                using (writer.WriteBlock("tags:"))
+                {
+                    WriteInclusionsAndExclusions(writer, TagsInclude, TagsExclude);
+                }
+            }
+
+            if (PathsInclude.Length > 0 || PathsExclude.Length > 0)
+            {
+                using (writer.WriteBlock("paths:"))
+                {
+                    WriteInclusionsAndExclusions(writer, PathsInclude, PathsExclude);
+                }
+            }
+        }
+
+        private static void WriteInclusionsAndExclusions(
+            CustomFileWriter writer,
+            IReadOnlyCollection<string> inclusions,
+            IReadOnlyCollection<string> exclusions)
+        {
+            if (inclusions.Count > 0)
+            {
+                using (writer.WriteBlock("include:"))
+                {
+                    inclusions.ForEach(x => writer.WriteLine($"- {x}"));
+                }
+            }
+
+            if (exclusions.Count > 0)
+            {
+                using (writer.WriteBlock("exclude:"))
+                {
+                    exclusions.ForEach(x => writer.WriteLine($"- {x}"));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

---
The Azure Pipelines configuration attribute now generates trigger branches, tags, and paths in the `azure-pipelines.yml` file according to [the schema](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?#triggers).

This only partially covers the possible triggers, there are PR triggers and scheduled triggers as well, but as this is my first contribution, I figured I would make sure I had the rhythm before I implemented the other trigger types.