### PR TITLE
Improve compatibility of CloudFoundryTasks.CloudFoundryEnsureServiceReady with different version of CF CLI

### DIFF
--- a/source/Nuke.Common/Tools/CloudFoundry/CloudFoundryTasks.cs
+++ b/source/Nuke.Common/Tools/CloudFoundry/CloudFoundryTasks.cs
@@ -4,9 +4,12 @@
 
 using System;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using Nuke.Common.Tooling;
+using Serilog;
 
 namespace Nuke.Common.Tools.CloudFoundry
 {
@@ -34,20 +37,39 @@ namespace Nuke.Common.Tools.CloudFoundry
         /// </summary>
         public static async Task CloudFoundryEnsureServiceReady(string serviceInstance)
         {
+            await CloudFoundryEnsureServiceReady(serviceInstance, TimeSpan.FromSeconds(5));
+        }
+
+        /// <summary>
+        ///   Create task which will complete when creation of an asynchronous service is complete.
+        ///   This uses polling to query it repeatedly
+        /// </summary>
+        public static async Task CloudFoundryEnsureServiceReady(string serviceInstance, TimeSpan checkInterval)
+        {
+            var guid = CloudFoundry($"service {serviceInstance} --guid", logOutput: false, logInvocation: false).First().Text;
+
             bool IsCreating()
             {
-                var commandResult = CloudFoundryGetServiceInfo(c => c
-                        .SetServiceInstance(serviceInstance))
-                    .First(x => x.Text.StartsWith("status:"))
-                    .Text;
-                var result = Regex.Match(commandResult, @"(?<=^status:\s+)[a-z].+", RegexOptions.Multiline).Value;
-                return result == "create in progress";
+                var output = CloudFoundryCurl(c => c
+                    .SetPath($"/v2/service_instances/{guid}")
+                    .DisableProcessLogOutput()
+                    .DisableProcessLogInvocation());
+
+                var response = output.StdToJson();
+                if (response.ContainsKey("error_code"))
+                    Assert.Fail($"Service creation failed with \n{response["description"]}");
+
+                return response.SelectToken("entity.last_operation.state")?.ToString() == "in progress";
             }
+
+            Log.Debug($"Waiting service {serviceInstance} to finish provisioning");
 
             while (IsCreating())
             {
-                await Task.Delay(5000);
+                await Task.Delay(checkInterval);
             }
+
+            Log.Debug($"Service {serviceInstance} is finished provisioning");
         }
     }
 }


### PR DESCRIPTION
Improve compatibility of CloudFoundryTasks.CloudFoundryEnsureServiceReady with different version of CF CLI by changing it to call API endpoint and processing resulting JSON instead of doing regex parsing on CLI text output


I confirm that the pull-request:

- [x ] Follows the contribution guidelines
- [x ] Is based on my own work
- [x ] Is in compliance with my employer
