### PR TITLE
Added Collection Parameters support for the teamcity generation

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=TeamCityAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=TeamCityAttribute.verified.txt
@@ -79,20 +79,6 @@ project {
             allowEmpty = true,
             display = ParameterDisplay.NORMAL)
         text (
-            "env.ListParam",
-            label = "ListParam",
-            description = "Test collections work as input",
-            value = "one two",
-            allowEmpty = true,
-            display = ParameterDisplay.NORMAL)
-        text (
-            "env.IEnumParam",
-            label = "IEnumParam",
-            description = "Test collections work as input",
-            value = "one two",
-            allowEmpty = true,
-            display = ParameterDisplay.NORMAL)
-        text (
             "env.ArrayParam",
             label = "ArrayParam",
             description = "Test collections work as input",

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=TeamCityAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=TeamCityAttribute.verified.txt
@@ -78,6 +78,29 @@ project {
             value = "",
             allowEmpty = true,
             display = ParameterDisplay.NORMAL)
+        text (
+            "env.ListParam",
+            label = "ListParam",
+            description = "Test collections work as input",
+            value = "one two",
+            allowEmpty = true,
+            display = ParameterDisplay.NORMAL)
+        text (
+            "env.IEnumParam",
+            label = "IEnumParam",
+            description = "Test collections work as input",
+            value = "one two",
+            allowEmpty = true,
+            display = ParameterDisplay.NORMAL)
+        text (
+            "env.ArrayParam",
+            label = "ArrayParam",
+            description = "Test collections work as input",
+            value = "one two",
+            allowMultiple = true,
+            valueSeparator = " ",
+            allowEmpty = true,
+            display = ParameterDisplay.NORMAL)
     }
 }
 object Restore : BuildType({

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -217,18 +217,6 @@ namespace Nuke.Common.Tests.CI
             public readonly string AzurePipelinesSystemAccessToken;
 
             [Parameter("Test collections work as input")]
-            public readonly List<string> ListParam = new()
-                                                     {
-                                                         "one", "two"
-                                                     };
-
-            [Parameter("Test collections work as input")]
-            public readonly IEnumerable<string> IEnumParam = new[]
-                                                             {
-                                                                 "one", "two"
-                                                             };
-
-            [Parameter("Test collections work as input")]
             public readonly string[] ArrayParam = new[]
                                                   {
                                                       "one", "two"

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -216,6 +216,24 @@ namespace Nuke.Common.Tests.CI
             [Parameter("Azure Pipelines System Access Token")]
             public readonly string AzurePipelinesSystemAccessToken;
 
+            [Parameter("Test collections work as input")]
+            public readonly List<string> ListParam = new()
+                                                     {
+                                                         "one", "two"
+                                                     };
+
+            [Parameter("Test collections work as input")]
+            public readonly IEnumerable<string> IEnumParam = new[]
+                                                             {
+                                                                 "one", "two"
+                                                             };
+
+            [Parameter("Test collections work as input")]
+            public readonly string[] ArrayParam = new[]
+                                                  {
+                                                      "one", "two"
+                                                  };
+
             public Target Publish => _ => _
                 .DependsOn(Clean, Test, Pack)
                 .Consumes(Pack)

--- a/source/Nuke.Common/CI/TeamCity/TeamCityAttribute.cs
+++ b/source/Nuke.Common/CI/TeamCity/TeamCityAttribute.cs
@@ -3,6 +3,7 @@
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -285,14 +286,20 @@ namespace Nuke.Common.CI.TeamCity
                     return TeamCityParameterType.Select;
                 return TeamCityParameterType.Text;
             }
-
+            
+            var defValue = defaultValue?.ToString();
+            if (defaultValue is IEnumerable<string> coll)
+            {
+                defValue = string.Join(" ", coll);
+            }
+            
             return new TeamCityConfigurationParameter
                    {
                        Name = member.Name,
                        Description = attribute.Description,
                        Options = valueSet?.ToDictionary(x => x.Item1, x => x.Item2),
                        Type = GetParameterType(),
-                       DefaultValue = defaultValue?.ToString(),
+                       DefaultValue = defValue,
                        Display = required ? TeamCityParameterDisplay.Prompt : TeamCityParameterDisplay.Normal,
                        AllowMultiple = member.GetMemberType().IsArray,
                        ValueSeparator = attribute.Separator ?? " "

--- a/source/Nuke.Common/CI/TeamCity/TeamCityAttribute.cs
+++ b/source/Nuke.Common/CI/TeamCity/TeamCityAttribute.cs
@@ -3,7 +3,6 @@
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -286,20 +285,14 @@ namespace Nuke.Common.CI.TeamCity
                     return TeamCityParameterType.Select;
                 return TeamCityParameterType.Text;
             }
-            
-            var defValue = defaultValue?.ToString();
-            if (defaultValue is IEnumerable<string> coll)
-            {
-                defValue = string.Join(" ", coll);
-            }
-            
+
             return new TeamCityConfigurationParameter
                    {
                        Name = member.Name,
                        Description = attribute.Description,
                        Options = valueSet?.ToDictionary(x => x.Item1, x => x.Item2),
                        Type = GetParameterType(),
-                       DefaultValue = defValue,
+                       DefaultValue = defaultValue is IEnumerable<string> coll ? string.Join(" ", coll) : defaultValue?.ToString(),
                        Display = required ? TeamCityParameterDisplay.Prompt : TeamCityParameterDisplay.Normal,
                        AllowMultiple = member.GetMemberType().IsArray,
                        ValueSeparator = attribute.Separator ?? " "


### PR DESCRIPTION
I confirm that the pull-request:

- [X ] Follows the contribution guidelines
- [X ] Is based on my own work
- [X ] Is in compliance with my employer