### PR TITLE
Remove unused variable introduced by refactoring

### DIFF
--- a/source/Nuke.GlobalTool/Program.Complete.cs
+++ b/source/Nuke.GlobalTool/Program.Complete.cs
@@ -37,7 +37,6 @@ namespace Nuke.GlobalTool
                 return 1;
             }
 
-            var position = EnvironmentInfo.GetParameter<int?>("position");
             var completionItems = SerializationTasks.YamlDeserializeFromFile<Dictionary<string, string[]>>(completionFile);
             foreach (var item in CompletionUtility.GetRelevantCompletionItems(words, completionItems))
                 Console.WriteLine(item);


### PR DESCRIPTION
Hello!

I've noticed that in commit https://github.com/nuke-build/nuke/commit/4b058e29d6125a9318a5348cd4f03edd7e25ca83 "position" variable is no longer required and can be easily removed (it doesn't look like have any significant side effects).
It looks like that warning was produced by automatic refactoring in IDE.

I'm not sure about is that change requires initial discussion, so decide to send that one-line change as is.

It will be nice to improve code quality a little bit.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer