### PR TITLE
Add TeamCity personal build detection

### DIFF
--- a/source/Nuke.Common/CI/TeamCity/TeamCity.cs
+++ b/source/Nuke.Common/CI/TeamCity/TeamCity.cs
@@ -124,6 +124,7 @@ namespace Nuke.Common.CI.TeamCity
         public string ServerUrl => ConfigurationProperties["teamcity.serverUrl"];
         [NoConvert] public string BranchName => ConfigurationProperties.GetValueOrDefault("teamcity.build.branch")
             .NotNull("Configuration property 'teamcity.build.branch' is null. See https://youtrack.jetbrains.com/issue/TW-62888.");
+        public bool IsBuildPersonal => bool.Parse(SystemProperties.GetValueOrDefault("build.is.personal", bool.FalseString));
 
         public void DisableServiceMessages()
         {


### PR DESCRIPTION
TeamCity system property "system.build.is.personal" is only available
in personal builds and has value "true".
In other builds the property does not exist.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer