### PR TITLE
Upgrade GitVersion to 5.1.2 in DotNetCore templates

### DIFF
--- a/source/Nuke.GlobalTool/templates/_build.sdk.csproj
+++ b/source/Nuke.GlobalTool/templates/_build.sdk.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="_NUKE_VERSION_" />
-    <PackageDownload Include="GitVersion.Tool" Version="[5.1.1]" />    // GITVERSION
+    <PackageDownload Include="GitVersion.Tool" Version="[5.1.2]" />    // GITVERSION
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The version to GitVersion included in the dotnet core templates does not work on Azure DevOps.
A number of bugs around this were fixed in GitVersion release 5.1.2.
This version runs on the same framework runtime as 5.1.1 and so should work as a drop in replacement. 

Important bugs fixed in this release were:
- GitVersionTask 5.1.0 - Error in Azure Devops private repos: Value cannot be null. Parameter name: source
-  Error on Azure Devops ubuntu Agents

See [GitVersion 5.1.2](https://github.com/GitTools/GitVersion/releases/tag/5.1.2) for more details of the fixes.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer