### PR TITLE
Issue 656 - Fixed IsDescendantPath issue with folders with similar names

### DIFF
--- a/source/Nuke.Common.Tests/PathConstructionTest.cs
+++ b/source/Nuke.Common.Tests/PathConstructionTest.cs
@@ -45,8 +45,12 @@ namespace Nuke.Common.Tests
         }
 
         [Theory]
-        [InlineData("C:\\A\\B\\C", "C:\\A\\B", false)]
+        [InlineData("C:\\A\\B", "C:\\A\\B\\C", true)]
         [InlineData("C:\\A\\B", "C:\\A\\B\\C\\", true)]
+        [InlineData("C:\\A\\B", "C:\\A", false)]
+        [InlineData("C:\\A\\B", "C:\\A\\C", false)]
+        [InlineData("C:\\A\\B\\C", "C:\\A\\B", false)]
+        [InlineData("C:\\A\\B\\C", "C:\\A\\B\\CD", false)]
         [InlineData("C:\\A\\B\\..\\C", "C:\\A\\B\\..\\C\\D", true)]
         [InlineData("/bin/etc", "/bin/etc/../etc/foo", true)]
         [InlineData("/bin/etc", "/bin/etc/../bar/foo", false)]

--- a/source/Nuke.Common/IO/PathConstruction.cs
+++ b/source/Nuke.Common/IO/PathConstruction.cs
@@ -118,7 +118,9 @@ namespace Nuke.Common.IO
         [Pure]
         public static bool IsDescendantPath(string basePath, string destinationPath)
         {
-            return NormalizePath(destinationPath).StartsWith(NormalizePath(basePath));
+            var destinationPathParts = NormalizePath(destinationPath).Split(s_allSeparators);
+            var basePathParts = NormalizePath(basePath).Split(s_allSeparators);
+            return destinationPathParts.SequenceStartsWith(basePathParts);
         }
 
         [Pure]

--- a/source/Nuke.Common/Utilities/Collections/Enumerable.Sequence.cs
+++ b/source/Nuke.Common/Utilities/Collections/Enumerable.Sequence.cs
@@ -1,0 +1,19 @@
+﻿// Copyright 2021 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nuke.Common.Utilities.Collections
+{
+    public static partial class EnumerableExtensions
+    {
+        public static bool SequenceStartsWith<T>(this IEnumerable<T> enumerable, IEnumerable<T> other, IEqualityComparer<T> comparer = null)
+        {
+            var enumerableList = enumerable as List<T> ?? enumerable.ToList();
+            var otherList = other as List<T> ?? other.ToList();
+            return enumerableList.Take(otherList.Count).SequenceEqual(otherList, comparer);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the issue described in issue 656.
I saw that in the repo you have created many extensions for Enumerables, and I liked the idea, so I created a new extension for checking if a sequence starts with another sequence. I took a lot of inspiration from [System.Linq SequenceEqual implementation](https://github.com/dotnet/corefx/blob/master/src/System.Linq/src/System/Linq/SequenceEqual.cs). Im also thinking of making a PR to System.Linq and see if they accept adding SequenceStartsWith to Linq.
I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer