### PR TITLE
Linux - GitVersion.dll not found when is using the last version of GitVersion

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="GitVersion.Tool" Version="[5.1.1]" />
+    <PackageDownload Include="GitVersion.Tool" Version="[5.3.4]" />
     <PackageDownload Include="JetBrains.dotCover.CommandLineTools" Version="[2019.2.2]" />
     <PackageDownload Include="JetBrains.ReSharper.CommandLineTools" Version="[2019.2.1]" />
     <PackageDownload Include="OpenCover" Version="[4.7.922]" />

--- a/source/Nuke.Common/Tools/GitVersion/GitVersionTasks.cs
+++ b/source/Nuke.Common/Tools/GitVersion/GitVersionTasks.cs
@@ -28,7 +28,7 @@ namespace Nuke.Common.Tools.GitVersion
         {
             return ToolPathResolver.GetPackageExecutable(
                 packageId: "GitVersion.Tool|GitVersion.CommandLine",
-                packageExecutable: "GitVersion.dll|GitVersion.exe",
+                packageExecutable: "GitVersion.dll|GitVersion.exe|gitversion.dll",
                 framework: framework);
         }
 


### PR DESCRIPTION
In Linux, when is using the last version of GitVersion, the GitVersion.dll was rename to gitversion.dll. (Linux is case sensitive)

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer