### PR TITLE
Guard against IndexOutOfRange exception if change log is empty

### DIFF
--- a/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
+++ b/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
@@ -193,6 +193,9 @@ namespace Nuke.Common.ChangeLog
                     .TrimEnd(']');
 
             var index = content.FindIndex(IsReleaseHead);
+            if (index < 0)
+                yield break;
+
             while (index < content.Count)
             {
                 var line = content[index];


### PR DESCRIPTION
<!--

Force-pushes may happen on develop branch (due to the nature of testing CI features). You can rebase and drop commits that do not belong to you. Otherwise, we will drop them manually when merging. Do NOT merge develop into your branch at any time!
    
-->
List.FindIndex returns -1 if not found. This throws an exception. I added a termination condition if the change log is empty.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
