### PR TITLE
Updated custom logger to handle errors and warnings from both angular and npm

### DIFF
--- a/build/Build.Enterprise.Enable.cs
+++ b/build/Build.Enterprise.Enable.cs
@@ -21,9 +21,9 @@ partial class Build
 {
     [Parameter] readonly string EnterpriseAccessToken;
 
-    public class RestartWithEnterpriseAttribute : BuildExtensionAttributeBase, IOnBeforeLogo
+    public class RestartWithEnterpriseAttribute : BuildExtensionAttributeBase, IOnBuildCreated
     {
-        public void OnBeforeLogo(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
+        public void OnBuildCreated(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
         {
             var accessToken = EnvironmentInfo.GetParameter<string>(nameof(EnterpriseAccessToken));
             var enterpriseDirectory = ((Build) build).ExternalRepositoriesDirectory / "enterprise";

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -37,9 +37,7 @@
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0008" />
     <PackageDownload Include="Codecov.Tool" Version="[1.12.3]" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.6.0]" />
-    <PackageDownload Include="JetBrains.dotCover.CommandLineTools" Version="[2020.1.3]" />
     <PackageDownload Include="JetBrains.ReSharper.GlobalTools" Version="[2020.3.2]" />
-    <PackageDownload Include="OpenCover" Version="[4.7.922]" />
     <PackageDownload Include="ReportGenerator" Version="[4.6.1]" />
     <PackageDownload Include="xunit.runner.console" Version="[2.4.1]" />
   </ItemGroup>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
 
   <!-- Import Nuke.Enterprise -->
-  <PropertyGroup Condition="Exists('..\external\enterprise\Nuke.Enterprise.csproj')">
+  <PropertyGroup Condition="Exists('..\external\enterprise\.gitignore')">
     <DefineConstants>$(DefineConstants);ENTERPRISE</DefineConstants>
     <NukeEnterprise>True</NukeEnterprise>
     <AppendTargetFrameworkToOutputPath>True</AppendTargetFrameworkToOutputPath>

--- a/build/specifications/SignTool.json
+++ b/build/specifications/SignTool.json
@@ -82,7 +82,7 @@
           },
           {
             "name": "FileDigestAlgorithm",
-            "type": "string",
+            "type": "SignToolDigestAlgorithm",
             "format": "/fd {value}",
             "help": "Specifies the file digest algorithm to use for creating file signatures. (Default is <c>SHA1</c>)"
           },
@@ -150,7 +150,7 @@
           },
           {
             "name": "TimestampServerDigestAlgorithm",
-            "type": "string",
+            "type": "SignToolDigestAlgorithm",
             "format": "/td {value}",
             "help": "Used with the <c>/tr</c> or <c>/tseal</c> switch to request a digest algorithm used by the RFC 3161 timestamp server."
           },
@@ -291,6 +291,13 @@
       "values": [
         "Embedded",
         "DetachedSignedData"
+      ]
+    },
+    {
+      "name": "SignToolDigestAlgorithm",
+      "values": [
+        "SHA1",
+        "SHA256"
       ]
     }
   ]

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -38,19 +38,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0" />
-    <PackageReference Include="FluentAssertions" Version="5.9.0"/>
+    <PackageReference Include="coverlet.msbuild" Version="3.0.3" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0"/>
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15"/>
-    <PackageReference Include="Verify.Xunit" Version="8.4.2" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.25"/>
+    <PackageReference Include="Verify.Xunit" Version="10.9.1" />
     <PackageReference Include="xunit" Version="2.4.1"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1"/>
   </ItemGroup>

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>preview</LangVersion>
-    <NoWarn>CS1701;CS1702;CS1591;CS0169;NU5129;NU5118</NoWarn>
+    <NoWarn>CS1591;NU5129;NU5118</NoWarn>
     <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
     <DebugSymbols>True</DebugSymbols>
     <DebugType>portable</DebugType>

--- a/source/Nuke.Common.Tests/Execution/BuildExecutorTest.cs
+++ b/source/Nuke.Common.Tests/Execution/BuildExecutorTest.cs
@@ -36,7 +36,7 @@ namespace Nuke.Common.Tests.Execution
         public void TestDefault()
         {
             ExecuteBuild();
-            AssertExecuted(A, B, C);
+            AssertSucceeded(A, B, C);
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace Nuke.Common.Tests.Execution
         {
             C.Invoked = true;
             ExecuteBuild(skippedTargets: new ExecutableTarget[0]);
-            AssertExecuted(C);
+            AssertSucceeded(C);
             AssertSkipped(A, B);
         }
 
@@ -59,7 +59,7 @@ namespace Nuke.Common.Tests.Execution
         public void TestParameterSkipped_Single()
         {
             ExecuteBuild(skippedTargets: new[] { A });
-            AssertExecuted(B, C);
+            AssertSucceeded(B, C);
             AssertSkipped(A);
             A.SkipReason.Should().Be("via --skip parameter");
         }
@@ -68,7 +68,7 @@ namespace Nuke.Common.Tests.Execution
         public void TestParameterSkipped_Multiple()
         {
             ExecuteBuild(skippedTargets: new[] { A, B });
-            AssertExecuted(C);
+            AssertSucceeded(C);
             AssertSkipped(A, B);
         }
 
@@ -77,7 +77,7 @@ namespace Nuke.Common.Tests.Execution
         {
             B.DependencyBehavior = DependencyBehavior.Skip;
             ExecuteBuild(skippedTargets: new[] { B });
-            AssertExecuted(C);
+            AssertSucceeded(C);
             AssertSkipped(A, B);
         }
 
@@ -86,7 +86,7 @@ namespace Nuke.Common.Tests.Execution
         {
             B.StaticConditions.Add(True);
             ExecuteBuild();
-            AssertExecuted(A, B, C);
+            AssertSucceeded(A, B, C);
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace Nuke.Common.Tests.Execution
             B.StaticConditions.Add(False);
             B.DependencyBehavior = DependencyBehavior.Execute;
             ExecuteBuild();
-            AssertExecuted(A, C);
+            AssertSucceeded(A, C);
             AssertSkipped(B);
             B.SkipReason.Should().Be("false");
         }
@@ -106,7 +106,7 @@ namespace Nuke.Common.Tests.Execution
             B.StaticConditions.Add(False);
             B.DependencyBehavior = DependencyBehavior.Skip;
             ExecuteBuild();
-            AssertExecuted(C);
+            AssertSucceeded(C);
             AssertSkipped(A, B);
             A.SkipReason.Should().Be("skipping B");
             B.SkipReason.Should().Be("false");
@@ -119,7 +119,7 @@ namespace Nuke.Common.Tests.Execution
             B.DynamicConditions.Add(() => condition);
 
             ExecuteBuild();
-            AssertExecuted(A, C);
+            AssertSucceeded(A, C);
             AssertSkipped(B);
         }
 
