### PR TITLE
Handle Case Sensitive Tool Caches for "PackAsTool"

### DIFF
--- a/source/Nuke.MSBuildTasks/PackPackageToolsTask.cs
+++ b/source/Nuke.MSBuildTasks/PackPackageToolsTask.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Nuke.Common;
 using Nuke.Common.Tooling;
 using static Nuke.Common.IO.PathConstruction;
 
@@ -38,11 +39,11 @@ namespace Nuke.MSBuildTasks
 
         private IEnumerable<ITaskItem> GetFiles(string packageId, string packageVersion)
         {
-            var packageToolsPath = Path.Combine(NuGetPackageRoot, packageId, packageVersion, "tools");
-            if (!Directory.Exists(packageToolsPath))
+            var packageToolsDirectory =  Path.Combine(NuGetPackageRoot, packageId.ToLowerInvariant(), packageVersion.ToLowerInvariant(), "tools");
+            if (!Directory.Exists(packageToolsDirectory))
                 yield break;
 
-            foreach (var file in Directory.GetFiles(packageToolsPath, "*", SearchOption.AllDirectories))
+            foreach (var file in Directory.GetFiles(packageToolsDirectory, "*", SearchOption.AllDirectories))
             {
                 var taskItem = new TaskItem(file);
                 taskItem.SetMetadata("BuildAction", "None");
@@ -52,7 +53,7 @@ namespace Nuke.MSBuildTasks
                         TargetFramework,
                         "any",
                         packageId,
-                        GetRelativePath(packageToolsPath, file)));
+                        GetRelativePath(packageToolsDirectory, file)));
                 yield return taskItem;
             }
         }


### PR DESCRIPTION
I made an attempt a few months back to get our nuke build packaged
up as a global tool. I couldn't ever get the auto-packing of `tools/`
dependencies to work. In the end I think I've tracked it down to the
package cache casing. on macOS and Linux packages are cached in
`~/.nuget/packages/`. Packages under that folder are all lower cased.

For macOS the pack code works _fine_ as the file system is case
insensitive, case preserving like Windows. On linux however I suspect
the `Directory.Exists` check is failing as the `packageId` is the `NuGet`
(Pascal) cased variant of the package name, not the lower cased one.

Still WIP as I've not managed to confirm this works outside a _super_
hacky POC. C&C welcome on _exactly_ how to deal with this casing
issue.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer