### PR TITLE
Add cover-dotnet to DotCover specification

### DIFF
--- a/build/specifications/DotCover.json
+++ b/build/specifications/DotCover.json
@@ -16,15 +16,15 @@
       "settingsClass": {
         "properties": [
           {
+            "name": "Configuration",
+            "type": "string",
+            "format": "{value}"
+          },
+          {
             "name": "TargetExecutable",
             "type": "string",
             "format": "--TargetExecutable={value}",
             "help": "File name of the program to analyse."
-          },
-          {
-            "name": "Configuration",
-            "type": "string",
-            "format": "{value}"
           },
           {
             "name": "ReportType",
@@ -56,15 +56,15 @@
       "settingsClass": {
         "properties": [
           {
+            "name": "Configuration",
+            "type": "string",
+            "format": "{value}"
+          },
+          {
             "name": "TargetExecutable",
             "type": "string",
             "format": "--TargetExecutable={value}",
             "help": "File name of the program to analyse."
-          },
-          {
-            "name": "Configuration",
-            "type": "string",
-            "format": "{value}"
           },
           {
             "name": "OutputFile",

--- a/build/specifications/DotCover.json
+++ b/build/specifications/DotCover.json
@@ -16,6 +16,12 @@
       "settingsClass": {
         "properties": [
           {
+            "name": "TargetExecutable",
+            "type": "string",
+            "format": "--TargetExecutable={value}",
+            "help": "File name of the program to analyse."
+          },
+          {
             "name": "Configuration",
             "type": "string",
             "format": "{value}"
@@ -47,6 +53,40 @@
         "analyse-cover"
       ],
       "definiteArgument": "cover",
+      "settingsClass": {
+        "properties": [
+          {
+            "name": "TargetExecutable",
+            "type": "string",
+            "format": "--TargetExecutable={value}",
+            "help": "File name of the program to analyse."
+          },
+          {
+            "name": "Configuration",
+            "type": "string",
+            "format": "{value}"
+          },
+          {
+            "name": "OutputFile",
+            "type": "string",
+            "format": "--Output={value}",
+            "help": "Path to the resulting coverage snapshot."
+          },
+          {
+            "name": "ReportType",
+            "type": "DotCoverReportType",
+            "format": "--ReportType={value}",
+            "help": "A type of the report. The default value is <c>XML</c>."
+          }
+        ]
+      }
+    },
+    {
+      "postfix": "CoverDotNet",
+      "commonPropertySets": [
+        "analyse-cover"
+      ],
+      "definiteArgument": "dotnet",
       "settingsClass": {
         "properties": [
           {
@@ -195,12 +235,6 @@
   ],
   "commonTaskPropertySets": {
     "analyse-cover": [
-      {
-        "name": "TargetExecutable",
-        "type": "string",
-        "format": "--TargetExecutable={value}",
-        "help": "File name of the program to analyse."
-      },
       {
         "name": "TargetArguments",
         "type": "string",


### PR DESCRIPTION
The changes will add support for running .NET Core unit tests with dotnet cli ([JetBrains documentation](https://www.jetbrains.com/help/dotcover/Running_Coverage_Analysis_from_the_Command_LIne.html#basic-scenario-for-net-core)). I have checked all arguments in `commonTaskPropertySets` and had to move `TargetExecutable` out because the new `dotnet` is directly wired to dotnet cli and therefor does not support `TargetExecutable`.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer