### PR TITLE
Add "dotnet tool restore" to specification of dotnet task

### DIFF
--- a/build/specifications/DotNet.json
+++ b/build/specifications/DotNet.json
@@ -743,12 +743,6 @@
             "help": "Adds an additional NuGet package source to use during installation."
           },
           {
-            "name": "PackageName",
-            "type": "string",
-            "format": "{value}",
-            "help": "The Name/ID of the NuGet package that contains the .NET Core Global Tool to install."
-          },
-          {
             "name": "ToolManifest",
             "type": "string",
             "format": "--tool-manifest {value}",

--- a/build/specifications/DotNet.json
+++ b/build/specifications/DotNet.json
@@ -724,6 +724,64 @@
       }
     },
     {
+      "help": "The <c>dotnet tool restore</c> command finds the tool manifest file that is in scope for the current directory and installs the tools that are listed in it.",
+      "postfix": "ToolRestore",
+      "omitCommonProperties": true,
+      "definiteArgument": "tool restore",
+      "settingsClass": {
+        "properties": [
+          {
+            "name": "ConfigFile",
+            "type": "string",
+            "format": "--configfile {value}",
+            "help": "Specifies the NuGet configuration (<em>nuget.config</em>) file to use."
+          },
+          {
+            "name": "Sources",
+            "type": "List<string>",
+            "format": "--add-source {value}",
+            "help": "Adds an additional NuGet package source to use during installation."
+          },
+          {
+            "name": "PackageName",
+            "type": "string",
+            "format": "{value}",
+            "help": "The Name/ID of the NuGet package that contains the .NET Core Global Tool to install."
+          },
+          {
+            "name": "ToolManifest",
+            "type": "string",
+            "format": "--tool-manifest {value}",
+            "help": "Path to the manifest file."
+          },
+          {
+            "name": "DisableParallel",
+            "type": "bool",
+            "format": "--disable-parallel",
+            "help": "Prevent restoring multiple projects in parallel."
+          },
+          {
+            "name": "IgnoreFailedSources",
+            "type": "bool",
+            "format": "--ignore-failed-sources",
+            "help": "Treat package source failures as warnings."
+          },
+          {
+            "name": "NoCache",
+            "type": "bool",
+            "format": "--no-cache",
+            "help": "Do not cache packages and http requests."
+          },
+          {
+            "name": "Interactive",
+            "type": "bool",
+            "format": "--interactive",
+            "help": "Allows the command to stop and wait for user input or action (for example to complete authentication)."
+          }
+        ]
+      }
+    },
+    {
       "help": "The <c>dotnet tool uninstall</c> command provides a way for you to uninstall .NET Core Global Tools from your machine. To use the command, you either have to specify that you want to remove a user-wide tool using the <c>--global</c> option or specify a path to where the tool is installed using the <c>--tool-path</c> option.",
       "postfix": "ToolUninstall",
       "omitCommonProperties": true,


### PR DESCRIPTION
This adds support for the "dotnet tool restore" command to the specification. Useful when working with tool manifests, especially in combination with CI.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer