### PR TITLE
Add missing owner parameter for SonarScanner

### DIFF
--- a/build/specifications/SonarScanner.json
+++ b/build/specifications/SonarScanner.json
@@ -34,6 +34,12 @@
             "help": "Specifies the version of your project."
           },
           {
+            "name": "Organization",
+            "type": "string",
+            "format": "/o:{value}",
+            "help": "Specifies the Organization of your project."
+          },
+          {
             "name": "Description",
             "type": "string",
             "format": "/d:sonar.projectDescription={value}",


### PR DESCRIPTION
I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer

Adds the missing parameter mentioned in #304 