### PR TITLE
Fix target invocation for overridden targets

### DIFF
--- a/source/Nuke.Common.Tests/Execution/DefaultInterfaceExecutionTest.cs
+++ b/source/Nuke.Common.Tests/Execution/DefaultInterfaceExecutionTest.cs
@@ -95,6 +95,17 @@ namespace Nuke.Common.Tests.Execution
             Assert.Throws<InvalidCastException>(() => ExecutableTargetFactory.CreateAll(build, x => x.E));
         }
 
+        [Fact]
+        public void TestDuplicateTargets()
+        {
+            var build = new DuplicateTargetTestBuild();
+            var targets = ExecutableTargetFactory.CreateAll(build);
+
+            targets.Count(x => x.Name == nameof(ITestBuild.Duplicate)).Should().Be(1);
+
+            // Otherwise ExecutionPlanner.GetExecutableTarget fails
+        }
+
         private interface IParameterInterface
         {
             [Parameter] string StringParameter => ValueInjectionUtility.TryGetValue(() => StringParameter);
@@ -130,6 +141,12 @@ namespace Nuke.Common.Tests.Execution
                 .Executes(() => { });
         }
 
+        private class DuplicateTargetTestBuild : NukeBuild, ITestBuild
+        {
+            public Target Duplicate => _ => _
+               .Executes(Action);
+        }
+
         private interface ITestBuild
         {
             public string Description => DefaultInterfaceExecutionTest.Description;
@@ -158,6 +175,9 @@ namespace Nuke.Common.Tests.Execution
                 .OnlyWhenDynamic(DynamicCondition)
                 .After(B)
                 .Before(C);
+
+            public Target Duplicate => _ => _
+               .Executes(Action);
         }
 
         private interface IInheritedTestBuild : ITestBuild

--- a/source/Nuke.Common/Execution/ExecutableTargetFactory.cs
+++ b/source/Nuke.Common/Execution/ExecutableTargetFactory.cs
@@ -98,7 +98,9 @@ namespace Nuke.Common.Execution
 
             return classProperties
                 .Concat(interfaceProperties)
-                .Where(x => x.PropertyType == typeof(Target)).ToList();
+                .Where(x => x.PropertyType == typeof(Target))
+                .Distinct(x => x.Name)
+                .ToList();
         }
     }
 }


### PR DESCRIPTION
When a build class overrides a target from an interface, executing the target via its name (command line) fails.

```csharp
        private interface ITestBuild
        {
            public Target Duplicate => _ => _
               .Executes(Action);
        }
        private class DuplicateTargetTestBuild : NukeBuild, ITestBuild
        {
            public Target Duplicate => _ => _
               .Executes(Action);
        }
```

Command `nuke duplicate` fails. This PR fixes it.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer