### PR TITLE
Resolves an issue where npm task would log warnings as errors

### DIFF
--- a/source/Nuke.Common/Tools/Npm/NpmTasks.cs
+++ b/source/Nuke.Common/Tools/Npm/NpmTasks.cs
@@ -1,4 +1,4 @@
-// Copyright 2020 Maintainers of NUKE.
+﻿// Copyright 2020 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -17,7 +17,7 @@ namespace Nuke.Common.Tools.Npm
                     break;
                 case OutputType.Err:
                 {
-                    if (output.StartsWith("npmWARN"))
+                    if (output.StartsWith("npmWARN") || output.StartsWith("npm WARN"))
                         Logger.Warn(output);
                     else
                         Logger.Error(output);


### PR DESCRIPTION
NPM outputs warnings to the error stream, some build systems fail because they assume there was build errors.

A custom logger was implemented in #419 but it checks for "npmWARN" instead of the current "npm WARN" (note the space). I am not sure if that was originally a typo or if it changed at some NPM version. This PR should handle both cases.

This re resolves #421 and was also discussed briefly on slack.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer