### PR TITLE
Add 'nuke :fix' command to add previously missing packages 

### DIFF
--- a/source/Nuke.Common/Constants.cs
+++ b/source/Nuke.Common/Constants.cs
@@ -53,5 +53,10 @@ namespace Nuke.Common
         {
             return GetTemporaryDirectory(rootDirectory) / $"{VisualStudioDebugParameterName}.log";
         }
+
+        internal static AbsolutePath GetMissingPackageFile(AbsolutePath rootDirectory)
+        {
+            return GetTemporaryDirectory(rootDirectory) / "missing-package.log";
+        }
     }
 }

--- a/source/Nuke.Common/NukeBuild.Statics.cs
+++ b/source/Nuke.Common/NukeBuild.Statics.cs
@@ -32,6 +32,7 @@ namespace Nuke.Common
             FileSystemTasks.EnsureExistingDirectory(TemporaryDirectory);
             BuildAssemblyDirectory = GetBuildAssemblyDirectory();
             BuildProjectDirectory = GetBuildProjectDirectory(BuildAssemblyDirectory);
+            BuildProjectFile = GetBuildProjectDirectory(BuildAssemblyDirectory);
 
             Verbosity = EnvironmentInfo.GetParameter<Verbosity?>(() => Verbosity) ?? Verbosity.Normal;
             Host = EnvironmentInfo.GetParameter<HostType?>(() => Host) ?? GetHostType();
@@ -63,6 +64,12 @@ namespace Nuke.Common
         /// </summary>
         [CanBeNull]
         public static AbsolutePath BuildProjectDirectory { get; }
+
+        /// <summary>
+        /// Gets the full path to the build project file, or <c>null</c>
+        /// </summary>
+        [CanBeNull]
+        public static AbsolutePath BuildProjectFile { get; }
 
         /// <summary>
         /// Gets the logging verbosity during build execution. Default is <see cref="Nuke.Common.Verbosity.Normal"/>.
@@ -130,7 +137,7 @@ namespace Nuke.Common
         }
 
         [CanBeNull]
-        private static AbsolutePath GetBuildProjectDirectory(AbsolutePath buildAssemblyDirectory)
+        private static AbsolutePath GetBuildProjectDirectory([CanBeNull] AbsolutePath buildAssemblyDirectory)
         {
             if (buildAssemblyDirectory == null)
                 return null;
@@ -141,6 +148,12 @@ namespace Nuke.Common
                     .SingleOrDefaultOrError($"Found multiple project files in '{x}'."))
                 .FirstOrDefault(x => x != null)
                 ?.DirectoryName;
+        }
+
+        [CanBeNull]
+        private static AbsolutePath GetBuildProjectFile([CanBeNull] AbsolutePath buildProjectDirectory)
+        {
+            return buildProjectDirectory?.GlobFiles("*.csproj").SingleOrDefault();
         }
 
         private static HostType GetHostType()

--- a/source/Nuke.Common/ProjectModel/ProjectModelTasks.cs
+++ b/source/Nuke.Common/ProjectModel/ProjectModelTasks.cs
@@ -92,11 +92,14 @@ namespace Nuke.Common.ProjectModel
                     Environment.SetEnvironmentVariable("MSBUILD_EXE_PATH", s_msbuildPathResolver.Value);
 
                 var projectCollection = new ProjectCollection();
-                var msbuildProject = new Microsoft.Build.Evaluation.Project(
-                    projectFile,
-                    GetProperties(configuration, targetFramework),
-                    projectCollection.DefaultToolsVersion,
-                    projectCollection);
+                var projectRoot = Microsoft.Build.Construction.ProjectRootElement.Open(projectFile, projectCollection, preserveFormatting: true);
+                var msbuildProject = Microsoft.Build.Evaluation.Project.FromProjectRootElement(projectRoot, new Microsoft.Build.Definition.ProjectOptions
+                {
+                    GlobalProperties = GetProperties(configuration, targetFramework),
+                    ToolsVersion = projectCollection.DefaultToolsVersion,
+                    ProjectCollection = projectCollection
+                });
+
                 var targetFrameworks = msbuildProject.AllEvaluatedItems
                     .Where(x => x.ItemType == "_TargetFrameworks")
                     .Select(x => x.EvaluatedInclude)

--- a/source/Nuke.Common/Tooling/NuGetPackageResolver.cs
+++ b/source/Nuke.Common/Tooling/NuGetPackageResolver.cs
@@ -241,7 +241,7 @@ namespace Nuke.Common.Tooling
             var projectDirectoryInfo = new DirectoryInfo(projectDirectory);
             var packagesConfigFile = projectDirectoryInfo.GetFiles("packages.config").SingleOrDefault()
                                      ?? projectDirectoryInfo.GetFiles("*.csproj")
-                                         .SingleOrDefaultOrError("Directory contains multiple project files.");
+                                         .SingleOrDefaultOrError($"Directory '{projectDirectory}' contains multiple project files.");
             return packagesConfigFile?.FullName;
         }
 

--- a/source/Nuke.Common/Tooling/ToolPathResolver.cs
+++ b/source/Nuke.Common/Tooling/ToolPathResolver.cs
@@ -1,11 +1,13 @@
-﻿// Copyright 2019 Maintainers of NUKE.
+// Copyright 2020 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using JetBrains.Annotations;
+using Nuke.Common.IO;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
 
@@ -18,6 +20,8 @@ namespace Nuke.Common.Tooling
         public static string NuGetPackagesConfigFile;
         public static string NuGetAssetsConfigFile;
         public static string PaketPackagesConfigFile;
+
+        internal const string MissingPackageDefaultVersion = "latest";
 
         [CanBeNull]
         public static string TryGetEnvironmentExecutable(string environmentExecutable)
@@ -65,50 +69,66 @@ namespace Nuke.Common.Tooling
             return frameworks[framework];
         }
 
-        private static string GetPackageDirectory(string[] packageIds, string version)
+        private static string GetPackageDirectory(string[] packageIds, [CanBeNull] string version)
         {
-            return packageIds
-                .SelectMany(x =>
-                    new Func<string>[]
-                    {
-                        () => ExecutingAssemblyDirectory != null
-                            ? Path.Combine(ExecutingAssemblyDirectory, x)
-                            : null,
-                        () => NuGetAssetsConfigFile != null
-                            ? NuGetPackageResolver.GetLocalInstalledPackage(x, NuGetAssetsConfigFile, version)?.Directory
-                            : null,
-                        () => NuGetPackagesConfigFile != null
-                            ? NuGetPackageResolver.GetLocalInstalledPackage(x, NuGetPackagesConfigFile, version)?.Directory
-                            : null,
-                        () => PaketPackagesConfigFile != null
-                            ? PaketPackageResolver.GetLocalInstalledPackageDirectory(x, PaketPackagesConfigFile)
-                            : null
-                    })
-                .Select(x => x.Invoke())
-                .FirstOrDefault(Directory.Exists)
-                .NotNull(
-                    new[]
+            try
+            {
+                return packageIds
+                    .SelectMany(x =>
+                        new Func<string>[]
                         {
-                            $"Could not find package {packageIds.Select(x => x.SingleQuote()).JoinCommaOr()} " +
-                            $"{(version != null ? $"({version}) " : string.Empty)}" +
-                            "using:"
-                        }
-                        .Concat(
-                            new[]
+                            () => ExecutingAssemblyDirectory != null
+                                ? Path.Combine(ExecutingAssemblyDirectory, x)
+                                : null,
+                            () => NuGetAssetsConfigFile != null
+                                ? NuGetPackageResolver.GetLocalInstalledPackage(x, NuGetAssetsConfigFile, version)?.Directory
+                                : null,
+                            () => NuGetPackagesConfigFile != null
+                                ? NuGetPackageResolver.GetLocalInstalledPackage(x, NuGetPackagesConfigFile, version)?.Directory
+                                : null,
+                            () => PaketPackagesConfigFile != null
+                                ? PaketPackageResolver.GetLocalInstalledPackageDirectory(x, PaketPackagesConfigFile)
+                                : null
+                        })
+                    .Select(x => x.Invoke())
+                    .FirstOrDefault(Directory.Exists)
+                    .NotNull(
+                        new[]
                             {
-                                NukeBuild.BuildProjectDirectory == null
-                                    ? $"Embedded packages directory at '{ExecutingAssemblyDirectory}'"
-                                    : null,
-                                NuGetAssetsConfigFile != null
-                                    ? $"Project assets file '{NuGetAssetsConfigFile}'"
-                                    : null,
-                                NuGetPackagesConfigFile != null
-                                    ? $"NuGet packages config '{NuGetPackagesConfigFile}'"
-                                    : null,
-                                PaketPackagesConfigFile != null
-                                    ? $"Paket packages config '{PaketPackagesConfigFile}'"
-                                    : null
-                            }.WhereNotNull().Select(x => $" - {x}")).JoinNewLine());
+                                $"Could not find package {packageIds.Select(x => x.SingleQuote()).JoinCommaOr()} " +
+                                $"{(version != null ? $"({version}) " : string.Empty)}" +
+                                "using:"
+                            }
+                            .Concat(
+                                new[]
+                                {
+                                    NukeBuild.BuildProjectDirectory == null
+                                        ? $"Embedded packages directory at '{ExecutingAssemblyDirectory}'"
+                                        : null,
+                                    NuGetAssetsConfigFile != null
+                                        ? $"Project assets file '{NuGetAssetsConfigFile}'"
+                                        : null,
+                                    NuGetPackagesConfigFile != null
+                                        ? $"NuGet packages config '{NuGetPackagesConfigFile}'"
+                                        : null,
+                                    PaketPackagesConfigFile != null
+                                        ? $"Paket packages config '{PaketPackagesConfigFile}'"
+                                        : null
+                                }.WhereNotNull().Select(x => $" - {x}")).JoinNewLine());
+            }
+            catch (Exception exception)
+            {
+                if (!NuGetPackagesConfigFile.EndsWithOrdinalIgnoreCase(".csproj"))
+                    throw;
+
+                TextTasks.WriteAllLines(
+                    Constants.GetMissingPackageFile(NukeBuild.RootDirectory),
+                    lines: new[] { NuGetPackagesConfigFile }
+                        .Concat(packageIds.Select(x => $"{x}@{version ?? MissingPackageDefaultVersion}"))
+                        .ToList());
+
+                throw new Exception(new[] { exception.Message, "Run 'nuke :fix' to add missing references." }.JoinNewLine(), exception);
+            }
         }
 
         public static string GetPathExecutable(string pathExecutable)

--- a/source/Nuke.GlobalTool/Program.Complete.cs
+++ b/source/Nuke.GlobalTool/Program.Complete.cs
@@ -20,19 +20,14 @@ namespace Nuke.GlobalTool
         [UsedImplicitly]
         public static int Complete(string[] args, [CanBeNull] string rootDirectory, [CanBeNull] string buildScript)
         {
+            if (rootDirectory == null)
+                return 0;
+
             var words = args.Single();
             if (!words.StartsWithOrdinalIgnoreCase(c_commandName))
-            {
                 return 0;
-            }
 
             words = words.Substring(c_commandName.Length).TrimStart();
-
-            if (rootDirectory == null)
-            {
-                // TODO: parse --root parameter
-                return 0;
-            }
 
             var completionFile = Constants.GetCompletionFile((AbsolutePath) rootDirectory);
             if (!File.Exists(completionFile))

--- a/source/Nuke.GlobalTool/Program.Fix.cs
+++ b/source/Nuke.GlobalTool/Program.Fix.cs
@@ -1,0 +1,105 @@
+// Copyright 2019 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.IO;
+using System.Linq;
+using JetBrains.Annotations;
+using Nuke.Common;
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+using Nuke.Common.Tooling;
+using Nuke.Common.Utilities;
+using Nuke.Common.Utilities.Collections;
+using static Nuke.Common.Utilities.ConsoleUtility;
+
+namespace Nuke.GlobalTool
+{
+    partial class Program
+    {
+        private const string PACKAGE_TYPE_DOWNLOAD = "PackageDownload";
+        private const string PACKAGE_TYPE_REFERENCE = "PackageReference";
+
+        [UsedImplicitly]
+        private static int Fix(string[] args, [CanBeNull] string rootDirectory, [CanBeNull] string buildScript)
+        {
+            if (rootDirectory == null)
+                return 0;
+
+            var missingPackageFile = Constants.GetMissingPackageFile((AbsolutePath) rootDirectory);
+            if (!File.Exists(missingPackageFile))
+                return 0;
+
+            Logger.Info("During last execution a package was found to be missing.");
+
+            var missingPackageContents = File.ReadAllLines(missingPackageFile);
+            var buildProjectFile = missingPackageContents.FirstOrDefault();
+            ControlFlow.Assert(File.Exists(buildProjectFile), $"File.Exists({buildProjectFile})");
+
+            var packages = missingPackageContents
+                .Skip(1)
+                .Select(x => x.Split("@", StringSplitOptions.RemoveEmptyEntries))
+                .ForEachLazy(x => ControlFlow.Assert(x.Length == 2, "x.Length == 2"))
+                .Select(x => (packageName: x[0], version: x[1])).ToList();
+            ControlFlow.Assert(packages.Count > 0, "packages.Count > 0");
+
+            var (selectedPackageId, selectedPackageVersion) = packages.Count == 1
+                ? packages.Single()
+                : PromptForChoice("Which package should be added?",
+                    packages.Select(x => (x, x.packageName)).ToArray());
+
+            if (selectedPackageVersion == ToolPathResolver.MissingPackageDefaultVersion)
+            {
+                var latestReleaseVersion = NuGetPackageResolver.GetLatestPackageVersion(selectedPackageId, includePrereleases: false);
+                var latestPrereleaseVersion = NuGetPackageResolver.GetLatestPackageVersion(selectedPackageId, includePrereleases: true);
+                var latestLocalVersion = NuGetPackageResolver.GetGlobalInstalledPackage(selectedPackageId, version: null, packagesConfigFile: null)
+                    ?.Version.ToString();
+
+                var packageVersions = new[]
+                                      {
+                                          ("latest release", latestReleaseVersion.GetAwaiter().GetResult()),
+                                          ("latest prerelease", latestPrereleaseVersion.GetAwaiter().GetResult()),
+                                          ("latest local", latestLocalVersion),
+                                          ("tbd elsewhere", null)
+                                      }
+                    .Where(x => x.Item2 != null)
+                    .Distinct(x => x.Item2)
+                    .Select(x => (x.Item2, $"{x.Item2 ?? "<null>"} ({x.Item1})")).ToArray();
+
+                selectedPackageVersion = packageVersions.Length == 1
+                    ? packageVersions.Single().Item1
+                    : PromptForChoice($"Which version of {selectedPackageId.SingleQuote()} should be added?", packageVersions);
+            }
+
+            var project = ProjectModelTasks.ParseProject(buildProjectFile).NotNull();
+            var referenceType = PACKAGE_TYPE_DOWNLOAD;
+            // var msbuildBinPath = project.GetProperty("MSBuildBinPath").EvaluatedValue;
+            // var sdkVersion = msbuildBinPath.Split("/", StringSplitOptions.RemoveEmptyEntries).Last();
+            // var referenceType = int.TryParse(sdkVersion.Split(".").First(), out var majorVersion) && majorVersion >= 3
+            //     ? PACKAGETYPE_DOWNLOAD
+            //     : PACKAGETYPE_REFERENCE;
+
+            var item = project.AddItem(referenceType, selectedPackageId).Single();
+            if (selectedPackageVersion != null)
+            {
+                item.Xml.AddMetadata(
+                    "Version",
+                    referenceType == PACKAGE_TYPE_DOWNLOAD
+                        ? $"[{selectedPackageVersion}]"
+                        : selectedPackageVersion,
+                    expressAsAttribute: true);
+            }
+
+            // if (referenceType == PACKAGE_TYPE_REFERENCE)
+            //     item.Xml.AddMetadata("ExcludeAssets", "All", expressAsAttribute: true);
+
+            project.Save();
+
+            File.Delete(missingPackageFile);
+            Logger.Success($"Added {item.EvaluatedInclude.SingleQuote()} to {buildProjectFile.SingleQuote()}.");
+
+            return 0;
+        }
+    }
+}

--- a/source/Nuke.GlobalTool/Program.cs
+++ b/source/Nuke.GlobalTool/Program.cs
@@ -24,6 +24,7 @@ namespace Nuke.GlobalTool
 
             try
             {
+                // TODO: parse from --root argument
                 var rootDirectory = Constants.TryGetRootDirectoryFrom(Directory.GetCurrentDirectory());
 
                 var buildScript = rootDirectory != null


### PR DESCRIPTION
Introduced ":fix" switch for nuke global tool, which lets you add a "PackageDownload" reference to your build project for previously missing tools in a failed build.

@matkoch Please let me know if this is what you had in mind.

There are some issues with which I'm not quite yet happy:
- way to determine .net core
- no good way to get latest version of a package
- I'm not sure how to detect if PackageDownload is supported. Does it depend on the dotnet runtime which executes the build, or the target framework of the build project? From what version on?

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer