### PR TITLE
API Design Proposal: Fluent API for CI configurations

### DIFF
--- a/source/Nuke.Common/CI/CIBuilder.cs
+++ b/source/Nuke.Common/CI/CIBuilder.cs
@@ -1,0 +1,21 @@
+// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Linq;
+
+namespace Nuke.Common.CI
+{
+    internal class CIBuilder : ICIBuilder
+    {
+        public ICIBuilder Add<T>(Action<T> action) where T : ICIProvider
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
+++ b/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
@@ -21,7 +21,7 @@ namespace Nuke.Common.CI.GitHubActions
     /// </summary>
     [PublicAPI]
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
-    public class GitHubActionsAttribute : ConfigurationAttributeBase
+    public class GitHubActionsAttribute : ConfigurationAttributeBase, ICIProvider
     {
         private readonly string _name;
         private readonly GitHubActionsImage[] _images;

--- a/source/Nuke.Common/CI/ICIBuilder.cs
+++ b/source/Nuke.Common/CI/ICIBuilder.cs
@@ -1,0 +1,18 @@
+// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Linq;
+
+namespace Nuke.Common.CI
+{
+    public interface ICIBuilder
+    {
+        ICIBuilder Add<T>(Action<T> action) where T : ICIProvider;
+    }
+}

--- a/source/Nuke.Common/CI/ICIProvider.cs
+++ b/source/Nuke.Common/CI/ICIProvider.cs
@@ -1,0 +1,18 @@
+// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Linq;
+
+namespace Nuke.Common.CI
+{
+    public interface ICIProvider
+    {
+        
+    }
+}

--- a/source/Nuke.Common/Execution/BuildManager.cs
+++ b/source/Nuke.Common/Execution/BuildManager.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Nuke.Common.CI;
 using Nuke.Common.Tooling;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
@@ -32,6 +33,9 @@ namespace Nuke.Common.Execution
             Console.CancelKeyPress += (s, e) => s_cancellationHandlers.ForEach(x => x());
 
             var build = Create<T>();
+            
+            build.ConfigureCI(new CIBuilder());
+            
             build.ExecutableTargets = ExecutableTargetFactory.CreateAll(build, defaultTargetExpressions);
 
             void ExecuteExtension<TExtension>(Action<TExtension> action)

--- a/source/Nuke.Common/NukeBuild.cs
+++ b/source/Nuke.Common/NukeBuild.cs
@@ -90,15 +90,15 @@ namespace Nuke.Common
         public IReadOnlyCollection<ExecutableTarget> ExecutingTargets => ExecutionPlan.Where(x => x.Status != ExecutionStatus.Skipped).ToList();
 
         protected internal virtual OutputSink OutputSink => Host switch
-            {
-                HostType.Bitrise => new BitriseOutputSink(),
-                HostType.Travis => new TravisCIOutputSink(),
-                HostType.TeamCity => new TeamCityOutputSink(new TeamCity()),
-                HostType.AzurePipelines => new AzurePipelinesOutputSink(new AzurePipelines()),
-                HostType.GitHubActions => new GitHubActionsOutputSink(new GitHubActions()),
-                HostType.AppVeyor => new AppVeyorOutputSink(new AppVeyor()),
-                _ => OutputSink.Default
-            };
+        {
+            HostType.Bitrise => new BitriseOutputSink(),
+            HostType.Travis => new TravisCIOutputSink(),
+            HostType.TeamCity => new TeamCityOutputSink(new TeamCity()),
+            HostType.AzurePipelines => new AzurePipelinesOutputSink(new AzurePipelines()),
+            HostType.GitHubActions => new GitHubActionsOutputSink(new GitHubActions()),
+            HostType.AppVeyor => new AppVeyorOutputSink(new AppVeyor()),
+            _ => OutputSink.Default
+        };
 
         [CanBeNull]
         protected internal virtual string NuGetPackagesConfigFile =>
@@ -116,5 +116,10 @@ namespace Nuke.Common
             .All(x => x.Status != ExecutionStatus.Failed &&
                       x.Status != ExecutionStatus.NotRun &&
                       x.Status != ExecutionStatus.Aborted);
+
+        public virtual void ConfigureCI(ICIBuilder builder)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
## Motivation

More customisation options and a more flexible approach to configuring continuous integration scripts would allow for specific usecases to be satisfied, such as declaring variable (and variable groups in the case of Azure Pipelines).

Although current attributes exist for each supported CI provider, we're limited to what we can parameterize.

Having a fluent API builder that would be invoked during startup of Nuke would allow for more flexibility. This PR aims at proposing the changes to allow for both attributes and fluent-based approaches.

## Specification

As part of `BuildManager`, we would invoke:

```cs
var build = Create<T>();
build.ConfigureCI(ICIBuilder builder);
```

```cs
interface ICIBuilder
{
	ICIBuilder Add<T>(Action<T> action) where T : ICIProvider
}
```

`ICIProvider` is a marker interfaces explicitly to label all valid types to be used in place of `T`, which would be implemented on:
- `AppVeyorAttribute`
- `GitHubActionsAttribute`
- `AzurePipelinesAttribute`
- `TeamCityAttribute`

Alternatively logic could be pulled out so that we do not leverage the existing attribute classes - but this would likely encourage a breaking change, but be more preferable.

```cs
public abstract partial class NukeBuild
{
    protected virtual void ConfigureCI(ICIBuilder builder);
}

public partial class Build : NukeBuild
{
    protected override void ConfigureCI(ICIBuilder builder)
    {
        builder.Add<GitHubActionsConfiguration>(x => x.OnPushBranches("master"));
    }
}
```

## Questions

- [ ] What's the desired outcome if both attributes AND fluent configuration are used? Merging likely?

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [x] Is in compliance with my employer