### PR TITLE
Fixes a typo in ReportGenerator FileFilters

### DIFF
--- a/build/specifications/ReportGenerator.json
+++ b/build/specifications/ReportGenerator.json
@@ -61,7 +61,7 @@
           {
             "name": "FileFilters",
             "type": "List<string>",
-            "format": "-classfilters:{value}",
+            "format": "-filefilters:{value}",
             "separator": ";",
             "help": "Optional list of files that should be included (+) or excluded (-) in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed. Default is +*."
           },

--- a/source/Nuke.Common/Tools/ReportGenerator/ReportGenerator.Generated.cs
+++ b/source/Nuke.Common/Tools/ReportGenerator/ReportGenerator.Generated.cs
@@ -187,7 +187,7 @@ namespace Nuke.Common.Tools.ReportGenerator
               .Add("-historydir:{value}", HistoryDirectory)
               .Add("-assemblyfilters:{value}", AssemblyFilters, separator: ';')
               .Add("-classfilters:{value}", ClassFilters, separator: ';')
-              .Add("-classfilters:{value}", FileFilters, separator: ';')
+              .Add("-filefilters:{value}", FileFilters, separator: ';')
               .Add("-tag:{value}", Tag)
               .Add("-verbosity:{value}", Verbosity);
             return base.ConfigureProcessArguments(arguments);


### PR DESCRIPTION
Fixes a typo in ReportGenerator FileFilters which was outputing `-classfilters` insteand of `-filefilters`

Closes #664 

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer