### PR TITLE
[Tool] Add CodeMetrics specification

### DIFF
--- a/build/specifications/CodeMetrics.json
+++ b/build/specifications/CodeMetrics.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://raw.githubusercontent.com/nuke-build/nuke/master/source/Nuke.CodeGeneration/schema.json",
+  "references": [
+    "https://github.com/dotnet/roslyn-analyzers/tree/master/src/Tools/Metrics",
+    "https://docs.microsoft.com/en-us/visualstudio/code-quality/code-metrics-values"
+  ],
+  "name": "CodeMetrics",
+  "officialUrl": "https://www.nuget.org/packages/Microsoft.CodeAnalysis.Metrics/",
+  "help": "Code metrics is a set of software measures that provide developers better insight into the code they are developing. By taking advantage of code metrics, developers can understand which types and/or methods should be reworked or more thoroughly tested. Development teams can identify potential risks, understand the current state of a project, and track progress during software development.",
+  "packageId": "Microsoft.CodeAnalysis.Metrics",
+  "packageExecutable": "Metrics.exe",
+  "tasks": [
+    {
+      "settingsClass": {
+        "properties": [
+          {
+            "name": "Project",
+            "type": "string",
+            "format": "/project:{value}",
+            "help": "Project to analyze."
+          },
+          {
+            "name": "Solution",
+            "type": "string",
+            "format": "/solution:{value}",
+            "help": "Solution to analyze."
+          },
+          {
+            "name": "OutputFile",
+            "type": "string",
+            "format": "/out:{value}",
+            "help": "Metrics results XML output file."
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adding the specification for Microsoft's CodeMetrics tool. I'm not sure if I set the references and the officialUrl as you originally intended.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer