### PR TITLE
Fix OutputEncoding of console OutputSinks

### DIFF
--- a/source/Nuke.Common/OutputSinks/AnsiColorOutputSink.cs
+++ b/source/Nuke.Common/OutputSinks/AnsiColorOutputSink.cs
@@ -13,6 +13,11 @@ namespace Nuke.Common.OutputSinks
     [ExcludeFromCodeCoverage]
     internal class AnsiColorOutputSink : OutputSink
     {
+        public AnsiColorOutputSink()
+        {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+        }
+
         public string ResetSequence { get; } = "\u001b[0m";
         public string TraceSequence => $"\u001b[{TraceCode}m";
         public string InformationSequence => $"\u001b[{InformationCode}m";

--- a/source/Nuke.Common/OutputSinks/SystemColorOutputSink.cs
+++ b/source/Nuke.Common/OutputSinks/SystemColorOutputSink.cs
@@ -15,6 +15,11 @@ namespace Nuke.Common.OutputSinks
     [ExcludeFromCodeCoverage]
     internal class SystemColorOutputSink : OutputSink
     {
+        public SystemColorOutputSink()
+        {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+        }
+
         internal override void WriteNormal(string text)
         {
             Console.WriteLine(text);


### PR DESCRIPTION
because ProcessTasks.StartProcessInternal create ProcessStartInfo with
UTF-8 encoding of std output

fixes #465

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer