### PR TITLE
Update KeyVaultSecretAttribute to read string values like regular Parameters if no KeyVault provided

### DIFF
--- a/source/Nuke.Common/Tools/AzureKeyVault/AzureKeyVaultSecretAttribute.cs
+++ b/source/Nuke.Common/Tools/AzureKeyVault/AzureKeyVaultSecretAttribute.cs
@@ -22,7 +22,8 @@ namespace Nuke.Common.Tools.AzureKeyVault
 
         protected override object GetValue(AzureKeyVaultConfiguration configuration, MemberInfo member)
         {
-            return AzureKeyVaultTasks.GetSecret(configuration, _secretName ?? member.Name);
+            return EnvironmentInfo.GetParameter<string>(member) ??
+                   AzureKeyVaultTasks.GetSecret(configuration, _secretName ?? member.Name);
         }
     }
 }


### PR DESCRIPTION
This used to be working in earlier versions.

The use case is so that you can supply `[KeyVaultSecrets]` just like regular parameters e.g. via CLI or Environment argument when running without a KeyVault access.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
