### PR TITLE
Fix PowerShell build script path in build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -4,4 +4,4 @@
 :; exit $?
 
 @ECHO OFF
-powershell -ExecutionPolicy ByPass -NoProfile %~dp0build.ps1 %*
+powershell -ExecutionPolicy ByPass -NoProfile "%~dp0build.ps1" %*

--- a/build.cmd
+++ b/build.cmd
@@ -4,4 +4,4 @@
 :; exit $?
 
 @ECHO OFF
-powershell -ExecutionPolicy ByPass -NoProfile %0\..\build.ps1 %*
+powershell -ExecutionPolicy ByPass -NoProfile %~dp0build.ps1 %*

--- a/build/Build.ReleaseImage.cs
+++ b/build/Build.ReleaseImage.cs
@@ -88,7 +88,7 @@ partial class Build
                     location: new PointF(image.Width / 2f, image.Height / 2f - 100),
                     options: graphicsOptions)
                 .DrawText(
-                    text: "0.24.0",
+                    text: GitVersion.NuGetVersionV2,
                     font: robotoFont.CreateFont(150),
                     color: Color.WhiteSmoke,
                     location: new PointF(image.Width / 2f, image.Height / 2f),

--- a/source/Nuke.GlobalTool/templates/build.cmd
+++ b/source/Nuke.GlobalTool/templates/build.cmd
@@ -4,4 +4,4 @@
 :; exit $?
 
 @ECHO OFF
-powershell -ExecutionPolicy ByPass -NoProfile %0\..\build.ps1 %*
+powershell -ExecutionPolicy ByPass -NoProfile "%~dp0build.ps1" %*


### PR DESCRIPTION
`build.cmd` builds an invalid path to `build.ps1`.

Suppose this repo has been locally cloned to `A:\nuke`. Running `build.cmd` will run PowerShell with the following command line:

    powershell -ExecutionPolicy ByPass -NoProfile "A:\nuke\build.cmd"\..\build.ps1

The are two problems:

1. `%0` expands to the file name of the running batch, not its path.
2. `build.ps1` is in the same directory as `build.cmd` and not in the parent (ie `..`).

This PR fixes both problems (and uses proper quoting) such that PowerShell gets executed as follows:

    powershell -ExecutionPolicy ByPass -NoProfile A:\nuke\build.ps1

---
I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer