### PR TITLE
Add Teams tasks

### DIFF
--- a/build/specifications/Teams.json
+++ b/build/specifications/Teams.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/nuke-build/nuke/master/source/Nuke.CodeGeneration/schema.json",
+  "references": [
+    "https://docs.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#office-365-connector-card",
+    "https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook"
+  ],
+  "name": "Teams",
+  "officialUrl": "https://www.microsoft.com/en-us/microsoft-365/microsoft-teams/group-chat-software",
+  "help": "Microsoft Teams is a proprietary business communication platform developed by Microsoft, as part of the Microsoft 365 family of products. Teams offers workspace chat and videoconferencing, file storage, and application integration. Teams is replacing other Microsoft-operated business messaging and collaboration platforms, including Skype for Business and Microsoft Classroom.",
+  "dataClasses": [
+    {
+      "name": "TeamsMessage",
+      "extensionMethods": true,
+      "properties": [
+        {
+          "name": "Title",
+          "type": "string",
+          "json": "title"
+        },
+        {
+          "name": "Text",
+          "type": "string",
+          "json": "text"
+        },
+        {
+          "name": "ThemeColor",
+          "type": "string",
+          "json": "themeColor"
+        }
+      ]
+    }
+  ]
+}

--- a/source/Nuke.Common/Tools/Teams/Teams.Extensions.cs
+++ b/source/Nuke.Common/Tools/Teams/Teams.Extensions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Nuke.Common.Tools.Teams
+{
+    public partial class TeamsMessage
+    {
+        [JsonProperty("@type")]
+        internal string Type => "MessageCard";
+        [JsonProperty("@context")]
+        internal string Context => "http://schema.org/extensions";
+    }
+}

--- a/source/Nuke.Common/Tools/Teams/Teams.Generated.cs
+++ b/source/Nuke.Common/Tools/Teams/Teams.Generated.cs
@@ -1,0 +1,114 @@
+// Generated from https://github.com/VolkmarR/nuke/blob/master/build/specifications/Teams.json
+
+using JetBrains.Annotations;
+using Newtonsoft.Json;
+using Nuke.Common;
+using Nuke.Common.Execution;
+using Nuke.Common.Tooling;
+using Nuke.Common.Tools;
+using Nuke.Common.Utilities.Collections;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Nuke.Common.Tools.Teams
+{
+    #region TeamsMessage
+    /// <summary>
+    ///   Used within <see cref="TeamsTasks"/>.
+    /// </summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public partial class TeamsMessage : ISettingsEntity
+    {
+        [JsonProperty("title")]
+        public virtual string Title { get; internal set; }
+        [JsonProperty("text")]
+        public virtual string Text { get; internal set; }
+        [JsonProperty("themeColor")]
+        public virtual string ThemeColor { get; internal set; }
+    }
+    #endregion
+    #region TeamsMessageExtensions
+    /// <summary>
+    ///   Used within <see cref="TeamsTasks"/>.
+    /// </summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    public static partial class TeamsMessageExtensions
+    {
+        #region Title
+        /// <summary>
+        ///   <p><em>Sets <see cref="TeamsMessage.Title"/></em></p>
+        /// </summary>
+        [Pure]
+        public static T SetTitle<T>(this T toolSettings, string title) where T : TeamsMessage
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Title = title;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="TeamsMessage.Title"/></em></p>
+        /// </summary>
+        [Pure]
+        public static T ResetTitle<T>(this T toolSettings) where T : TeamsMessage
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Title = null;
+            return toolSettings;
+        }
+        #endregion
+        #region Text
+        /// <summary>
+        ///   <p><em>Sets <see cref="TeamsMessage.Text"/></em></p>
+        /// </summary>
+        [Pure]
+        public static T SetText<T>(this T toolSettings, string text) where T : TeamsMessage
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Text = text;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="TeamsMessage.Text"/></em></p>
+        /// </summary>
+        [Pure]
+        public static T ResetText<T>(this T toolSettings) where T : TeamsMessage
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Text = null;
+            return toolSettings;
+        }
+        #endregion
+        #region ThemeColor
+        /// <summary>
+        ///   <p><em>Sets <see cref="TeamsMessage.ThemeColor"/></em></p>
+        /// </summary>
+        [Pure]
+        public static T SetThemeColor<T>(this T toolSettings, string themeColor) where T : TeamsMessage
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ThemeColor = themeColor;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="TeamsMessage.ThemeColor"/></em></p>
+        /// </summary>
+        [Pure]
+        public static T ResetThemeColor<T>(this T toolSettings) where T : TeamsMessage
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.ThemeColor = null;
+            return toolSettings;
+        }
+        #endregion
+    }
+    #endregion
+}

--- a/source/Nuke.Common/Tools/Teams/TeamsTasks.cs
+++ b/source/Nuke.Common/Tools/Teams/TeamsTasks.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Newtonsoft.Json;
+using Nuke.Common.Tooling;
+
+namespace Nuke.Common.Tools.Teams
+{
+    [PublicAPI]
+    public static class TeamsTasks
+    {
+        public static void SendTeamsMessage(Configure<TeamsMessage> configurator, string webhook)
+        {
+            SendTeamsMessageAsync(configurator, webhook).Wait();
+        }
+
+        public static async Task SendTeamsMessageAsync(Configure<TeamsMessage> configurator, string webhook)
+        {
+            var message = configurator(new TeamsMessage());
+            var messageJson = JsonConvert.SerializeObject(message);
+
+            using var client = new WebClient();
+
+            client.Headers["Content-Type"] = "application/json";
+
+            var response = await client.UploadDataTaskAsync(webhook, "POST", Encoding.UTF8.GetBytes(messageJson) );
+            var responseText = Encoding.UTF8.GetString(response);
+            ControlFlow.Assert(responseText == "1", $"'{responseText}' == '1'");
+        }
+    }
+}


### PR DESCRIPTION
Added SendTeamsMessage method. The current version of the TeamsMessage is limited to *Title*, *Text* and *ThemeColor*. This allows to create messages in teams like this example

![image](https://user-images.githubusercontent.com/9860916/95136450-6bb4c600-0766-11eb-866a-3584014c0444.png)

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

Resolves #252 