### PR TITLE
Fix nuke setup command for paths with space symbol

### DIFF
--- a/source/Nuke.GlobalTool/Program.Setup.cs
+++ b/source/Nuke.GlobalTool/Program.Setup.cs
@@ -383,7 +383,7 @@ namespace Nuke.GlobalTool
             if (solutionFile != null)
                 dictionary["Solution"] = rootDirectory.GetUnixRelativePathTo(solutionFile).ToString();
             SerializationTasks.JsonSerializeToFile(dictionary, parametersFile);
-            GitTasks.Git($"add {parametersFile}", logInvocation: false, logOutput: false);
+            GitTasks.Git($"add \"{parametersFile}\"", logInvocation: false, logOutput: false);
         }
     }
 }


### PR DESCRIPTION
I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