@@ -130,7 +130,7 @@ namespace Nuke.Common.Tests.Execution
             B.DynamicConditions.Add(() => condition);
             A.Actions.Add(() => condition = true);
             ExecuteBuild();
-            AssertExecuted(A, B, C);
+            AssertSucceeded(A, B, C);
         }
 
         private void ExecuteBuild(ExecutableTarget[] skippedTargets = null)
@@ -140,13 +140,12 @@ namespace Nuke.Common.Tests.Execution
             var build = new TestBuild();
             build.ExecutableTargets = new[] { A, B, C };
             build.ExecutionPlan = new[] { A, B, C };
-            build.ExecutionPlan.ForEach(x => x.Status = ExecutionStatus.NotRun);
             BuildExecutor.Execute(build, SelectNames(skippedTargets));
         }
 
-        private static void AssertExecuted(params ExecutableTarget[] targets)
+        private static void AssertSucceeded(params ExecutableTarget[] targets)
         {
-            targets.ForEach(x => x.Status.Should().Be(ExecutionStatus.Executed));
+            targets.ForEach(x => x.Status.Should().Be(ExecutionStatus.Succeeded));
             targets.ForEach(x => x.SkipReason.Should().BeNull());
         }
 

--- a/source/Nuke.Common.Tests/ParameterServiceTest.cs
+++ b/source/Nuke.Common.Tests/ParameterServiceTest.cs
@@ -221,6 +221,7 @@ namespace Nuke.Common.Tests
                 .Should().BeEquivalentTo(verbosities);
         }
 
+#pragma warning disable CS0649
         private class TestBuild : NukeBuild, ITestComponent
         {
             [Parameter] public string String;
@@ -233,5 +234,6 @@ namespace Nuke.Common.Tests
         {
             [Parameter] bool Param => ValueInjectionUtility.TryGetValue<bool?>(() => Param) ?? false;
         }
+#pragma warning restore CS0649
     }
 }

--- a/source/Nuke.Common.Tests/SchemaUtilityTest.TestGetBuildSchema.verified.txt
+++ b/source/Nuke.Common.Tests/SchemaUtilityTest.TestGetBuildSchema.verified.txt
@@ -86,7 +86,7 @@
         },
         "Target": {
           "type": "array",
-          "description": "List of targets to be executed. Default is '{default_target}'",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
           "items": {
             "type": "string",
             "enum": [

--- a/source/Nuke.Common.Tests/SchemaUtilityTest.cs
+++ b/source/Nuke.Common.Tests/SchemaUtilityTest.cs
@@ -48,7 +48,7 @@ namespace Nuke.Common.Tests
         },
         ""Target"": {
           ""type"": ""array"",
-          ""description"": ""List of targets to be executed. Default is '{default_target}'"",
+          ""description"": ""List of targets to be invoked. Default is '{default_target}'"",
           ""items"": {
             ""type"": ""string"",
             ""enum"": [

--- a/source/Nuke.Common.Tests/SchemaUtilityTest.cs
+++ b/source/Nuke.Common.Tests/SchemaUtilityTest.cs
@@ -72,6 +72,7 @@ namespace Nuke.Common.Tests
                 });
         }
 
+#pragma warning disable CS0649
         private class TestBuild : NukeBuild, ITestComponent
         {
             [Parameter] public string Param;
@@ -97,5 +98,6 @@ namespace Nuke.Common.Tests
             Target Bar => _ => _;
             Target Zoo => _ => _;
         }
+#pragma warning restore CS0649
     }
 }

