### PR TITLE
Fix for #650 (Generated build project for legacy solution not working)

### DIFF
--- a/source/Nuke.Common/Utilities/TemplateUtility.cs
+++ b/source/Nuke.Common/Utilities/TemplateUtility.cs
@@ -178,7 +178,7 @@ namespace Nuke.Common.Utilities
 
         private static string Replace(this string str, [CanBeNull] IReadOnlyDictionary<string, string> tokens)
         {
-            return tokens?.Aggregate(str, (t, r) => t.Replace($"_{r.Key}_", r.Value));
+            return tokens?.OrderByDescending(x => x.Key.Length).Aggregate(str, (t, r) => t.Replace($"_{r.Key}_", r.Value));
         }
     }
 }

--- a/source/Nuke.GlobalTool/templates/_build.legacy.csproj
+++ b/source/Nuke.GlobalTool/templates/_build.legacy.csproj
@@ -117,6 +117,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Build.cs" />
+    <Compile Include="Configuration.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
- Add missing Configuration.cs to csproj
- Adjust target framework version to 4.7.2
- Wrong token replacement when one token name is the prefix of another token (e.g. _NUKE_VERSION_ vs. _NUKE_VERSION_MAJOR_MINOR_) -> fixed by replacing longer tokens first

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

Fixes #650 