### PR TITLE
Add secret flag to sonar.login to Begin and End settings

### DIFF
--- a/build/specifications/SonarScanner.json
+++ b/build/specifications/SonarScanner.json
@@ -55,6 +55,7 @@
             "name": "Login",
             "type": "string",
             "format": "/d:sonar.login={value}",
+            "secret": true,
             "help": "Specifies the username or access token to authenticate with to SonarQube. If this argument is added to the begin step, it must also be added on the end step."
           },
           {
@@ -233,6 +234,7 @@
             "name": "Login",
             "type": "string",
             "format": "/d:sonar.login={value}",
+            "secret": true,
             "help": "Specifies the username or access token to authenticate with to SonarQube. If this argument is added to the begin step, it must also be added on the end step."
           },
           {


### PR DESCRIPTION
Treats the `/d:sonar.login` as secret as usually an access-token is passed to this parameter.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