--- a/source/Nuke.Common/CI/GenerateBuildServerConfigurationsAttribute.cs
+++ b/source/Nuke.Common/CI/GenerateBuildServerConfigurationsAttribute.cs
@@ -11,9 +11,9 @@ using Nuke.Common.Utilities.Collections;
 namespace Nuke.Common.CI
 {
     public class GenerateBuildServerConfigurationsAttribute
-        : BuildServerConfigurationGenerationAttributeBase, IOnBeforeLogo
+        : BuildServerConfigurationGenerationAttributeBase, IOnBuildCreated
     {
-        public void OnBeforeLogo(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
+        public void OnBuildCreated(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
         {
             var configurationId = EnvironmentInfo.GetParameter<string>(ConfigurationParameterName);
             if (configurationId == null)

--- a/source/Nuke.Common/CI/InvokeBuildServerConfigurationGenerationAttribute.cs
+++ b/source/Nuke.Common/CI/InvokeBuildServerConfigurationGenerationAttribute.cs
@@ -15,9 +15,9 @@ using Nuke.Common.Utilities.Collections;
 namespace Nuke.Common.CI
 {
     public class InvokeBuildServerConfigurationGenerationAttribute
-        : BuildServerConfigurationGenerationAttributeBase, IOnBeforeLogo
+        : BuildServerConfigurationGenerationAttributeBase, IOnBuildCreated
     {
-        public void OnBeforeLogo(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
+        public void OnBuildCreated(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
         {
             if (NukeBuild.IsServerBuild)
                 return;

--- a/source/Nuke.Common/Execution/ArgumentsFromCommitMessageAttribute.cs
+++ b/source/Nuke.Common/Execution/ArgumentsFromCommitMessageAttribute.cs
@@ -16,13 +16,13 @@ using static Nuke.Common.CI.InvokeBuildServerConfigurationGenerationAttribute;
 namespace Nuke.Common.Execution
 {
     [PublicAPI]
-    public class ArgumentsFromCommitMessageAttribute : BuildExtensionAttributeBase, IOnBeforeLogo
+    public class ArgumentsFromCommitMessageAttribute : BuildExtensionAttributeBase, IOnBuildCreated
     {
         private bool GenerationMode { get; } = EnvironmentInfo.GetParameter<string>(ConfigurationParameterName) != null;
 
         public string Prefix { get; set; } = "[nuke++]";
 
-        public void OnBeforeLogo(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
+        public void OnBuildCreated(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
         {
             if (GenerationMode)
                 return;

--- a/source/Nuke.Common/Execution/ArgumentsFromParametersFileAttribute.cs
+++ b/source/Nuke.Common/Execution/ArgumentsFromParametersFileAttribute.cs
@@ -19,11 +19,11 @@ using static Nuke.Common.CI.BuildServerConfigurationGenerationAttributeBase;
 namespace Nuke.Common.Execution
 {
     [PublicAPI]
-    public class ArgumentsFromParametersFileAttribute : BuildExtensionAttributeBase, IOnBeforeLogo
+    public class ArgumentsFromParametersFileAttribute : BuildExtensionAttributeBase, IOnBuildCreated
     {
         private bool GenerationMode { get; } = EnvironmentInfo.GetParameter<string>(ConfigurationParameterName) != null;
 
-        public void OnBeforeLogo(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
+        public void OnBuildCreated(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
         {
             var parameterMembers = ValueInjectionUtility.GetParameterMembers(build.GetType(), includeUnlisted: true);
             var passwords = new Dictionary<string, byte[]>();

--- a/source/Nuke.Common/Execution/BuildExecutor.cs
+++ b/source/Nuke.Common/Execution/BuildExecutor.cs
@@ -27,7 +27,7 @@ namespace Nuke.Common.Execution
         public static void Execute(NukeBuild build, [CanBeNull] IReadOnlyCollection<string> skippedTargets)
         {
             MarkSkippedTargets(build, skippedTargets);
-            RequirementService.ValidateRequirements(build, build.ExecutingTargets.ToList());
+            RequirementService.ValidateRequirements(build, build.ScheduledTargets.ToList());
             var previouslyExecutedTargets = UpdateInvocationHash(build);
 
             BuildManager.CancellationHandler += ExecuteAssuredTargets;
@@ -44,8 +44,8 @@ namespace Nuke.Common.Execution
 
             void ExecuteAssuredTargets()
             {
-                var assuredTargets = build.ExecutionPlan.Where(x => x.AssuredAfterFailure && x.Status == ExecutionStatus.NotRun);
-                assuredTargets.ForEach(x => Execute(build, x, previouslyExecutedTargets, failureMode: true));
+                var assuredScheduledTargets = build.ExecutionPlan.Where(x => x.AssuredAfterFailure && x.Status == ExecutionStatus.Scheduled);
+                assuredScheduledTargets.ForEach(x => Execute(build, x, previouslyExecutedTargets, failureMode: true));
             }
         }
 
@@ -149,8 +149,8 @@ namespace Nuke.Common.Execution
 
                 void TryMarkTargetSkipped(ExecutableTarget dependentTarget)
                 {
-                    var executingTargets = build.ExecutionPlan.Where(x => x.Status == ExecutionStatus.NotRun);
-                    if (executingTargets.Any(x => x.ExecutionDependencies.Contains(dependentTarget) || x.Triggers.Contains(dependentTarget)))
+                    var scheduledTargets = build.ExecutionPlan.Where(x => x.Status == ExecutionStatus.Scheduled);
+                    if (scheduledTargets.Any(x => x.ExecutionDependencies.Contains(dependentTarget) || x.Triggers.Contains(dependentTarget)))
                         return;
 
                     MarkTargetSkipped(dependentTarget, reason: $"skipping {target.Name}");

--- a/source/Nuke.Common/Execution/BuildExecutor.cs
+++ b/source/Nuke.Common/Execution/BuildExecutor.cs
@@ -104,8 +104,8 @@ namespace Nuke.Common.Execution
             using (Logger.Block(target.Name))
             {
                 target.Status = ExecutionStatus.Running;
-                build.ExecuteExtension<IOnTargetStart>(x => x.OnTargetStart(build, target));
-                build.OnTargetStart(target.Name);
+                build.ExecuteExtension<IOnTargetRunning>(x => x.OnTargetRunning(build, target));
+                build.OnTargetRunning(target.Name);
                 var stopwatch = Stopwatch.StartNew();
                 try
                 {

--- a/source/Nuke.Common/Execution/BuildExecutor.cs
+++ b/source/Nuke.Common/Execution/BuildExecutor.cs
@@ -90,7 +90,6 @@ namespace Nuke.Common.Execution
             {
                 target.Status = ExecutionStatus.Skipped;
                 build.ExecuteExtension<IOnTargetSkipped>(x => x.OnTargetSkipped(build, target));
-                build.OnTargetSkipped(target.Name);
                 AppendToBuildAttemptFile(target.Name);
                 return;
             }
@@ -105,14 +104,12 @@ namespace Nuke.Common.Execution
             {
                 target.Status = ExecutionStatus.Running;
                 build.ExecuteExtension<IOnTargetRunning>(x => x.OnTargetRunning(build, target));
-                build.OnTargetRunning(target.Name);
                 var stopwatch = Stopwatch.StartNew();
                 try
                 {
                     target.Actions.ForEach(x => x());
                     target.Status = ExecutionStatus.Succeeded;
                     build.ExecuteExtension<IOnTargetSucceeded>(x => x.OnTargetSucceeded(build, target));
-                    build.OnTargetSucceeded(target.Name);
                     AppendToBuildAttemptFile(target.Name);
                 }
                 catch (Exception exception)
@@ -122,7 +119,6 @@ namespace Nuke.Common.Execution
                     if (!target.SummaryInformation.Any())
                         target.SummaryInformation.Add((exception.GetType().Name, exception.Message));
                     build.ExecuteExtension<IOnTargetFailed>(x => x.OnTargetFailed(build, target));
-                    build.OnTargetFailed(target.Name);
                     if (!target.ProceedAfterFailure && !failureMode)
                         throw new TargetExecutionException(target.Name, exception);
                 }

--- a/source/Nuke.Common/Execution/BuildExecutor.cs
+++ b/source/Nuke.Common/Execution/BuildExecutor.cs
@@ -103,7 +103,7 @@ namespace Nuke.Common.Execution
 
             using (Logger.Block(target.Name))
             {
-                target.Status = ExecutionStatus.Executing;
+                target.Status = ExecutionStatus.Running;
                 build.ExecuteExtension<IOnTargetStart>(x => x.OnTargetStart(build, target));
                 build.OnTargetStart(target.Name);
                 var stopwatch = Stopwatch.StartNew();

--- a/source/Nuke.Common/Execution/BuildExecutor.cs
+++ b/source/Nuke.Common/Execution/BuildExecutor.cs
@@ -110,9 +110,9 @@ namespace Nuke.Common.Execution
                 try
                 {
                     target.Actions.ForEach(x => x());
-                    target.Status = ExecutionStatus.Executed;
-                    build.ExecuteExtension<IOnTargetExecuted>(x => x.OnTargetExecuted(build, target));
-                    build.OnTargetExecuted(target.Name);
+                    target.Status = ExecutionStatus.Succeeded;
+                    build.ExecuteExtension<IOnTargetSucceeded>(x => x.OnTargetSucceeded(build, target));
+                    build.OnTargetSucceeded(target.Name);
                     AppendToBuildAttemptFile(target.Name);
                 }
                 catch (Exception exception)

--- a/source/Nuke.Common/Execution/BuildExecutor.cs
+++ b/source/Nuke.Common/Execution/BuildExecutor.cs
@@ -119,6 +119,8 @@ namespace Nuke.Common.Execution
                 {
                     Logger.Error(exception);
                     target.Status = ExecutionStatus.Failed;
+                    if (!target.SummaryInformation.Any())
+                        target.SummaryInformation.Add((exception.GetType().Name, exception.Message));
                     build.ExecuteExtension<IOnTargetFailed>(x => x.OnTargetFailed(build, target));
                     build.OnTargetFailed(target.Name);
                     if (!target.ProceedAfterFailure && !failureMode)

--- a/source/Nuke.Common/Execution/BuildExtensionAttributeBase.cs
+++ b/source/Nuke.Common/Execution/BuildExtensionAttributeBase.cs
@@ -23,15 +23,15 @@ namespace Nuke.Common.Execution
     }
 
     [PublicAPI]
-    public interface IOnBeforeLogo : IBuildExtension
+    public interface IOnBuildCreated : IBuildExtension
     {
-        void OnBeforeLogo(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets);
+        void OnBuildCreated(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets);
     }
 
     [PublicAPI]
-    public interface IOnAfterLogo : IBuildExtension
+    public interface IOnBuildInitialized : IBuildExtension
     {
-        void OnAfterLogo(
+        void OnBuildInitialized(
             NukeBuild build,
             IReadOnlyCollection<ExecutableTarget> executableTargets,
             IReadOnlyCollection<ExecutableTarget> executionPlan);
@@ -44,9 +44,9 @@ namespace Nuke.Common.Execution
     }
 
     [PublicAPI]
-    public interface IOnTargetStart : IBuildExtension
+    public interface IOnTargetRunning : IBuildExtension
     {
-        void OnTargetStart(NukeBuild build, ExecutableTarget target);
+        void OnTargetRunning(NukeBuild build, ExecutableTarget target);
     }
 
     [PublicAPI]

--- a/source/Nuke.Common/Execution/BuildExtensionAttributeBase.cs
+++ b/source/Nuke.Common/Execution/BuildExtensionAttributeBase.cs
@@ -50,9 +50,9 @@ namespace Nuke.Common.Execution
     }
 
     [PublicAPI]
-    public interface IOnTargetExecuted : IBuildExtension
+    public interface IOnTargetSucceeded : IBuildExtension
     {
-        void OnTargetExecuted(NukeBuild build, ExecutableTarget target);
+        void OnTargetSucceeded(NukeBuild build, ExecutableTarget target);
     }
 
     [PublicAPI]

--- a/source/Nuke.Common/Execution/BuildManager.cs
+++ b/source/Nuke.Common/Execution/BuildManager.cs
@@ -40,7 +40,7 @@ namespace Nuke.Common.Execution
             {
                 build.ExecutableTargets = ExecutableTargetFactory.CreateAll(build, defaultTargetExpressions);
 
-                build.ExecuteExtension<IOnBeforeLogo>(x => x.OnBeforeLogo(build, build.ExecutableTargets));
+                build.ExecuteExtension<IOnBuildCreated>(x => x.OnBuildCreated(build, build.ExecutableTargets));
                 build.OnBuildCreated();
 
                 Logger.OutputSink = NukeBuild.Host.OutputSink;
@@ -65,7 +65,7 @@ namespace Nuke.Common.Execution
                     build.ExecutableTargets,
                     EnvironmentInfo.GetParameter<string[]>(() => build.InvokedTargets));
 
-                build.ExecuteExtension<IOnAfterLogo>(x => x.OnAfterLogo(build, build.ExecutableTargets, build.ExecutionPlan));
+                build.ExecuteExtension<IOnBuildInitialized>(x => x.OnBuildInitialized(build, build.ExecutableTargets, build.ExecutionPlan));
                 build.OnBuildInitialized();
 
                 CancellationHandler += Finish;

--- a/source/Nuke.Common/Execution/BuildManager.cs
+++ b/source/Nuke.Common/Execution/BuildManager.cs
@@ -41,7 +41,6 @@ namespace Nuke.Common.Execution
                 build.ExecutableTargets = ExecutableTargetFactory.CreateAll(build, defaultTargetExpressions);
 
                 build.ExecuteExtension<IOnBuildCreated>(x => x.OnBuildCreated(build, build.ExecutableTargets));
-                build.OnBuildCreated();
 
                 Logger.OutputSink = NukeBuild.Host.OutputSink;
 
@@ -66,7 +65,6 @@ namespace Nuke.Common.Execution
                     EnvironmentInfo.GetParameter<string[]>(() => build.InvokedTargets));
 
                 build.ExecuteExtension<IOnBuildInitialized>(x => x.OnBuildInitialized(build, build.ExecutableTargets, build.ExecutionPlan));
-                build.OnBuildInitialized();
 
                 CancellationHandler += Finish;
                 BuildExecutor.Execute(
@@ -104,7 +102,6 @@ namespace Nuke.Common.Execution
                     Logger.OutputSink.WriteSummary(build);
                 }
 
-                build.OnBuildFinished();
                 build.ExecuteExtension<IOnBuildFinished>(x => x.OnBuildFinished(build));
             }
         }

--- a/source/Nuke.Common/Execution/BuildManager.cs
+++ b/source/Nuke.Common/Execution/BuildManager.cs
@@ -92,7 +92,7 @@ namespace Nuke.Common.Execution
                 if (build.ExecutionPlan != null)
                 {
                     build.ExecutionPlan
-                        .Where(x => x.Status == ExecutionStatus.Executing)
+                        .Where(x => x.Status == ExecutionStatus.Running)
                         .ForEach(x => x.Status = ExecutionStatus.Aborted);
 
                     Logger.OutputSink.WriteSummary(build);

--- a/source/Nuke.Common/Execution/BuildManager.cs
+++ b/source/Nuke.Common/Execution/BuildManager.cs
@@ -84,17 +84,19 @@ namespace Nuke.Common.Execution
             }
             finally
             {
-                if (build.ExecutionPlan?.Any(x => x.Status != ExecutionStatus.NotRun) ?? false)
-                    Finish();
+                Finish();
             }
 
             void Finish()
             {
-                build.ExecutionPlan
-                    .Where(x => x.Status == ExecutionStatus.Executing)
-                    .ForEach(x => x.Status = ExecutionStatus.Aborted);
+                if (build.ExecutionPlan != null)
+                {
+                    build.ExecutionPlan
+                        .Where(x => x.Status == ExecutionStatus.Executing)
+                        .ForEach(x => x.Status = ExecutionStatus.Aborted);
 
-                Logger.OutputSink.WriteSummary(build);
+                    Logger.OutputSink.WriteSummary(build);
+                }
 
                 build.OnBuildFinished();
                 build.ExecuteExtension<IOnBuildFinished>(x => x.OnBuildFinished(build));

--- a/source/Nuke.Common/Execution/BuildManager.cs
+++ b/source/Nuke.Common/Execution/BuildManager.cs
@@ -91,9 +91,15 @@ namespace Nuke.Common.Execution
             {
                 if (build.ExecutionPlan != null)
                 {
-                    build.ExecutionPlan
-                        .Where(x => x.Status == ExecutionStatus.Running)
-                        .ForEach(x => x.Status = ExecutionStatus.Aborted);
+                    foreach (var target in build.ExecutionPlan)
+                    {
+                        target.Status = target.Status switch
+                        {
+                            ExecutionStatus.Running => ExecutionStatus.Aborted,
+                            ExecutionStatus.Scheduled => ExecutionStatus.NotRun,
+                            _ => target.Status
+                        };
+                    }
 
                     Logger.OutputSink.WriteSummary(build);
                 }

--- a/source/Nuke.Common/Execution/CheckBuildProjectConfigurationsAttribute.cs
+++ b/source/Nuke.Common/Execution/CheckBuildProjectConfigurationsAttribute.cs
@@ -14,11 +14,11 @@ using Nuke.Common.Utilities.Collections;
 namespace Nuke.Common.Execution
 {
     [PublicAPI]
-    public class CheckBuildProjectConfigurationsAttribute : BuildExtensionAttributeBase, IOnAfterLogo
+    public class CheckBuildProjectConfigurationsAttribute : BuildExtensionAttributeBase, IOnBuildInitialized
     {
         public int TimeoutInMilliseconds { get; set; } = 500;
 
-        public void OnAfterLogo(
+        public void OnBuildInitialized(
             NukeBuild build,
             IReadOnlyCollection<ExecutableTarget> executableTargets,
             IReadOnlyCollection<ExecutableTarget> executionPlan)

--- a/source/Nuke.Common/Execution/CheckPathEnvironmentVariableAttribute.cs
+++ b/source/Nuke.Common/Execution/CheckPathEnvironmentVariableAttribute.cs
@@ -11,9 +11,9 @@ using Nuke.Common.Tooling;
 namespace Nuke.Common.Execution
 {
     [PublicAPI]
-    public class CheckPathEnvironmentVariableAttribute : BuildExtensionAttributeBase, IOnAfterLogo
+    public class CheckPathEnvironmentVariableAttribute : BuildExtensionAttributeBase, IOnBuildInitialized
     {
-        public void OnAfterLogo(
+        public void OnBuildInitialized(
             NukeBuild build,
             IReadOnlyCollection<ExecutableTarget> executableTargets,
             IReadOnlyCollection<ExecutableTarget> executionPlan)

--- a/source/Nuke.Common/Execution/EventInvoker.cs
+++ b/source/Nuke.Common/Execution/EventInvoker.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2021 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nuke.Common.Execution
+{
+    internal class EventInvoker : BuildExtensionAttributeBase,
+        IOnBuildCreated,
+        IOnBuildInitialized,
+        IOnTargetRunning,
+        IOnTargetSkipped,
+        IOnTargetSucceeded,
+        IOnTargetFailed,
+        IOnBuildFinished
+    {
+        public void OnBuildCreated(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
+        {
+            build.OnBuildCreated();
+        }
+
+        public void OnBuildInitialized(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets, IReadOnlyCollection<ExecutableTarget> executionPlan)
+        {
+            build.OnBuildInitialized();
+        }
+
+        public void OnTargetRunning(NukeBuild build, ExecutableTarget target)
+        {
+            build.OnTargetRunning(target.Name);
+        }
+
+        public void OnTargetSkipped(NukeBuild build, ExecutableTarget target)
+        {
+            build.OnTargetSkipped(target.Name);
+        }
+
+        public void OnTargetSucceeded(NukeBuild build, ExecutableTarget target)
+        {
+            build.OnTargetSucceeded(target.Name);
+        }
+
+        public void OnTargetFailed(NukeBuild build, ExecutableTarget target)
+        {
+            build.OnTargetFailed(target.Name);
+        }
+
+        public void OnBuildFinished(NukeBuild build)
+        {
+            build.OnBuildFinished();
+        }
+    }
+}

--- a/source/Nuke.Common/Execution/ExecutionStatus.cs
+++ b/source/Nuke.Common/Execution/ExecutionStatus.cs
@@ -11,7 +11,7 @@ namespace Nuke.Common.Execution
     {
         NotRun,
         Skipped,
-        Executed,
+        Succeeded,
         Failed,
         Executing,
         Aborted,

--- a/source/Nuke.Common/Execution/ExecutionStatus.cs
+++ b/source/Nuke.Common/Execution/ExecutionStatus.cs
@@ -13,7 +13,7 @@ namespace Nuke.Common.Execution
         Skipped,
         Succeeded,
         Failed,
-        Executing,
+        Running,
         Aborted,
         Collective
     }

--- a/source/Nuke.Common/Execution/ExecutionStatus.cs
+++ b/source/Nuke.Common/Execution/ExecutionStatus.cs
@@ -9,6 +9,8 @@ namespace Nuke.Common.Execution
 {
     public enum ExecutionStatus
     {
+        None,
+        Scheduled,
         NotRun,
         Skipped,
         Succeeded,

--- a/source/Nuke.Common/Execution/HandleHelpRequestsAttribute.cs
+++ b/source/Nuke.Common/Execution/HandleHelpRequestsAttribute.cs
@@ -8,9 +8,9 @@ using System.Linq;
 
 namespace Nuke.Common.Execution
 {
-    internal class HandleHelpRequestsAttribute : BuildExtensionAttributeBase, IOnAfterLogo
+    internal class HandleHelpRequestsAttribute : BuildExtensionAttributeBase, IOnBuildInitialized
     {
-        public void OnAfterLogo(
+        public void OnBuildInitialized(
             NukeBuild build,
             IReadOnlyCollection<ExecutableTarget> executableTargets,
             IReadOnlyCollection<ExecutableTarget> executionPlan)

--- a/source/Nuke.Common/Execution/HandleShellCompletionAttribute.cs
+++ b/source/Nuke.Common/Execution/HandleShellCompletionAttribute.cs
@@ -9,9 +9,9 @@ using static Nuke.Common.Constants;
 
 namespace Nuke.Common.Execution
 {
-    internal class HandleShellCompletionAttribute : BuildExtensionAttributeBase, IOnBeforeLogo
+    internal class HandleShellCompletionAttribute : BuildExtensionAttributeBase, IOnBuildCreated
     {
-        public void OnBeforeLogo(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
+        public void OnBuildCreated(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
         {
             SchemaUtility.WriteBuildSchemaFile(build);
             SchemaUtility.WriteDefaultParametersFile();

--- a/source/Nuke.Common/Execution/HandleVisualStudioDebuggingAttribute.cs
+++ b/source/Nuke.Common/Execution/HandleVisualStudioDebuggingAttribute.cs
@@ -13,11 +13,11 @@ using JetBrains.Annotations;
 namespace Nuke.Common.Execution
 {
     [PublicAPI]
-    public class HandleVisualStudioDebuggingAttribute : BuildExtensionAttributeBase, IOnBeforeLogo
+    public class HandleVisualStudioDebuggingAttribute : BuildExtensionAttributeBase, IOnBuildCreated
     {
         public int TimeoutInMilliseconds { get; } = 10_000;
 
-        public void OnBeforeLogo(
+        public void OnBuildCreated(
             NukeBuild build,
             IReadOnlyCollection<ExecutableTarget> executableTargets)
         {

--- a/source/Nuke.Common/Execution/RequirementService.cs
+++ b/source/Nuke.Common/Execution/RequirementService.cs
@@ -17,9 +17,9 @@ namespace Nuke.Common.Execution
     /// </summary>
     internal static class RequirementService
     {
-        public static void ValidateRequirements(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executingTargets)
+        public static void ValidateRequirements(NukeBuild build, IReadOnlyCollection<ExecutableTarget> scheduledTargets)
         {
-            foreach (var target in executingTargets)
+            foreach (var target in scheduledTargets)
             foreach (var requirement in target.Requirements)
             {
                 if (requirement is Expression<Func<bool>> boolExpression)

--- a/source/Nuke.Common/Execution/UnsetVisualStudioEnvironmentVariablesAttribute.cs
+++ b/source/Nuke.Common/Execution/UnsetVisualStudioEnvironmentVariablesAttribute.cs
@@ -11,9 +11,9 @@ using Nuke.Common.Utilities.Collections;
 namespace Nuke.Common.Execution
 {
     [PublicAPI]
-    public class UnsetVisualStudioEnvironmentVariablesAttribute : BuildExtensionAttributeBase, IOnBeforeLogo
+    public class UnsetVisualStudioEnvironmentVariablesAttribute : BuildExtensionAttributeBase, IOnBuildCreated
     {
-        public void OnBeforeLogo(
+        public void OnBuildCreated(
             NukeBuild build,
             IReadOnlyCollection<ExecutableTarget> executableTargets)
         {

--- a/source/Nuke.Common/INukeBuild.cs
+++ b/source/Nuke.Common/INukeBuild.cs
@@ -25,6 +25,8 @@ namespace Nuke.Common
         IReadOnlyCollection<ExecutableTarget> FinishedTargets { get; }
 
         bool IsSuccessful { get; }
+        bool IsFailing { get; }
+        bool IsFinished { get; }
 
         AbsolutePath RootDirectory { get; }
         AbsolutePath TemporaryDirectory { get; }

--- a/source/Nuke.Common/INukeBuild.cs
+++ b/source/Nuke.Common/INukeBuild.cs
@@ -27,6 +27,7 @@ namespace Nuke.Common
         bool IsSuccessful { get; }
         bool IsFailing { get; }
         bool IsFinished { get; }
+        int? ExitCode { get; set; }
 
         AbsolutePath RootDirectory { get; }
         AbsolutePath TemporaryDirectory { get; }

--- a/source/Nuke.Common/INukeBuild.cs
+++ b/source/Nuke.Common/INukeBuild.cs
@@ -17,7 +17,12 @@ namespace Nuke.Common
 
         IReadOnlyCollection<ExecutableTarget> InvokedTargets { get; }
         IReadOnlyCollection<ExecutableTarget> SkippedTargets { get; }
-        IReadOnlyCollection<ExecutableTarget> ExecutingTargets { get; }
+        IReadOnlyCollection<ExecutableTarget> ScheduledTargets { get; }
+        IReadOnlyCollection<ExecutableTarget> RunningTargets { get; }
+        IReadOnlyCollection<ExecutableTarget> AbortedTargets { get; }
+        IReadOnlyCollection<ExecutableTarget> FailedTargets { get; }
+        IReadOnlyCollection<ExecutableTarget> SucceededTargets { get; }
+        IReadOnlyCollection<ExecutableTarget> FinishedTargets { get; }
 
         bool IsSuccessful { get; }
 

--- a/source/Nuke.Common/IO/FileSystemTasks.cs
+++ b/source/Nuke.Common/IO/FileSystemTasks.cs
@@ -44,9 +44,19 @@ namespace Nuke.Common.IO
             return Directory.Exists(path);
         }
 
+        public static void EnsureExistingParentDirectory(AbsolutePath file)
+        {
+            EnsureExistingParentDirectory((string) file);
+        }
+
         public static void EnsureExistingParentDirectory(string file)
         {
             EnsureExistingDirectory(Path.GetDirectoryName(file).NotNull($"Path.GetDirectoryName({file}) != null"));
+        }
+
+        public static void EnsureExistingDirectory(AbsolutePath directory)
+        {
+            EnsureExistingDirectory((string) directory);
         }
 
         public static void EnsureExistingDirectory(string directory)
@@ -56,6 +66,11 @@ namespace Nuke.Common.IO
 
             Logger.Info($"Creating directory '{directory}'...");
             Directory.CreateDirectory(directory);
+        }
+
+        public static void EnsureCleanDirectory(AbsolutePath directory)
+        {
+            EnsureCleanDirectory((string) directory);
         }
 
         public static void EnsureCleanDirectory(string directory)

--- a/source/Nuke.Common/IO/GlobbingOptionsAttribute.cs
+++ b/source/Nuke.Common/IO/GlobbingOptionsAttribute.cs
@@ -14,7 +14,7 @@ namespace Nuke.Common.IO
     /// Allows to configure the case-sensitivity used for globbing operations in <see cref="PathConstruction"/>.
     /// </summary>
     [PublicAPI]
-    public sealed class GlobbingOptionsAttribute : BuildExtensionAttributeBase, IOnBeforeLogo
+    public sealed class GlobbingOptionsAttribute : BuildExtensionAttributeBase, IOnBuildCreated
     {
         private readonly GlobbingCaseSensitivity _caseSensitivity;
 
@@ -23,7 +23,7 @@ namespace Nuke.Common.IO
             _caseSensitivity = caseSensitivity;
         }
 
-        public void OnBeforeLogo(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
+        public void OnBuildCreated(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
         {
             PathConstruction.GlobbingCaseSensitivity = _caseSensitivity;
         }

--- a/source/Nuke.Common/ITargetDefinition.cs
+++ b/source/Nuke.Common/ITargetDefinition.cs
@@ -195,13 +195,13 @@ namespace Nuke.Common
     public enum DependencyBehavior
     {
         /// <summary>
-        /// Execute all dependencies.
-        /// </summary>
-        Execute,
-
-        /// <summary>
         /// Skip all dependencies which are not required by another target.
         /// </summary>
-        Skip
+        Skip,
+
+        /// <summary>
+        /// Execute all dependencies.
+        /// </summary>
+        Execute
     }
 }

--- a/source/Nuke.Common/NukeBuild.Events.cs
+++ b/source/Nuke.Common/NukeBuild.Events.cs
@@ -49,7 +49,7 @@ namespace Nuke.Common
         }
 
         /// <summary>
-        /// Method that is invoked after the build has finished (successful or failed).
+        /// Method that is invoked after the build has finished (succeeded or failed).
         /// </summary>
         protected internal virtual void OnBuildFinished()
         {
@@ -58,14 +58,7 @@ namespace Nuke.Common
         /// <summary>
         /// Method that is invoked before a target is about to start.
         /// </summary>
-        protected internal virtual void OnTargetStart(string target)
-        {
-        }
-
-        /// <summary>
-        /// Method that is invoked when a shadow target is absent.
-        /// </summary>
-        protected internal virtual void OnTargetAbsent(string target)
+        protected internal virtual void OnTargetRunning(string target)
         {
         }
 

--- a/source/Nuke.Common/NukeBuild.Events.cs
+++ b/source/Nuke.Common/NukeBuild.Events.cs
@@ -79,7 +79,7 @@ namespace Nuke.Common
         /// <summary>
         /// Method that is invoked when a target has been executed successfully. 
         /// </summary>
-        protected internal virtual void OnTargetExecuted(string target)
+        protected internal virtual void OnTargetSucceeded(string target)
         {
         }
 

--- a/source/Nuke.Common/NukeBuild.Events.cs
+++ b/source/Nuke.Common/NukeBuild.Events.cs
@@ -13,6 +13,7 @@ using Nuke.Common.Utilities.Collections;
 
 namespace Nuke.Common
 {
+    [EventInvoker(Priority = float.MinValue)]
     public abstract partial class NukeBuild
     {
         internal List<IBuildExtension> BuildExtensions { get; }

--- a/source/Nuke.Common/NukeBuild.cs
+++ b/source/Nuke.Common/NukeBuild.cs
@@ -78,7 +78,7 @@ namespace Nuke.Common
         /// <summary>
         /// Gets the list of targets that were invoked.
         /// </summary>
-        [Parameter("List of targets to be executed. Default is '{default_target}'.",
+        [Parameter("List of targets to be invoked. Default is '{default_target}'.",
             Name = InvokedTargetsParameterName,
             Separator = TargetsSeparator,
             ValueProviderMember = nameof(TargetNames))]
@@ -94,9 +94,34 @@ namespace Nuke.Common
         public IReadOnlyCollection<ExecutableTarget> SkippedTargets => ExecutionPlan.Where(x => x.Status == ExecutionStatus.Skipped).ToList();
 
         /// <summary>
-        /// Gets the list of targets that are executing.
+        /// Gets the list of targets that are scheduled.
         /// </summary>
-        public IReadOnlyCollection<ExecutableTarget> ExecutingTargets => ExecutionPlan.Where(x => x.Status != ExecutionStatus.Skipped).ToList();
+        public IReadOnlyCollection<ExecutableTarget> ScheduledTargets => ExecutionPlan.Where(x => x.Status == ExecutionStatus.Scheduled).ToList();
+
+        /// <summary>
+        /// Gets the list of targets that are running.
+        /// </summary>
+        public IReadOnlyCollection<ExecutableTarget> RunningTargets => ExecutionPlan.Where(x => x.Status == ExecutionStatus.Running).ToList();
+
+        /// <summary>
+        /// Gets the list of targets that were aborted.
+        /// </summary>
+        public IReadOnlyCollection<ExecutableTarget> AbortedTargets => ExecutionPlan.Where(x => x.Status == ExecutionStatus.Aborted).ToList();
+
+        /// <summary>
+        /// Gets the list of targets that have failed.
+        /// </summary>
+        public IReadOnlyCollection<ExecutableTarget> FailedTargets => ExecutionPlan.Where(x => x.Status == ExecutionStatus.Failed).ToList();
+
+        /// <summary>
+        /// Gets the list of targets that have succeeded.
+        /// </summary>
+        public IReadOnlyCollection<ExecutableTarget> SucceededTargets => ExecutionPlan.Where(x => x.Status == ExecutionStatus.Succeeded).ToList();
+
+        /// <summary>
+        /// Gets the list of targets that have been finished (failed or succeeded).
+        /// </summary>
+        public IReadOnlyCollection<ExecutableTarget> FinishedTargets => FailedTargets.Concat(SucceededTargets).ToList();
 
         /// <summary>
         /// Gets a value whether to show the execution plan (HTML).

--- a/source/Nuke.Common/NukeBuild.cs
+++ b/source/Nuke.Common/NukeBuild.cs
@@ -163,6 +163,8 @@ namespace Nuke.Common
         internal IEnumerable<string> HostNames => Host.AvailableTypes.Select(x => x.Name);
 
         public bool IsSuccessful => ExecutionPlan.All(x => x.Status != ExecutionStatus.Failed && x.Status != ExecutionStatus.Aborted);
+        public bool IsFailing => !IsSuccessful;
+        public bool IsFinished => !ScheduledTargets.Concat(RunningTargets).Any();
 
         /// <summary>
         /// Gets or sets the build exit code.

--- a/source/Nuke.Common/NukeBuild.cs
+++ b/source/Nuke.Common/NukeBuild.cs
@@ -148,7 +148,7 @@ namespace Nuke.Common
 
         public void ReportSummary(string caption, string text)
         {
-            ExecutionPlan.Single(x => x.Status == ExecutionStatus.Executing)
+            ExecutionPlan.Single(x => x.Status == ExecutionStatus.Running)
                 .SummaryInformation.Add((caption, text));
         }
     }

--- a/source/Nuke.Common/NukeBuild.cs
+++ b/source/Nuke.Common/NukeBuild.cs
@@ -137,10 +137,7 @@ namespace Nuke.Common
         internal IEnumerable<string> TargetNames => ExecutableTargetFactory.GetTargetProperties(GetType()).Select(x => x.GetDisplayShortName());
         internal IEnumerable<string> HostNames => Host.AvailableTypes.Select(x => x.Name);
 
-        public bool IsSuccessful => (!ExitCode.HasValue || ExitCode == 0) && ExecutionPlan
-            .All(x => x.Status != ExecutionStatus.Failed &&
-                      x.Status != ExecutionStatus.NotRun &&
-                      x.Status != ExecutionStatus.Aborted);
+        public bool IsSuccessful => ExecutionPlan.All(x => x.Status != ExecutionStatus.Failed && x.Status != ExecutionStatus.Aborted);
 
         /// <summary>
         /// Gets or sets the build exit code.

--- a/source/Nuke.Common/OutputSinks/OutputSink.cs
+++ b/source/Nuke.Common/OutputSinks/OutputSink.cs
@@ -156,7 +156,7 @@ namespace Nuke.Common.OutputSinks
                    + (information != null ? $"   // {information}" : string.Empty);
 
             static string GetDurationOrBlank(ExecutableTarget target)
-                => target.Status == ExecutionStatus.Executed ||
+                => target.Status == ExecutionStatus.Succeeded ||
                    target.Status == ExecutionStatus.Failed ||
                    target.Status == ExecutionStatus.Aborted
                     ? GetDuration(target.Duration)
@@ -182,7 +182,7 @@ namespace Nuke.Common.OutputSinks
                     case ExecutionStatus.Skipped:
                         WriteNormal(line);
                         break;
-                    case ExecutionStatus.Executed:
+                    case ExecutionStatus.Succeeded:
                         WriteSuccess(line);
                         break;
                     case ExecutionStatus.Aborted:
@@ -192,6 +192,8 @@ namespace Nuke.Common.OutputSinks
                     case ExecutionStatus.Failed:
                         WriteError(line);
                         break;
+                    default:
+                        throw new NotSupportedException(target.Status.ToString());
                 }
             }
 

--- a/source/Nuke.Common/Tooling/VerbosityMappingAttribute.cs
+++ b/source/Nuke.Common/Tooling/VerbosityMappingAttribute.cs
@@ -11,7 +11,7 @@ using Nuke.Common.Execution;
 namespace Nuke.Common.Tooling
 {
     [PublicAPI]
-    public class VerbosityMappingAttribute : BuildExtensionAttributeBase, IOnAfterLogo
+    public class VerbosityMappingAttribute : BuildExtensionAttributeBase, IOnBuildInitialized
     {
         private readonly Type _targetType;
 
@@ -25,7 +25,7 @@ namespace Nuke.Common.Tooling
         public string Normal { get; set; }
         public string Verbose { get; set; }
 
-        public void OnAfterLogo(
+        public void OnBuildInitialized(
             NukeBuild build,
             IReadOnlyCollection<ExecutableTarget> executableTargets,
             IReadOnlyCollection<ExecutableTarget> executionPlan)

--- a/source/Nuke.Common/Tools/DotCover/TeamCitySetDotCoverHomePathAttribute.cs
+++ b/source/Nuke.Common/Tools/DotCover/TeamCitySetDotCoverHomePathAttribute.cs
@@ -12,9 +12,9 @@ using Nuke.Common.Execution;
 namespace Nuke.Common.Tools.DotCover
 {
     [PublicAPI]
-    public class TeamCitySetDotCoverHomePathAttribute : BuildExtensionAttributeBase, IOnAfterLogo
+    public class TeamCitySetDotCoverHomePathAttribute : BuildExtensionAttributeBase, IOnBuildInitialized
     {
-        public void OnAfterLogo(
+        public void OnBuildInitialized(
             NukeBuild build,
             IReadOnlyCollection<ExecutableTarget> executableTargets,
             IReadOnlyCollection<ExecutableTarget> executionPlan)

--- a/source/Nuke.Common/Tools/Npm/NpmTasks.cs
+++ b/source/Nuke.Common/Tools/Npm/NpmTasks.cs
@@ -11,6 +11,9 @@ namespace Nuke.Common.Tools.Npm
         public static void CustomLogger(OutputType type, string output)
         {
             var outputLowered = output.ToLower();
+            
+            //err! covers NPM errors
+            //error: covers angular errors
             if (outputLowered.Contains("err!") || outputLowered.Contains("error:"))
                 Logger.Error(output);
             else if (outputLowered.Contains("warn"))

--- a/source/Nuke.Common/Tools/Npm/NpmTasks.cs
+++ b/source/Nuke.Common/Tools/Npm/NpmTasks.cs
@@ -10,21 +10,13 @@ namespace Nuke.Common.Tools.Npm
     {
         public static void CustomLogger(OutputType type, string output)
         {
-            switch (type)
-            {
-                case OutputType.Std:
-                    Logger.Normal(output);
-                    break;
-                case OutputType.Err:
-                {
-                    if (output.StartsWith("npmWARN") || output.StartsWith("npm WARN"))
-                        Logger.Warn(output);
-                    else
-                        Logger.Error(output);
-
-                    break;
-                }
-            }
+            var outputLowered = output.ToLower();
+            if (outputLowered.Contains("err!") || outputLowered.Contains("error:"))
+                Logger.Error(output);
+            else if (outputLowered.Contains("warn"))
+                Logger.Warn(output);
+            else
+                Logger.Normal(output);
         }
     }
 }

--- a/source/Nuke.Common/ValueInjection/InjectNonParameterValuesAttribute.cs
+++ b/source/Nuke.Common/ValueInjection/InjectNonParameterValuesAttribute.cs
@@ -9,9 +9,9 @@ using Nuke.Common.Execution;
 
 namespace Nuke.Common.ValueInjection
 {
-    public class InjectNonParameterValuesAttribute : BuildExtensionAttributeBase, IOnAfterLogo
+    public class InjectNonParameterValuesAttribute : BuildExtensionAttributeBase, IOnBuildInitialized
     {
-        public void OnAfterLogo(
+        public void OnBuildInitialized(
             NukeBuild build,
             IReadOnlyCollection<ExecutableTarget> executableTargets,
             IReadOnlyCollection<ExecutableTarget> executionPlan)

--- a/source/Nuke.Common/ValueInjection/InjectParameterValuesAttribute.cs
+++ b/source/Nuke.Common/ValueInjection/InjectParameterValuesAttribute.cs
@@ -9,9 +9,9 @@ using Nuke.Common.Execution;
 
 namespace Nuke.Common.ValueInjection
 {
-    public class InjectParameterValuesAttribute : BuildExtensionAttributeBase, IOnBeforeLogo
+    public class InjectParameterValuesAttribute : BuildExtensionAttributeBase, IOnBuildCreated
     {
-        public void OnBeforeLogo(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
+        public void OnBuildCreated(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
         {
             ValueInjectionUtility.InjectValues(build, x => x is ParameterAttribute);
         }


### PR DESCRIPTION
Summary:

When building and testing angular projects with nuke we found that information logs were being output as errors. This would fail our builds on Azure DevOps. I'd like to suggest this change to the CustomLogger for NPM to be more generalized when catching errors, warnings and normal logs.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
