### PR TITLE
Fix requirement check of parameters defined in interfaces

### DIFF
--- a/source/Nuke.Common.Tests/Execution/DefaultInterfaceExecutionTest.cs
+++ b/source/Nuke.Common.Tests/Execution/DefaultInterfaceExecutionTest.cs
@@ -77,11 +77,36 @@ namespace Nuke.Common.Tests.Execution
         }
 
         [Fact]
+        public void TestRequirementValidation()
+        {
+            EnvironmentInfo.SetVariable("StringParameter", "hello");
+            var build = new ParameterBuild();
+            var targets = ExecutableTargetFactory.CreateAll(build, x => ((IParameterInterface)x).HelloWorld);
+
+            // must not throw
+            RequirementService.ValidateRequirements(build, targets);
+        }
+
+        [Fact]
         public void TestInvalidDependencyType()
         {
             var build = new InvalidDependencyTypeTestBuild();
             Assert.Throws<InvalidCastException>(() => ExecutableTargetFactory.CreateAll(build, x => x.E));
         }
+
+        private interface IParameterInterface
+        {
+            [Parameter] string StringParameter => InjectionUtility.GetInjectionValue(() => StringParameter);
+
+            public Target HelloWorld => _ => _
+                .Requires(() => StringParameter)
+                .Executes(() =>
+                {
+                    Logger.Info(StringParameter);
+                });
+        }
+
+        private class ParameterBuild : NukeBuild, IParameterInterface { }
 
         private class TestBuild : NukeBuild, ITestBuild
         {

--- a/source/Nuke.Common/Execution/RequirementService.cs
+++ b/source/Nuke.Common/Execution/RequirementService.cs
@@ -38,9 +38,11 @@ namespace Nuke.Common.Execution
 
         private static bool IsMemberNull(MemberInfo member, NukeBuild build, ExecutableTarget target = null)
         {
-            member = member.DeclaringType != build.GetType()
-                ? build.GetType().GetMember(member.Name).Single()
-                : member;
+            if (member.DeclaringType != build.GetType())
+            {
+                // Can happen when a derived class overrides a member
+                member = build.GetType().GetMember(member.Name).SingleOrDefault() ?? member;
+            }
 
             var from = target != null ? $"from target '{target.Name}' " : string.Empty;
             ControlFlow.Assert(member.HasCustomAttribute<InjectionAttributeBase>(),


### PR DESCRIPTION
Currently build execution fails when using parameters in an interface, even if the value is provided. This fixes it while retaining ability to interactively provide a missing parameter value if the member is overriden in the derived class.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer