### PR TITLE
Fix GetBranches condition

### DIFF
--- a/source/Nuke.Common/CI/AppVeyor/AppVeyorAttribute.cs
+++ b/source/Nuke.Common/CI/AppVeyor/AppVeyorAttribute.cs
@@ -87,7 +87,7 @@ namespace Nuke.Common.CI.AppVeyor
 
         protected AppVeyorBranches GetBranches()
         {
-            if (BranchesOnly.Length == 0 || BranchesExcept.Length == 0)
+            if (BranchesOnly.Length == 0 && BranchesExcept.Length == 0)
                 return null;
 
             return new AppVeyorBranches


### PR DESCRIPTION
Fixes minor logic bug. Up until now no `branches:` fragment is generated when only `BranchesOnly` or `BranchesExcept` is specified.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
