### PR TITLE
Change DupFinder DiscardCost argument to int

### DIFF
--- a/build/specifications/DupFinder.json
+++ b/build/specifications/DupFinder.json
@@ -71,7 +71,7 @@
           },
           {
             "name": "DiscardCost",
-            "type": "bool",
+            "type": "int",
             "format": "--discard-cost={value}",
             "help": "Allows setting a threshold for code complexity of the duplicated fragments. The fragments with lower complexity are discarded as non-duplicates. The value for this option is provided in relative units. Using this option, you can filter out equal code fragments that present no semantic duplication. E.g. you can often have the following statements in tests: <c>Assert.AreEqual(gold, result);</c>. If the <c>discard-cost</c> value is less than 10, statements like that will appear as duplicates, which is obviously unhelpful. You'll need to play a bit with this value to find a balance between avoiding false positives and missing real duplicates. The proper values will differ for different codebases."
           },


### PR DESCRIPTION
I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

DiscardCost should be an integer value (it's a threshold setting).
See [https://www.jetbrains.com/help/resharper/dupFinder.html](dupFinder documentation) --discard-cost.