### PR TITLE
Add method to set variable in AzurePipelines

### DIFF
--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelines.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelines.cs
@@ -206,6 +206,16 @@ namespace Nuke.Common.CI.AzurePipelines
                     .AddPairWhenValueNotNull("code", code));
         }
 
+        public void SetVariable(string name, string value, bool? isSecret = null)
+        {
+            WriteCommand(
+                "task.setvariable",
+                value,
+                dictionaryConfigurator: x => x
+                    .AddPair("variable", name)
+                    .AddPairWhenValueNotNull("issecret", isSecret));
+        }
+
         private string GetText(AzurePipelinesIssueType type)
         {
             return type switch


### PR DESCRIPTION
In our project we use Azure Pipelines yaml build together with nuke. To share some info between nuke and yaml actions we set variables during the build process and then use them in build actions. At the moment we use the following code to set the variable:
```
AzurePipelines?.WriteCommand(
                "task.setvariable", 
                Value,
                dictionaryConfigurator: x => x
                    .AddPair("variable", Name));
```

It would be more convenient to have a method to execute this task and hide the internals:
```
AzurePipelines?.SetVariable(Name, Value);
```

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
