### PR TITLE
Make the optinal suffix parameter really optional

### DIFF
--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
@@ -21,6 +21,13 @@ namespace Nuke.Common.CI.AzurePipelines
     {
         private readonly string _suffix;
         private readonly AzurePipelinesImage[] _images;
+        
+        public AzurePipelinesAttribute(
+            AzurePipelinesImage image,
+            params AzurePipelinesImage[] images)
+            : this(null, image, images)
+        {            
+        }
 
         public AzurePipelinesAttribute(
             [CanBeNull] string suffix,


### PR DESCRIPTION
I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

This is an alternative to https://github.com/nuke-build/web/pull/10