### PR TITLE
Fix NullReferenceException in CreateGitHubMilestone

### DIFF
--- a/source/Nuke.Common/Tools/GitHub/GitHubTasks.cs
+++ b/source/Nuke.Common/Tools/GitHub/GitHubTasks.cs
@@ -93,7 +93,7 @@ namespace Nuke.Common.Tools.GitHub
         {
             ControlFlow.Assert(repository.IsGitHubRepository(), text: "repository.IsGitHubRepository()");
 
-            await GitHubClient.Issue.Milestone.Create(
+            await Client.Issue.Milestone.Create(
                 repository.GetGitHubOwner(),
                 repository.GetGitHubName(),
                 new NewMilestone(title));
@@ -111,7 +111,7 @@ namespace Nuke.Common.Tools.GitHub
                 ControlFlow.Assert(milestone.ClosedIssues != 0, "milestone.ClosedIssues != 0");
             }
 
-            await GitHubClient.Issue.Milestone.Update(
+            await Client.Issue.Milestone.Update(
                 repository.GetGitHubOwner(),
                 repository.GetGitHubName(),
                 milestone.Number,


### PR DESCRIPTION
`CreateGitHubMilestone` and `CloseGitHubMilestone` both use `GitHubClient` directly which can be uninitialized.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer