### PR TITLE
Fix SwitchWorkingDirectory for allowCreate=false

### DIFF
--- a/source/Nuke.Common/EnvironmentInfo.Others.cs
+++ b/source/Nuke.Common/EnvironmentInfo.Others.cs
@@ -33,7 +33,7 @@ namespace Nuke.Common
 
         public static IDisposable SwitchWorkingDirectory(string workingDirectory, bool allowCreate = true)
         {
-            if (!Directory.Exists(workingDirectory))
+            if (allowCreate)
                 FileSystemTasks.EnsureExistingDirectory(workingDirectory);
 
             var previousWorkingDirectory = WorkingDirectory;


### PR DESCRIPTION
Currently `SwitchWorkingDirectory` ignores the `allowCreate` parameter.

The following PR
- invokes `EnsureExistingDirectory` for `allowCreate=true`
- checks the existence of the new working directory via `ControlFlow.Assert`.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer