### PR TITLE
CorFlags CLI tool

### DIFF
--- a/build/specifications/CorFlags.json
+++ b/build/specifications/CorFlags.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://raw.githubusercontent.com/nuke-build/nuke/master/source/Nuke.CodeGeneration/schema.json",
+  "name": "CorFlags",
+  "officialUrl": "https://docs.microsoft.com/en-us/dotnet/framework/tools/corflags-exe-corflags-conversion-tool",
+  "help": "The CorFlags Conversion tool allows you to configure the CorFlags section of the header of a portable executable image.",
+  "pathExecutable": "CorFlags.exe",
+  "tasks": [
+    {
+      "help": "The CorFlags Conversion tool allows you to configure the CorFlags section of the header of a portable executable image.",
+      "settingsClass": {
+        "properties": [
+          {
+            "name": "NoLogo",
+            "type": "bool",
+            "format": "-nologo",
+            "help": "Suppresses the Microsoft startup banner display."
+          },
+          {
+            "name": "UpgradeCLRHeader",
+            "type": "bool",
+            "format": "-UpgradeCLRHeader",
+            "help": "Upgrades the CLR header version to 2.5. <em>Note</em>: Assemblies must have a CLR header version of 2.5 or greater to run natively."
+          },
+          {
+            "name": "RevertCLRHeader",
+            "type": "bool",
+            "format": "-RevertCLRHeader",
+            "help": "Reverts the CLR header version to 2.0."
+          },
+          {
+            "name": "Force",
+            "type": "bool",
+            "format": "-Force",
+            "help": "Forces an update even if the assembly is strong-named. <em>Important</em>: If you update a strong-named assembly, you must sign it again before executing its code."
+          },
+          {
+            "name": "Assembly",
+            "type": "string",
+            "format": "{value}",
+            "help": "The name of the assembly for which to configure the CorFlags."
+          },
+          {
+            "name": "ILOnly",
+            "type": "bool",
+            "format": "-ILONLY{value}",
+            "customValue": true,
+            "help": "Sets/clears the ILONLY flag."
+          },
+          {
+            "name": "Requires32Bit",
+            "type": "bool",
+            "format": "-32BIT{value}",
+            "customValue": true,
+            "help": "Sets/clears the 32BITREQUIRED flag."
+          },
+          {
+            "name": "Prefers32Bit",
+            "type": "bool",
+            "format": "-32BITPREF{value}",
+            "customValue": true,
+            "help": "Sets/clears the 32BITPREFERRED flag."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/source/Nuke.Common/Tools/CorFlags/CorFlagsSettings.cs
+++ b/source/Nuke.Common/Tools/CorFlags/CorFlagsSettings.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Nuke.Common.Tools.CorFlags
+{
+    partial class CorFlagsSettings
+    {
+        private string GetILOnly()
+        {
+            return ToPlusMinus(ILOnly);
+        }
+
+        private string GetRequires32Bit()
+        {
+            return ToPlusMinus(Requires32Bit);
+        }
+
+        private string GetPrefers32Bit()
+        {
+            return ToPlusMinus(Prefers32Bit);
+        }
+
+        private string ToPlusMinus(bool? value)
+        {
+            return value switch
+            {
+                true => "+",
+                false => "-",
+                null => null
+            };
+        }
+    }
+}


### PR DESCRIPTION
CorFlags CLI tool integration.

I named the 32bit flags according to [` System.Reflection.PortableExecutable.CorFlags`](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.portableexecutable.corflags?view=net-5.0), since their "natural" name (e.g. `32BitPref`) doesn't work in NUKE, because the name is not valid in the generated C# code.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer