### PR TITLE
Ensure console is set to produce UTF-8 output

### DIFF
--- a/source/Nuke.GlobalTool/templates/build.netcore.ps1
+++ b/source/Nuke.GlobalTool/templates/build.netcore.ps1
@@ -8,6 +8,7 @@ Write-Output "PowerShell $($PSVersionTable.PSEdition) version $($PSVersionTable.
 
 Set-StrictMode -Version 2.0; $ErrorActionPreference = "Stop"; $ConfirmPreference = "None"; trap { exit 1 }
 $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 ###########################################################################
 # CONFIGURATION

--- a/source/Nuke.GlobalTool/templates/build.netfx.ps1
+++ b/source/Nuke.GlobalTool/templates/build.netfx.ps1
@@ -8,6 +8,7 @@ Write-Output "PowerShell $($PSVersionTable.PSEdition) version $($PSVersionTable.
 
 Set-StrictMode -Version 2.0; $ErrorActionPreference = "Stop"; $ConfirmPreference = "None"; trap { exit 1 }
 $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 ###########################################################################
 # CONFIGURATION


### PR DESCRIPTION
I confirm that the pull-request:

- [ x ] Follows the contribution guidelines
- [ x ] Is based on my own work
- [ x ] Is in compliance with my employer

Long story short. We were running NUKE in [Atlassian Bamboo](https://www.atlassian.com/software/bamboo) environment and saw this kind of output in the web UI:

```
09-Apr-2020 18:34:24 | ��������������������������������������������
-- | --
09-Apr-2020 18:34:24 | Target������������������Status������Duration
09-Apr-2020 18:34:24 | ��������������������������������������������
09-Apr-2020 18:34:24 | RestoreNuGetPackages����Executed��������0:02
09-Apr-2020 18:34:24 | PackNukeFiles�����������Executed��������0:00
09-Apr-2020 18:34:24 | RestoreNpmPackages������Executed��������0:14
09-Apr-2020 18:34:24 | Pack��������������������Executed��������1:02
09-Apr-2020 18:34:24 | ��������������������������������������������
09-Apr-2020 18:34:24 | Total�����������������������������������1:19
09-Apr-2020 18:34:24 | ��������������������������������������������
09-Apr-2020 18:34:24 |  
09-Apr-2020 18:34:24 | Build succeeded on 9.4.2020 18.34.24. \(^?^)/
```

Reading Atlassian documentation gave hints how to configure UTF-8 for server, but also that you need to [initialize your console session properly](https://confluence.atlassian.com/bamkb/unicode-characters-from-a-windows-console-are-not-displayed-correctly-in-bamboo-build-logs-953652359.html). I changed my VCS controlled build.ps1 to have

`[Console]::OutputEncoding = [System.Text.Encoding]::UTF8`

And it fixed the problem. **We are calling the default build.cmd from build server** to initialize build.

Now the output is:

```
09-Apr-2020 18:39:11 | ════════════════════════════════════════════
-- | --
09-Apr-2020 18:39:11 | Target                  Status      Duration
09-Apr-2020 18:39:11 | ────────────────────────────────────────────
09-Apr-2020 18:39:11 | RestoreNuGetPackages    Executed        0:02
09-Apr-2020 18:39:11 | PackNukeFiles           Executed        0:00
09-Apr-2020 18:39:11 | RestoreNpmPackages      Executed        0:14
09-Apr-2020 18:39:11 | Pack                    Executed        1:01
09-Apr-2020 18:39:11 | ────────────────────────────────────────────
09-Apr-2020 18:39:11 | Total                                   1:17
09-Apr-2020 18:39:11 | ════════════════════════════════════════════
09-Apr-2020 18:39:11 |  
09-Apr-2020 18:39:11 | Build succeeded on 9.4.2020 18.39.11. ＼（＾ᴗ＾）／
```

It seems that is also possible to configure this on Windows level (registry), but may require specific version of Windows. Ideally build tool output would just work also in environments where it's harder to configure.

So here I'm suggesting adding the explicit output directive to default templates. Would this make sense?

Thank you for this awesome tool! I've so far used only for a week but seeing great benefits.