### PR TITLE
Fix KeyVault attributes not working via command line arguments

### DIFF
--- a/source/Nuke.Common.Tests/Execution/ParameterServiceTests.cs
+++ b/source/Nuke.Common.Tests/Execution/ParameterServiceTests.cs
@@ -1,0 +1,44 @@
+﻿// Copyright 2019 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using Nuke.Common.Execution;
+using Nuke.Common.Tools.AzureKeyVault.Attributes;
+using Xunit;
+
+namespace Nuke.Common.Tests.Execution
+{
+    public class ParameterServiceTests
+    {
+        [Fact]
+        public void CanGetParameterDescription_ForParameter()
+        {
+            var memberInfo = typeof(FunkyClass)
+                .GetTypeInfo()
+                .DeclaredMembers
+                .Single(m => m.Name == "StringParameter");
+            var description = ParameterService.GetParameterDescription(memberInfo);
+            description.Should().Be("String parameter description");
+        }
+
+        [Fact]
+        public void DoesNotThrowOnGetDescription_ForKeyVaultSecret()
+        {
+            var memberInfo = typeof(FunkyClass)
+                .GetTypeInfo()
+                .DeclaredMembers
+                .Single(m => m.Name == "KeyVaultSecretParameter");
+            var description = ParameterService.GetParameterDescription(memberInfo);
+            description.Should().BeNull();
+        }
+
+        public class FunkyClass
+        {
+            [Parameter(description: "String parameter description")] string StringParameter;
+            [KeyVaultSecret] string KeyVaultSecretParameter;
+        }
+    }
+}

--- a/source/Nuke.Common/Tools/AzureKeyVault/Attributes/KeyVaultSecretAttribute.cs
+++ b/source/Nuke.Common/Tools/AzureKeyVault/Attributes/KeyVaultSecretAttribute.cs
@@ -14,7 +14,7 @@ namespace Nuke.Common.Tools.AzureKeyVault.Attributes
     [PublicAPI]
     [AttributeUsage(AttributeTargets.Field)]
     [MeansImplicitUse(ImplicitUseKindFlags.Assign)]
-    public class KeyVaultSecretAttribute : InjectionAttributeBase
+    public class KeyVaultSecretAttribute : ParameterAttribute
     {
         protected static KeyVaultTaskSettings CreateSettings (string secretName, KeyVaultSettings keyVaultSettings)
         {
@@ -62,6 +62,12 @@ namespace Nuke.Common.Tools.AzureKeyVault.Attributes
                 return KeyVaultTasks.GetCertificateBundle(CreateSettings(secretName, settings));
             if (memberType == typeof(KeyVault))
                 return KeyVaultTasks.LoadVault(CreateSettings(secretName, settings));
+
+            var baseValue = base.GetValue(member, instance);
+            if (baseValue != default)
+            {
+                return baseValue;
+            }
 
             throw new NotSupportedException();
         }


### PR DESCRIPTION
I'm using the `[KeyVaultSecret]` attribute in lots of my own builds and have noticed that I was no longer able to override the values via command line or enviornment arguments. Additionally, this should fix the build from crashing when an attribute is marked as required by a target but is not present.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer