### PR TITLE
Change access of abstract members from internal to public on OutputSink to allow custom implementations

### DIFF
--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesOutputSink.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesOutputSink.cs
@@ -28,7 +28,7 @@ namespace Nuke.Common.CI.AzurePipelines
         protected override string ErrorCode => "31;1";
         protected override string SuccessCode => "32;1";
 
-        internal override IDisposable WriteBlock(string text)
+        public override IDisposable WriteBlock(string text)
         {
             return DelegateDisposable.CreateBracket(
                 () => _azurePipelines.Group(text),

--- a/source/Nuke.Common/CI/Bitrise/BitriseOutputSink.cs
+++ b/source/Nuke.Common/CI/Bitrise/BitriseOutputSink.cs
@@ -21,7 +21,7 @@ namespace Nuke.Common.CI.Bitrise
         protected override string ErrorCode => "31;1";
         protected override string SuccessCode => "32;1";
 
-        internal override IDisposable WriteBlock(string text)
+        public override IDisposable WriteBlock(string text)
         {
             return DelegateDisposable.CreateBracket(
                 () => WriteNormal(FigletTransform.GetText(text, "ansi-shadow")));

--- a/source/Nuke.Common/CI/GitHubActions/GitHubActionsOutputSink.cs
+++ b/source/Nuke.Common/CI/GitHubActions/GitHubActionsOutputSink.cs
@@ -24,7 +24,7 @@ namespace Nuke.Common.CI.GitHubActions
         protected override string ErrorCode => "31;1";
         protected override string SuccessCode => "32;1";
 
-        internal override IDisposable WriteBlock(string text)
+        public override IDisposable WriteBlock(string text)
         {
             return DelegateDisposable.CreateBracket(
                 () => _githubActions.Group(text),

--- a/source/Nuke.Common/CI/GitLab/GitLabOutputSink.cs
+++ b/source/Nuke.Common/CI/GitLab/GitLabOutputSink.cs
@@ -28,7 +28,7 @@ namespace Nuke.Common.CI.GitLab
         protected override string ErrorCode => "31;1";
         protected override string SuccessCode => "32;1";
 
-        internal override IDisposable WriteBlock(string text)
+        public override IDisposable WriteBlock(string text)
         {
             return DelegateDisposable.CreateBracket(
                 () => _gitlab.BeginSection(text),

--- a/source/Nuke.Common/CI/TeamCity/TeamCityOutputSink.cs
+++ b/source/Nuke.Common/CI/TeamCity/TeamCityOutputSink.cs
@@ -29,7 +29,7 @@ namespace Nuke.Common.CI.TeamCity
         protected override string ErrorCode => "31";
         protected override string SuccessCode => "32";
 
-        internal override IDisposable WriteBlock(string text)
+        public override IDisposable WriteBlock(string text)
         {
             var stopWatch = new Stopwatch();
 
@@ -51,7 +51,7 @@ namespace Nuke.Common.CI.TeamCity
 
         protected override bool EnableWriteErrors => false;
 
-        protected override void WriteWarning(string text, string details = null)
+        public override void WriteWarning(string text, string details = null)
         {
             _teamCity.WriteWarning(text);
             if (details != null)

--- a/source/Nuke.Common/CI/TravisCI/TravisCIOutputSink.cs
+++ b/source/Nuke.Common/CI/TravisCI/TravisCIOutputSink.cs
@@ -21,7 +21,7 @@ namespace Nuke.Common.CI.TravisCI
         protected override string ErrorCode => "31;1";
         protected override string SuccessCode => "32;1";
 
-        internal override IDisposable WriteBlock(string text)
+        public override IDisposable WriteBlock(string text)
         {
             return DelegateDisposable.CreateBracket(
                 () => Console.WriteLine($"travis_fold:start:{text}"),

--- a/source/Nuke.Common/OutputSinks/AnsiColorOutputSink.cs
+++ b/source/Nuke.Common/OutputSinks/AnsiColorOutputSink.cs
@@ -56,36 +56,36 @@ namespace Nuke.Common.OutputSinks
             return $"{ErrorSequence}{text}{ResetSequence}";
         }
 
-        internal override void WriteNormal(string text)
+        public override void WriteNormal(string text)
         {
             Console.WriteLine(text);
         }
 
-        internal override void WriteTrace(string text)
+        public override void WriteTrace(string text)
         {
             Console.WriteLine(FormatTrace(text));
         }
 
-        internal override void WriteInformation(string text)
+        public override void WriteInformation(string text)
         {
             Console.WriteLine(FormatInformation(text));
         }
 
-        protected override void WriteWarning(string text, string details = null)
+        public override void WriteWarning(string text, string details = null)
         {
             Console.WriteLine(FormatWarning(text));
             if (details != null)
                 Console.WriteLine(FormatWarning(details));
         }
 
-        protected override void WriteError(string text, string details = null)
+        public override void WriteError(string text, string details = null)
         {
             Console.WriteLine(FormatError(text));
             if (details != null)
                 Console.WriteLine(FormatError(details));
         }
 
-        internal override void WriteSuccess(string text)
+        public override void WriteSuccess(string text)
         {
             Console.WriteLine(FormatSuccess(text));
         }

--- a/source/Nuke.Common/OutputSinks/OutputSink.cs
+++ b/source/Nuke.Common/OutputSinks/OutputSink.cs
@@ -33,7 +33,7 @@ namespace Nuke.Common.OutputSinks
 
         internal readonly List<Tuple<LogLevel, string>> SevereMessages = new List<Tuple<LogLevel, string>>();
 
-        internal virtual IDisposable WriteBlock(string text)
+        public virtual IDisposable WriteBlock(string text)
         {
             return DelegateDisposable.CreateBracket(
                 () =>
@@ -59,7 +59,7 @@ namespace Nuke.Common.OutputSinks
             Logger.Normal("╚═╝  ╚═══╝ ╚═════╝ ╚═╝  ╚═╝╚══════╝");
         }
 
-        internal virtual void WriteSummary(NukeBuild build)
+        public virtual void WriteSummary(NukeBuild build)
         {
             if (SevereMessages.Count > 0)
             {
@@ -259,12 +259,12 @@ namespace Nuke.Common.OutputSinks
             WriteNormal(string.Empty);
         }
 
-        internal abstract void WriteNormal(string text);
-        internal abstract void WriteSuccess(string text);
-        internal abstract void WriteTrace(string text);
-        internal abstract void WriteInformation(string text);
+        public abstract void WriteNormal(string text);
+        public  abstract void WriteSuccess(string text);
+        public  abstract void WriteTrace(string text);
+        public  abstract void WriteInformation(string text);
 
-        protected abstract void WriteWarning(string text, string details = null);
-        protected abstract void WriteError(string text, string details = null);
+        public  abstract void WriteWarning(string text, string details = null);
+        public  abstract void WriteError(string text, string details = null);
     }
 }

--- a/source/Nuke.Common/OutputSinks/SystemColorOutputSink.cs
+++ b/source/Nuke.Common/OutputSinks/SystemColorOutputSink.cs
@@ -15,34 +15,34 @@ namespace Nuke.Common.OutputSinks
     [ExcludeFromCodeCoverage]
     internal class SystemColorOutputSink : OutputSink
     {
-        internal override void WriteNormal(string text)
+        public override void WriteNormal(string text)
         {
             Console.WriteLine(text);
         }
 
-        internal override void WriteSuccess(string text)
+        public override void WriteSuccess(string text)
         {
             WriteWithColors(text, ConsoleColor.Green);
         }
 
-        internal override void WriteTrace(string text)
+        public override void WriteTrace(string text)
         {
             WriteWithColors(text, ConsoleColor.Gray);
         }
 
-        internal override void WriteInformation(string text)
+        public override void WriteInformation(string text)
         {
             WriteWithColors(text, ConsoleColor.Cyan);
         }
 
-        protected override void WriteWarning(string text, string details = null)
+        public override void WriteWarning(string text, string details = null)
         {
             WriteWithColors(text, ConsoleColor.Yellow);
             if (details != null)
                 WriteWithColors(details, ConsoleColor.Yellow);
         }
 
-        protected override void WriteError(string text, string details = null)
+        public override void WriteError(string text, string details = null)
         {
             WriteWithColors(text, ConsoleColor.Red);
             if (details != null)


### PR DESCRIPTION


I confirm that the pull-request:

- [ x] Follows the contribution guidelines
- [ x] Is based on my own work
- [ x] Is in compliance with my employer
