### PR TITLE
Use DeleteDirectoryInternal instead of Directory.Delete

### DIFF
--- a/source/Nuke.Common/IO/FileSystemTasks.cs
+++ b/source/Nuke.Common/IO/FileSystemTasks.cs
@@ -177,7 +177,8 @@ namespace Nuke.Common.IO
             string source,
             string target,
             DirectoryExistsPolicy directoryPolicy = DirectoryExistsPolicy.Fail,
-            FileExistsPolicy filePolicy = FileExistsPolicy.Fail)
+            FileExistsPolicy filePolicy = FileExistsPolicy.Fail,
+            bool deleteRemainingFiles = false)
         {
             ControlFlow.Assert(!Directory.Exists(target) || directoryPolicy != DirectoryExistsPolicy.Fail,
                 $"!Directory.Exists({target}) || policy != DirectoryExistsPolicy.Fail");
@@ -191,7 +192,9 @@ namespace Nuke.Common.IO
             {
                 Directory.GetDirectories(source).ForEach(x => MoveDirectoryToDirectory(x, target, directoryPolicy, filePolicy));
                 Directory.GetFiles(source).ForEach(x => MoveFileToDirectory(x, target, filePolicy));
-                Directory.Delete(source);
+
+                if (!new DirectoryInfo(source).EnumerateFileSystemInfos().Any() || deleteRemainingFiles)
+                    DeleteDirectoryInternal(source);
             }
         }
 


### PR DESCRIPTION
Directory.Delete throws if the directory is not empty, which happens if FileExistsPolicy.Skip or FileExistsPolicy.OverwriteIfNewer is used.

fixes #587

