### PR TITLE
Fix verbosity mapping for MSBuild/DotNet and add three new mappings

### DIFF
--- a/source/Nuke.Common/Tools/NUnit/NUnitTasks.cs
+++ b/source/Nuke.Common/Tools/NUnit/NUnitTasks.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using JetBrains.Annotations;
+using Nuke.Common.Tooling;
+
+namespace Nuke.Common.Tools.NUnit
+{
+    [PublicAPI]
+    public class NUnitVerbosityMappingAttribute : VerbosityMappingAttribute
+    {
+        public NUnitVerbosityMappingAttribute()
+            : base(typeof(NUnitTraceLevel))
+        {
+            Quiet = nameof(NUnitTraceLevel.Off);
+            Minimal = nameof(NUnitTraceLevel.Warning);
+            Normal = nameof(NUnitTraceLevel.Info);
+            Verbose = nameof(NUnitTraceLevel.Verbose);
+        }
+    }
+}

--- a/source/Nuke.Common/Tools/OpenCover/OpenCoverTasks.cs
+++ b/source/Nuke.Common/Tools/OpenCover/OpenCoverTasks.cs
@@ -1,13 +1,25 @@
-// Copyright 2019 Maintainers of NUKE.
+﻿// Copyright 2019 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
-using System;
-using System.Linq;
+using JetBrains.Annotations;
 using Nuke.Common.Tooling;
 
 namespace Nuke.Common.Tools.OpenCover
 {
+    [PublicAPI]
+    public class OpenCoverVerbosityMappingAttribute : VerbosityMappingAttribute
+    {
+        public OpenCoverVerbosityMappingAttribute()
+            : base(typeof(OpenCoverVerbosity))
+        {
+            Quiet = nameof(OpenCoverVerbosity.Off);
+            Minimal = nameof(OpenCoverVerbosity.Warn);
+            Normal = nameof(OpenCoverVerbosity.Info);
+            Verbose = nameof(OpenCoverVerbosity.Verbose);
+        }
+    }
+
     partial class OpenCoverSettingsExtensions
     {
         public static OpenCoverSettings SetTargetSettings(this OpenCoverSettings toolSettings, ToolSettings targetSettings)

--- a/source/Nuke.Common/Tools/ReportGenerator/ReportGeneratorTasks.cs
+++ b/source/Nuke.Common/Tools/ReportGenerator/ReportGeneratorTasks.cs
@@ -1,11 +1,25 @@
-// Copyright 2019 Maintainers of NUKE.
+﻿// Copyright 2019 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
+using JetBrains.Annotations;
 using Nuke.Common.Tooling;
 
 namespace Nuke.Common.Tools.ReportGenerator
 {
+    [PublicAPI]
+    public class ReportGeneratorVerbosityMappingAttribute : VerbosityMappingAttribute
+    {
+        public ReportGeneratorVerbosityMappingAttribute()
+            : base(typeof(ReportGeneratorVerbosity))
+        {
+            Quiet = nameof(ReportGeneratorVerbosity.Off);
+            Minimal = nameof(ReportGeneratorVerbosity.Warning);
+            Normal = nameof(ReportGeneratorVerbosity.Info);
+            Verbose = nameof(ReportGeneratorVerbosity.Verbose);
+        }
+    }
+
     partial class ReportGeneratorSettings
     {
         private string GetToolPath()


### PR DESCRIPTION
I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

1.  It looks that there was a bug in the default verbosity mapping attribute for MSBuild and DotNet tasks.
2. I added three more mappings for NUnit, OpenCover and RaportGenerator, 