### PR TITLE
Set Instance to Default on first access

### DIFF
--- a/source/Nuke.Common/Host.cs
+++ b/source/Nuke.Common/Host.cs
@@ -38,7 +38,7 @@ namespace Nuke.Common
             }
         }
 
-        public static Host Instance { get; private set; }
+        public static Host Instance { get; private set; } = Default;
 
         public static Host Default =>
             AvailableTypes


### PR DESCRIPTION
Currently, the `Host.Instance` is null in case the `Host.Default` is not evaluated once.

The first access was in the static c'tor of `NukeBuild`, but this is too late for the following use case:

```csharp
class Build : NukeBuild
{
    public static int Main()
    {
        var jobStageName = GitLab.Instance.JobStage; // Here is Instance property is null
        switch (jobStageName)
        {
            case "build":
                return Execute<Build>(x => ((IBuild)x).Build);
            case "deploy":
                return Execute<Build>(x => ((IDeploy)x).Deploy);
            default:
                break;
        }
        return Execute<Build>(x => ((IPack)x).Pack);
    }
}
```
Maybe there is a better approach for this. Also, the easy workaround is just access the `Host.Default` once, before Gitlab.Instance is set. It's just not so obvious.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
