### PR TITLE
Allow to set description from derived attributes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug Report
+description: "Requires Sponsorship 💖"
+labels: "bug :beetle:"
+body:
+  - type: markdown
+    attributes:
+      value: "***Important:** To create a bug report, you must be an active supporter of our community, i.e., a sponsor of NUKE on [GitHub](https://github.com/sponsors/matkoch)/[OpenCollective](https://opencollective.com/nuke), a frequent blogger/mentor, or greatly involved in any other recognized OSS project. High-impact bugs may be reported/fixed at any time, feature ideas may be discussed openly on [Slack](https://slofile.com/slack/nukebuildnet). Please don't take offense at this, particularly when an issue is closed with reference to this text. It is simply a time management decision. Also note, that unless being a bronze/silver/gold sponsor, there is no guarantee as of when an issue or pull-request will be acknowledged or resolved.*"
+
+  - type: input
+    id: execution_engine_version
+    attributes:
+      label: Version
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Relevant Code
+      description: What part of your build seems relevant?
+      render: code
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: What actually happened?
+      placeholder: You may skip this if a stacktrace is provided in the next field.
+  - type: textarea
+    id: stacktrace
+    attributes:
+      label: Stacktrace
+      render: code
+
+  - type: textarea
+    attributes:
+      label: Anything else we should know?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contact us on Slack
+    url: https://slofile.com/slack/nukebuildnet
+    about: Get in touch with the whole community
+  - name: Contact us on Twitter
+    url: https://twitter.com/nukebuildnet
+    about: Make it short in a tweet

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature Request
+description: "Requires Sponsorship 💖"
+labels: "enhancement :sparkles:"
+body:
+  - type: markdown
+    attributes:
+      value: "***Important:** To create a bug report, you must be an active supporter of our community, i.e., a sponsor of NUKE on [GitHub](https://github.com/sponsors/matkoch)/[OpenCollective](https://opencollective.com/nuke), a frequent blogger/mentor, or greatly involved in any other recognized OSS project. High-impact bugs may be reported/fixed at any time, feature ideas may be discussed openly on [Slack](https://slofile.com/slack/nukebuildnet). Please don't take offense at this, particularly when an issue is closed with reference to this text. It is simply a time management decision. Also note, that unless being a bronze/silver/gold sponsor, there is no guarantee as of when an issue or pull-request will be acknowledged or resolved.*"
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: What should the new feature do?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Usage Example
+      description: How would the proposed feature be used?
+      render: code
+
+  - type: textarea
+    attributes:
+      label: Alternative
+      description: What is the current alternative?

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -31,11 +31,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Cache .tmp, ~/.nuget/packages
+      - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:
           path: |
-            .tmp
+            .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', 'source/**/*.csproj') }}
       - name: Run './build.cmd Test Pack'
@@ -48,11 +48,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Cache .tmp, ~/.nuget/packages
+      - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:
           path: |
-            .tmp
+            .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', 'source/**/*.csproj') }}
       - name: Run './build.cmd Test Pack'
@@ -65,11 +65,11 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Cache .tmp, ~/.nuget/packages
+      - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:
           path: |
-            .tmp
+            .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', 'source/**/*.csproj') }}
       - name: Run './build.cmd Test Pack'

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -38,8 +38,8 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', 'source/**/*.csproj') }}
-      - name: Run './build.cmd Test Pack'
-        run: ./build.cmd Test Pack
+      - name: Run './build.cmd Test Pack Enterprise'
+        run: ./build.cmd Test Pack Enterprise
         env:
           EnterpriseAccessToken: ${{ secrets.ENTERPRISE_ACCESS_TOKEN }}
           SlackUserAccessToken: ${{ secrets.SLACK_USER_ACCESS_TOKEN }}
@@ -55,8 +55,8 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', 'source/**/*.csproj') }}
-      - name: Run './build.cmd Test Pack'
-        run: ./build.cmd Test Pack
+      - name: Run './build.cmd Test Pack Enterprise'
+        run: ./build.cmd Test Pack Enterprise
         env:
           EnterpriseAccessToken: ${{ secrets.ENTERPRISE_ACCESS_TOKEN }}
           SlackUserAccessToken: ${{ secrets.SLACK_USER_ACCESS_TOKEN }}
@@ -72,8 +72,8 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('global.json', 'source/**/*.csproj') }}
-      - name: Run './build.cmd Test Pack'
-        run: ./build.cmd Test Pack
+      - name: Run './build.cmd Test Pack Enterprise'
+        run: ./build.cmd Test Pack Enterprise
         env:
           EnterpriseAccessToken: ${{ secrets.ENTERPRISE_ACCESS_TOKEN }}
           SlackUserAccessToken: ${{ secrets.SLACK_USER_ACCESS_TOKEN }}

--- a/appveyor.continuous.yml
+++ b/appveyor.continuous.yml
@@ -36,6 +36,6 @@ artifacts:
 
 environment:
   EnterpriseAccessToken:
-    secure: xN0u4hko5f9nZKV8l87oQpE5awbItu1NaGgw2m2lX+5diHwjcCbJNKyOMP3quZm4
+    secure: NS0OfaCbCEzJFNcG9uYj36hZklejQSHYI3pOGeO3EtWntRiFv/m39AJY3c1MCjRj
   SlackUserAccessToken:
     secure: cMArtN7cGnW6zI9ryMiQZSfcv2y+6Ads8KPvZIN18IQnpTBY6zzBEyCL+1i8v4OF08HW7oY3BDIXWEMT6PdeSQ==

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ artifacts:
 
 environment:
   EnterpriseAccessToken:
-    secure: xN0u4hko5f9nZKV8l87oQpE5awbItu1NaGgw2m2lX+5diHwjcCbJNKyOMP3quZm4
+    secure: NS0OfaCbCEzJFNcG9uYj36hZklejQSHYI3pOGeO3EtWntRiFv/m39AJY3c1MCjRj
   PublicNuGetApiKey:
     secure: eeJb0U4UaZ7VnH8mfrei0NMxm3MPahOI7gLfxzGgoKLRBXKlr+8/2ayCY+uwdg7T
   SignPathApiToken:

--- a/build.ps1
+++ b/build.ps1
@@ -25,6 +25,9 @@ $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
 $env:DOTNET_MULTILEVEL_LOOKUP = 0
 $env:DOTNET_ROLL_FORWARD = "Major"
 
+#$env:NUKE_ENTERPRISE_SOURCE = "https://nuget.pkg.github.com/nuke-build/index.json"
+#$env:NUKE_ENTERPRISE_USERNAME = "nuke-bot"
+
 ###########################################################################
 # EXECUTION
 ###########################################################################
@@ -74,6 +77,10 @@ else {
 }
 
 Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+
+#if (Test-Path env:NUKE_ENTERPRISE_PASSWORD) {
+#    ExecSafe { & $env:DOTNET_EXE nuget add source $env:NUKE_ENTERPRISE_SOURCE --username $env:NUKE_ENTERPRISE_USERNAME --password $env:NUKE_ENTERPRISE_PASSWORD }
+#}
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,9 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_MULTILEVEL_LOOKUP=0
 export DOTNET_ROLL_FORWARD="Major"
 
+#export NUKE_ENTERPRISE_SOURCE="https://nuget.pkg.github.com/nuke-build/index.json"
+#export NUKE_ENTERPRISE_USERNAME="nuke-bot"
+
 ###########################################################################
 # EXECUTION
 ###########################################################################
@@ -67,6 +70,10 @@ else
 fi
 
 echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+
+#if [[ ! -z ${$NUKE_ENTERPRISE_PASSWORD+x} && "$NUKE_ENTERPRISE_PASSWORD" != "" ]]; then
+#    "$DOTNET_EXE" nuget add source "$NUKE_ENTERPRISE_SOURCE" --username "$NUKE_ENTERPRISE_USERNAME" --password "$NUKE_ENTERPRISE_PASSWORD" --store-password-in-clear-text
+#fi
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/Build.CI.AppVeyor.cs
+++ b/build/Build.CI.AppVeyor.cs
@@ -51,7 +51,7 @@ partial class Build
     {
         public const string EnterpriseAccessToken = EnterpriseAccessTokenName + ":" + EnterpriseAccessTokenValue;
         const string EnterpriseAccessTokenName = nameof(Build.EnterpriseAccessToken);
-        const string EnterpriseAccessTokenValue = "xN0u4hko5f9nZKV8l87oQpE5awbItu1NaGgw2m2lX+5diHwjcCbJNKyOMP3quZm4";
+        const string EnterpriseAccessTokenValue = "NS0OfaCbCEzJFNcG9uYj36hZklejQSHYI3pOGeO3EtWntRiFv/m39AJY3c1MCjRj";
 
         public const string NuGetApiKey = NuGetApiKeyName + ":" + NuGetApiKeyValue;
         const string NuGetApiKeyName = nameof(PublicNuGetApiKey);

--- a/build/Build.CI.AppVeyor.cs
+++ b/build/Build.CI.AppVeyor.cs
@@ -4,7 +4,7 @@
 
 using Nuke.Common.CI.AppVeyor;
 using Nuke.Components;
-#if ENTERPRISE
+#if NUKE_ENTERPRISE
 using Nuke.Enterprise.Notifications;
 #endif
 
@@ -26,7 +26,7 @@ using Nuke.Enterprise.Notifications;
             AppVeyorSecrets.TwitterAccessTokenSecret,
             AppVeyorSecrets.GitterAuthToken,
             AppVeyorSecrets.SlackWebhook,
-#if ENTERPRISE
+#if NUKE_ENTERPRISE
             AppVeyorSecrets.SlackUserAccessToken
 #endif
         })]
@@ -41,7 +41,7 @@ using Nuke.Enterprise.Notifications;
         new string[]
         {
             AppVeyorSecrets.EnterpriseAccessToken,
-#if ENTERPRISE
+#if NUKE_ENTERPRISE
             AppVeyorSecrets.SlackUserAccessToken
 #endif
         })]
@@ -85,7 +85,7 @@ partial class Build
         const string SlackWebhookName = nameof(Build.SlackWebhook);
         const string SlackWebhookValue = "xENxLITTR28hBLEY51YWMeHhxkhg1h1tLY1zGre1/hkn8u/b12lFivnxtTPuMWjAYkoPLlkJ4v39FLYPcxGYbAxRRMcJiHjrNyPtFfK6ddo=";
 
-#if ENTERPRISE
+#if NUKE_ENTERPRISE
         public const string SlackUserAccessToken = SlackUserAccessTokenName + ":" + SlackUserAccessTokenValue;
         const string SlackUserAccessTokenName = IHazSlackCredentials.Slack + nameof(IHazSlackCredentials.UserAccessToken);
         const string SlackUserAccessTokenValue = "cMArtN7cGnW6zI9ryMiQZSfcv2y+6Ads8KPvZIN18IQnpTBY6zzBEyCL+1i8v4OF08HW7oY3BDIXWEMT6PdeSQ==";

--- a/build/Build.CI.AzurePipelines.cs
+++ b/build/Build.CI.AzurePipelines.cs
@@ -11,7 +11,7 @@ using Nuke.Common.CI.AzurePipelines.Configuration;
 using Nuke.Common.Execution;
 using Nuke.Common.Tooling;
 using Nuke.Components;
-#if ENTERPRISE
+#if NUKE_ENTERPRISE
 using Nuke.Enterprise.Notifications;
 using static Nuke.Enterprise.Notifications.IHazSlackCredentials;
 #endif
@@ -24,11 +24,11 @@ using static Nuke.Enterprise.Notifications.IHazSlackCredentials;
     ImportSecrets = new[]
                     {
                         nameof(EnterpriseAccessToken),
-#if ENTERPRISE
+#if NUKE_ENTERPRISE
                         Slack + nameof(IHazSlackCredentials.UserAccessToken),
 #endif
                     },
-#if ENTERPRISE
+#if NUKE_ENTERPRISE
     ImportSystemAccessTokenAs = IHazAzurePipelinesAccessToken.AzurePipelines + nameof(IHazAzurePipelinesAccessToken.AccessToken),
 #endif
     InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -4,8 +4,7 @@
 
 using Nuke.Common.CI.GitHubActions;
 using Nuke.Components;
-using static Nuke.Components.IHazTwitterCredentials;
-#if ENTERPRISE
+#if NUKE_ENTERPRISE
 using Nuke.Enterprise.Notifications;
 using static Nuke.Enterprise.Notifications.IHazSlackCredentials;
 #endif
@@ -23,7 +22,7 @@ using static Nuke.Enterprise.Notifications.IHazSlackCredentials;
     ImportSecrets = new[]
                     {
                         nameof(EnterpriseAccessToken),
-#if ENTERPRISE
+#if NUKE_ENTERPRISE
                         Slack + nameof(IHazSlackCredentials.UserAccessToken),
 #endif
                     })]

--- a/build/Build.CI.GitHubActions.cs
+++ b/build/Build.CI.GitHubActions.cs
@@ -17,7 +17,14 @@ using static Nuke.Enterprise.Notifications.IHazSlackCredentials;
     OnPushBranchesIgnore = new[] { MasterBranch, ReleaseBranchPrefix + "/*" },
     OnPullRequestBranches = new[] { DevelopBranch },
     PublishArtifacts = false,
-    InvokedTargets = new[] { nameof(ITest.Test), nameof(IPack.Pack) },
+    InvokedTargets = new[]
+                     {
+                         nameof(ITest.Test),
+                         nameof(IPack.Pack),
+#if NUKE_ENTERPRISE
+                         nameof(Enterprise)
+#endif
+                     },
     CacheKeyFiles = new[] { "global.json", "source/**/*.csproj" },
     ImportSecrets = new[]
                     {

--- a/build/Build.Enterprise.Enable.cs
+++ b/build/Build.Enterprise.Enable.cs
@@ -14,7 +14,7 @@ using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.Git;
 using Nuke.Common.Utilities;
 
-#if !ENTERPRISE
+#if !NUKE_ENTERPRISE
 [RestartWithEnterprise]
 #endif
 partial class Build

--- a/build/Build.Enterprise.cs
+++ b/build/Build.Enterprise.cs
@@ -2,7 +2,7 @@
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
-#if ENTERPRISE
+#if NUKE_ENTERPRISE
 
 using System;
 using System.Linq;

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -16,6 +16,7 @@ using Nuke.Common.Git;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Tools.GitHub;
 using Nuke.Common.Tools.GitVersion;
 using Nuke.Common.Utilities.Collections;
 using Nuke.Components;
@@ -108,10 +109,7 @@ partial class Build
     IEnumerable<string> IReportIssues.InspectCodeFailOnCategories => new string[0];
 
     string PublicNuGetSource => "https://api.nuget.org/v3/index.json";
-
-    string GitHubRegistrySource => GitHubActions != null
-        ? $"https://nuget.pkg.github.com/{GitHubActions.GitHubRepositoryOwner}/index.json"
-        : null;
+    string GitHubRegistrySource => $"https://nuget.pkg.github.com/{GitRepository.GetGitHubOwner()}/index.json";
 
     [Parameter] [Secret] readonly string PublicNuGetApiKey;
     [Parameter] [Secret] readonly string GitHubRegistryApiKey;

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -10,6 +10,11 @@
     <NukeRootDirectory>.\..</NukeRootDirectory>
   </PropertyGroup>
 
+  <PropertyGroup Condition="Exists('..\external\enterprise\.gitignore')">
+    <NukeEnterprise>True</NukeEnterprise>
+    <AppendTargetFrameworkToOutputPath>True</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
   <!-- Test properties for MSBuild integration -->
   <PropertyGroup>
     <NukeTasksEnabled Condition="'$(NukeTasksEnabled)' == ''">False</NukeTasksEnabled>
@@ -56,19 +61,10 @@
     <ProjectReference Include="..\source\Nuke.Components\Nuke.Components.csproj" />
     <ProjectReference Include="..\source\Nuke.CodeGeneration\Nuke.CodeGeneration.csproj" />
     <ProjectReference Include="..\source\Nuke.SourceGenerators\Nuke.SourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
-  </ItemGroup>
-
-  <!-- Import Nuke.Enterprise -->
-  <PropertyGroup Condition="Exists('..\external\enterprise\.gitignore')">
-    <DefineConstants>$(DefineConstants);ENTERPRISE</DefineConstants>
-    <NukeEnterprise>True</NukeEnterprise>
-    <AppendTargetFrameworkToOutputPath>True</AppendTargetFrameworkToOutputPath>
-  </PropertyGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\external\enterprise\Nuke.Enterprise.csproj" Condition="'$(NukeEnterprise)' == 'True'" />
   </ItemGroup>
 
+  <Import Project="..\external\enterprise\Nuke.Enterprise.props" Condition="'$(NukeEnterprise)' == 'True'" />
   <Import Project="..\source\Nuke.Common\Nuke.Common.targets" />
 
 </Project>

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
@@ -35,10 +35,12 @@ on:
       - !pull_request_exclude_path
   workflow_dispatch:
     inputs:
-      NuGetApiKey:
-        description: "NuGet Api Key"
-      OtherData:
-        description: "Other Data"
+      OptionalInput:
+        description: "Optional Input"
+        required: false
+      RequiredInput:
+        description: "Required Input"
+        required: true
   schedule:
     - cron: '* 0 * * *'
 
@@ -58,8 +60,8 @@ jobs:
       - name: Run './build.cmd Test'
         run: ./build.cmd Test
         env:
-          NuGetApiKey: ${{ github.event.inputs.NuGetApiKey }}
-          OtherData: ${{ github.event.inputs.OtherData }}
+          OptionalInput: ${{ github.event.inputs.OptionalInput }}
+          RequiredInput: ${{ github.event.inputs.RequiredInput }}
       - uses: actions/upload-artifact@v1
         with:
           name: src
@@ -87,8 +89,8 @@ jobs:
       - name: Run './build.cmd Test'
         run: ./build.cmd Test
         env:
-          NuGetApiKey: ${{ github.event.inputs.NuGetApiKey }}
-          OtherData: ${{ github.event.inputs.OtherData }}
+          OptionalInput: ${{ github.event.inputs.OptionalInput }}
+          RequiredInput: ${{ github.event.inputs.RequiredInput }}
       - uses: actions/upload-artifact@v1
         with:
           name: src
@@ -116,8 +118,8 @@ jobs:
       - name: Run './build.cmd Test'
         run: ./build.cmd Test
         env:
-          NuGetApiKey: ${{ github.event.inputs.NuGetApiKey }}
-          OtherData: ${{ github.event.inputs.OtherData }}
+          OptionalInput: ${{ github.event.inputs.OptionalInput }}
+          RequiredInput: ${{ github.event.inputs.RequiredInput }}
       - uses: actions/upload-artifact@v1
         with:
           name: src

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
@@ -48,11 +48,11 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Cache .tmp, ~/.nuget/packages
+      - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:
           path: |
-            .tmp
+            .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
       - name: Run './build.cmd Test'
@@ -77,11 +77,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Cache .tmp, ~/.nuget/packages
+      - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:
           path: |
-            .tmp
+            .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
       - name: Run './build.cmd Test'
@@ -106,11 +106,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Cache .tmp, ~/.nuget/packages
+      - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:
           path: |
-            .tmp
+            .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
       - name: Run './build.cmd Test'

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=simple-triggers_attribute=GitHubActionsAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=simple-triggers_attribute=GitHubActionsAttribute.verified.txt
@@ -24,11 +24,11 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Cache .tmp, ~/.nuget/packages
+      - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:
           path: |
-            .tmp
+            .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
       - name: Run './build.cmd Test'
@@ -53,11 +53,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Cache .tmp, ~/.nuget/packages
+      - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:
           path: |
-            .tmp
+            .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
       - name: Run './build.cmd Test'
@@ -82,11 +82,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Cache .tmp, ~/.nuget/packages
+      - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v2
         with:
           path: |
-            .tmp
+            .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
       - name: Run './build.cmd Test'

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -139,7 +139,8 @@ namespace Nuke.Common.Tests.CI
                         OnPullRequestTags = new[] { "pull_request_tag" },
                         OnPullRequestIncludePaths = new[] { "pull_request_include_path" },
                         OnPullRequestExcludePaths = new[] { "pull_request_exclude_path" },
-                        OnWorkflowDispatchInputs = new[] { "NuGetApiKey", "OtherData" }
+                        OnWorkflowDispatchInputs = new[] { "OptionalInput" },
+                        OnWorkflowDispatchRequiredInputs = new[] { "RequiredInput" }
                     }
                 );
 

--- a/source/Nuke.Common/CI/Bamboo/Bamboo.cs
+++ b/source/Nuke.Common/CI/Bamboo/Bamboo.cs
@@ -17,6 +17,8 @@ namespace Nuke.Common.CI.Bamboo
     [ExcludeFromCodeCoverage]
     public class Bamboo : Host, IBuildServer
     {
+        public new static Bamboo Instance => Host.Instance as Bamboo;
+
         internal static bool IsRunningBamboo => !Environment.GetEnvironmentVariable("BAMBOO_SERVER").IsNullOrEmpty();
 
         internal Bamboo()

--- a/source/Nuke.Common/CI/Bitrise/Bitrise.cs
+++ b/source/Nuke.Common/CI/Bitrise/Bitrise.cs
@@ -18,6 +18,8 @@ namespace Nuke.Common.CI.Bitrise
     [ExcludeFromCodeCoverage]
     public class Bitrise : Host, IBuildServer
     {
+        public new static Bitrise Instance => Host.Instance as Bitrise;
+
         internal static bool IsRunningBitrise => !Environment.GetEnvironmentVariable("BITRISE_BUILD_URL").IsNullOrEmpty();
 
         private static DateTime ConvertUnixTimestamp(long timestamp)

--- a/source/Nuke.Common/CI/GitHubActions/Configuration/GitHubActionsWorkflowDispatchTrigger.cs
+++ b/source/Nuke.Common/CI/GitHubActions/Configuration/GitHubActionsWorkflowDispatchTrigger.cs
@@ -6,6 +6,7 @@ using System;
 using System.Linq;
 using JetBrains.Annotations;
 using Nuke.Common.Utilities;
+using Nuke.Common.Utilities.Collections;
 
 namespace Nuke.Common.CI.GitHubActions.Configuration
 {
@@ -13,6 +14,7 @@ namespace Nuke.Common.CI.GitHubActions.Configuration
     public class GitHubActionsWorkflowDispatchTrigger : GitHubActionsDetailedTrigger
     {
         public string[] Inputs { get; set; }
+        public string[] RequiredInputs { get; set; }
 
         public override void Write(CustomFileWriter writer)
         {
@@ -22,14 +24,18 @@ namespace Nuke.Common.CI.GitHubActions.Configuration
                 writer.WriteLine("inputs:");
                 using (writer.Indent())
                 {
-                    foreach (var input in Inputs)
+                    void WriteInput(string input, bool required)
                     {
                         writer.WriteLine($"{input}:");
                         using (writer.Indent())
                         {
                             writer.WriteLine($"description: {input.SplitCamelHumpsWithSeparator(" ", Constants.KnownWords).DoubleQuote()}");
+                            writer.WriteLine($"required: {required.ToString().ToLowerInvariant()}");
                         }
                     }
+
+                    Inputs.ForEach(x => WriteInput(x, required: false));
+                    RequiredInputs.ForEach(x => WriteInput(x, required: true));
                 }
             }
         }

--- a/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
+++ b/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
@@ -60,7 +60,7 @@ namespace Nuke.Common.CI.GitHubActions
         public string[] ImportSecrets { get; set; } = new string[0];
         public string ImportGitHubTokenAs { get; set; }
 
-        public string[] CacheIncludePatterns { get; set; } = { ".tmp", "~/.nuget/packages" };
+        public string[] CacheIncludePatterns { get; set; } = { ".nuke/temp", "~/.nuget/packages" };
         public string[] CacheExcludePatterns { get; set; } = new string[0];
         public string[] CacheKeyFiles { get; set; } = { "**/global.json", "**/*.csproj" };
 

--- a/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
+++ b/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
@@ -55,6 +55,7 @@ namespace Nuke.Common.CI.GitHubActions
         public string[] OnPullRequestIncludePaths { get; set; } = new string[0];
         public string[] OnPullRequestExcludePaths { get; set; } = new string[0];
         public string[] OnWorkflowDispatchInputs { get; set; } = new string[0];
+        public string[] OnWorkflowDispatchRequiredInputs { get; set; } = new string[0];
         public string OnCronSchedule { get; set; }
 
         public string[] ImportSecrets { get; set; } = new string[0];
@@ -148,7 +149,7 @@ namespace Nuke.Common.CI.GitHubActions
 
         protected virtual IEnumerable<(string Key, string Value)> GetImports()
         {
-            foreach (var input in OnWorkflowDispatchInputs)
+            foreach (var input in OnWorkflowDispatchInputs.Concat(OnWorkflowDispatchRequiredInputs))
                 yield return (input, $"${{{{ github.event.inputs.{input} }}}}");
 
             static string GetSecretValue(string secret)
@@ -203,11 +204,13 @@ namespace Nuke.Common.CI.GitHubActions
                              };
             }
 
-            if (OnWorkflowDispatchInputs.Length > 0)
+            if (OnWorkflowDispatchInputs.Length > 0 ||
+                OnWorkflowDispatchRequiredInputs.Length > 0)
             {
                 yield return new GitHubActionsWorkflowDispatchTrigger
                              {
-                                 Inputs = OnWorkflowDispatchInputs
+                                 Inputs = OnWorkflowDispatchInputs,
+                                 RequiredInputs = OnWorkflowDispatchRequiredInputs,
                              };
             }
 

--- a/source/Nuke.Common/CI/InvokeBuildServerConfigurationGenerationAttribute.cs
+++ b/source/Nuke.Common/CI/InvokeBuildServerConfigurationGenerationAttribute.cs
@@ -29,6 +29,9 @@ namespace Nuke.Common.CI
             if (hasConfigurationChanged.All(x => !x))
                 return;
 
+            if (build.Help)
+                return;
+
             Logger.Info("Press any key to continue...");
             Console.ReadKey();
         }

--- a/source/Nuke.Common/CI/Jenkins/Jenkins.cs
+++ b/source/Nuke.Common/CI/Jenkins/Jenkins.cs
@@ -18,6 +18,8 @@ namespace Nuke.Common.CI.Jenkins
     [ExcludeFromCodeCoverage]
     public class Jenkins : Host, IBuildServer
     {
+        public new static Jenkins Instance => Host.Instance as Jenkins;
+
         internal static bool IsRunningJenkins => !Environment.GetEnvironmentVariable("JENKINS_HOME").IsNullOrEmpty();
 
         internal Jenkins()

--- a/source/Nuke.Common/CI/TravisCI/TravisCI.cs
+++ b/source/Nuke.Common/CI/TravisCI/TravisCI.cs
@@ -18,6 +18,8 @@ namespace Nuke.Common.CI.TravisCI
     [ExcludeFromCodeCoverage]
     public class TravisCI : Host, IBuildServer
     {
+        public new static TravisCI Instance => Host.Instance as TravisCI;
+
         internal static bool IsRunningTravisCI => !Environment.GetEnvironmentVariable("TRAVIS").IsNullOrEmpty();
 
         internal TravisCI()

--- a/source/Nuke.Common/Execution/ArgumentsFromParametersFileAttribute.cs
+++ b/source/Nuke.Common/Execution/ArgumentsFromParametersFileAttribute.cs
@@ -25,6 +25,7 @@ namespace Nuke.Common.Execution
 
         public void OnBuildCreated(NukeBuild build, IReadOnlyCollection<ExecutableTarget> executableTargets)
         {
+            // TODO: probably remove
             if (!Directory.Exists(Constants.GetNukeDirectory(NukeBuild.RootDirectory)))
                 return;
 
@@ -78,11 +79,12 @@ namespace Nuke.Common.Execution
                 }
                 catch (Exception exception)
                 {
-                    throw new Exception($"Failed to parse parameters file '{file}'.", exception);
+                    throw new Exception($"Failed parsing parameters file '{file}'.", exception);
                 }
             }
 
             return new[] { (File: Constants.GetDefaultParametersFile(NukeBuild.RootDirectory), Profile: Constants.DefaultProfileName) }
+                .Where(x => File.Exists(x.File))
                 .Concat(NukeBuild.LoadedLocalProfiles.Select(x => (File: Constants.GetParametersProfileFile(NukeBuild.RootDirectory, x), Profile: x)))
                 .ForEachLazy(x => ControlFlow.Assert(File.Exists(x.File), $"File.Exists({x.File})"))
                 .SelectMany(x => Load(x.File), (x, r) => (x.Profile, r.Name, r.Values));

--- a/source/Nuke.Common/Execution/UpdateNotificationAttribute.cs
+++ b/source/Nuke.Common/Execution/UpdateNotificationAttribute.cs
@@ -20,7 +20,7 @@ namespace Nuke.Common.Execution
             if (NukeBuild.IsLocalBuild && ShouldNotify)
             {
                 Notify();
-                Logger.Info("Press any key to continue...");
+                Logger.Info("Press any key to continue without update...");
                 Console.ReadKey();
             }
         }

--- a/source/Nuke.Common/IO/AbsolutePath.cs
+++ b/source/Nuke.Common/IO/AbsolutePath.cs
@@ -98,6 +98,7 @@ namespace Nuke.Common.IO
 
         public override string ToString()
         {
+            // TODO: DoubleQuoteIfNeeded ?
             return _path;
         }
     }

--- a/source/Nuke.Common/IO/XmlTasks.cs
+++ b/source/Nuke.Common/IO/XmlTasks.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
@@ -41,6 +42,11 @@ namespace Nuke.Common.IO
 
         public static void XmlPoke(string path, string xpath, object value, params (string prefix, string uri)[] namespaces)
         {
+            XmlPoke(path, xpath, value, Encoding.UTF8, namespaces);
+        }
+
+        public static void XmlPoke(string path, string xpath, object value, Encoding encoding, params (string prefix, string uri)[] namespaces)
+        {
             var document = XDocument.Load(path, LoadOptions.PreserveWhitespace);
             var (elements, attributes) = GetObjects(document, xpath, namespaces);
 
@@ -50,7 +56,7 @@ namespace Nuke.Common.IO
             elements.SingleOrDefault()?.SetValue(value);
             attributes.SingleOrDefault()?.SetValue(value);
 
-            var writerSettings = new XmlWriterSettings { OmitXmlDeclaration = document.Declaration == null };
+            var writerSettings = new XmlWriterSettings { OmitXmlDeclaration = document.Declaration == null, Encoding = encoding };
             using var xmlWriter = XmlWriter.Create(path, writerSettings);
             document.Save(xmlWriter);
         }

--- a/source/Nuke.Common/Nuke.Common.csproj
+++ b/source/Nuke.Common/Nuke.Common.csproj
@@ -40,6 +40,7 @@
     <None Include="..\Nuke.MSBuildTasks\bin\$(Configuration)\netcoreapp2.1\publish\**\*.*" PackagePath="build\netcore" Pack="true" />
     <None Include="..\Nuke.MSBuildTasks\bin\$(Configuration)\net472\publish\**\*.*" PackagePath="build\netfx" Pack="true" />
     <None Include="..\Nuke.SourceGenerators\bin\$(Configuration)\netstandard2.0\*.dll" PackagePath="analyzers\dotnet\cs" Pack="true" />
+    <None Include="..\..\external\enterprise\bin\$(Configuration)\netcoreapp3.1\ref\Nuke.Enterprise.dll" PackagePath="build\netcore" Pack="true" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.Common/Nuke.Common.targets
+++ b/source/Nuke.Common/Nuke.Common.targets
@@ -8,6 +8,14 @@
 
   <Import Project="$(NukeTasksDirectory)\Nuke.MSBuildTasks.targets" Condition="'$(NukeTasksEnabled)' != 'False'" />
 
+  <ItemGroup Condition="'$(NukeEnterprise)' != 'True'">
+    <Reference Include="$(NukeTasksDirectory)\Nuke.Enterprise.dll" Condition="Exists('$(NukeTasksDirectory)\Nuke.Enterprise.dll')">
+      <Private>False</Private>
+      <CopyLocal>False</CopyLocal>
+      <ExternallyResolved>True</ExternallyResolved>
+    </Reference>
+  </ItemGroup>
+
   <PropertyGroup>
     <NukeScriptDirectory Condition="'$(NukeScriptDirectory)' == ''">$(NukeRootDirectory)</NukeScriptDirectory>
   </PropertyGroup>

--- a/source/Nuke.Common/Nuke.Common.targets
+++ b/source/Nuke.Common/Nuke.Common.targets
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(NukeDefaultExcludes)' != 'False'">
-    <None Remove="*.csproj.DotSettings;.editorconfig" />
+    <None Remove="*.csproj.DotSettings;.editorconfig;Directory.Build.props;Directory.Build.targets" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(NukeScriptDirectory)' != ''">
@@ -25,6 +25,7 @@
   <ItemGroup Condition="'$(NukeRootDirectory)' != ''">
     <None Include="$(NukeRootDirectory)\.nuke\parameters.json" LinkBase="config" />
     <None Include="$(NukeRootDirectory)\.nuke\parameters.*.json" LinkBase="config" />
+    <None Include="$(NukeRootDirectory)\**\Directory.Build.*" LinkBase="Directory.Build" />
     <None Include="$(NukeRootDirectory)\global.json" LinkBase="config" Condition="Exists('$(NukeRootDirectory)\global.json')" />
     <None Include="$(NukeRootDirectory)\nuget.config" LinkBase="config" Condition="Exists('$(NukeRootDirectory)\nuget.config')" />
     <None Include="$(NukeRootDirectory)\GitVersion.yml" LinkBase="config" Condition="Exists('$(NukeRootDirectory)\GitVersion.yml')" />

--- a/source/Nuke.Common/ParameterAttribute.cs
+++ b/source/Nuke.Common/ParameterAttribute.cs
@@ -39,7 +39,8 @@ namespace Nuke.Common
             Description = description;
         }
 
-        public virtual string Description { get; }
+        [CanBeNull]
+        public virtual string Description { get; set; }
 
         [CanBeNull]
         public string Name { get; set; }

--- a/source/Nuke.GlobalTool/Program.Setup.cs
+++ b/source/Nuke.GlobalTool/Program.Setup.cs
@@ -383,7 +383,7 @@ namespace Nuke.GlobalTool
             if (solutionFile != null)
                 dictionary["Solution"] = rootDirectory.GetUnixRelativePathTo(solutionFile).ToString();
             SerializationTasks.JsonSerializeToFile(dictionary, parametersFile);
-            GitTasks.Git($"add {parametersFile}", logInvocation: false, logOutput: false);
+            GitTasks.Git($"add {parametersFile.ToString().DoubleQuoteIfNeeded()}", logInvocation: false, logOutput: false);
         }
     }
 }

--- a/source/Nuke.GlobalTool/Rewriting/Cake/AbsolutePathRewriter.cs
+++ b/source/Nuke.GlobalTool/Rewriting/Cake/AbsolutePathRewriter.cs
@@ -14,7 +14,7 @@ using Nuke.Common.Utilities;
 
 namespace Nuke.GlobalTool.Rewriting.Cake
 {
-    internal class AbsolutePathRewriter : CSharpSyntaxRewriter
+    internal class AbsolutePathRewriter : SafeSyntaxRewriter
     {
         public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
         {

--- a/source/Nuke.GlobalTool/Rewriting/Cake/ClassRewriter.cs
+++ b/source/Nuke.GlobalTool/Rewriting/Cake/ClassRewriter.cs
@@ -17,7 +17,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Nuke.GlobalTool.Rewriting.Cake
 {
-    internal class ClassRewriter : CSharpSyntaxRewriter
+    internal class ClassRewriter : SafeSyntaxRewriter
     {
         private static readonly SyntaxTrivia BeginMultilineComment = SyntaxTrivia(SyntaxKind.MultiLineCommentTrivia, "/*");
         private static readonly SyntaxTrivia EndMultilineComment = SyntaxTrivia(SyntaxKind.MultiLineCommentTrivia, "*/");

--- a/source/Nuke.GlobalTool/Rewriting/Cake/FormattingRewriter.cs
+++ b/source/Nuke.GlobalTool/Rewriting/Cake/FormattingRewriter.cs
@@ -13,7 +13,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Nuke.GlobalTool.Rewriting.Cake
 {
-    internal class FormattingRewriter : CSharpSyntaxRewriter
+    internal class FormattingRewriter : SafeSyntaxRewriter
     {
         private static readonly SyntaxTrivia[] Indent = { Space, Space, Space, Space };
 

--- a/source/Nuke.GlobalTool/Rewriting/Cake/IdentifierNameRewriter.cs
+++ b/source/Nuke.GlobalTool/Rewriting/Cake/IdentifierNameRewriter.cs
@@ -14,7 +14,7 @@ using Nuke.Common.Tools.MSBuild;
 
 namespace Nuke.GlobalTool.Rewriting.Cake
 {
-    internal class IdentifierNameRewriter : CSharpSyntaxRewriter
+    internal class IdentifierNameRewriter : SafeSyntaxRewriter
     {
         private static Dictionary<string, string> Replacements =>
             new()

--- a/source/Nuke.GlobalTool/Rewriting/Cake/InvocationRewriter.cs
+++ b/source/Nuke.GlobalTool/Rewriting/Cake/InvocationRewriter.cs
@@ -14,7 +14,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Nuke.GlobalTool.Rewriting.Cake
 {
-    internal class InvocationRewriter : CSharpSyntaxRewriter
+    internal class InvocationRewriter : SafeSyntaxRewriter
     {
         private static IEnumerable<ReplacementData> Replacements =>
             new ReplacementData[]

--- a/source/Nuke.GlobalTool/Rewriting/Cake/MemberAccessRewriter.cs
+++ b/source/Nuke.GlobalTool/Rewriting/Cake/MemberAccessRewriter.cs
@@ -13,7 +13,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Nuke.GlobalTool.Rewriting.Cake
 {
-    internal class MemberAccessRewriter : CSharpSyntaxRewriter
+    internal class MemberAccessRewriter : SafeSyntaxRewriter
     {
         private Dictionary<string, string> Replacements =>
             new()

--- a/source/Nuke.GlobalTool/Rewriting/Cake/ParameterRewriter.cs
+++ b/source/Nuke.GlobalTool/Rewriting/Cake/ParameterRewriter.cs
@@ -13,7 +13,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Nuke.GlobalTool.Rewriting.Cake
 {
-    internal class ParameterRewriter : CSharpSyntaxRewriter
+    internal class ParameterRewriter : SafeSyntaxRewriter
     {
         public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
         {

--- a/source/Nuke.GlobalTool/Rewriting/Cake/RegularFieldRewriter.cs
+++ b/source/Nuke.GlobalTool/Rewriting/Cake/RegularFieldRewriter.cs
@@ -11,7 +11,7 @@ using Nuke.Common;
 
 namespace Nuke.GlobalTool.Rewriting.Cake
 {
-    internal class RegularFieldRewriter : CSharpSyntaxRewriter
+    internal class RegularFieldRewriter : SafeSyntaxRewriter
     {
         public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
         {

--- a/source/Nuke.GlobalTool/Rewriting/Cake/RemoveUsingDirectivesRewriter.cs
+++ b/source/Nuke.GlobalTool/Rewriting/Cake/RemoveUsingDirectivesRewriter.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Nuke.GlobalTool.Rewriting.Cake
 {
-    internal class RemoveUsingDirectivesRewriter : CSharpSyntaxRewriter
+    internal class RemoveUsingDirectivesRewriter : SafeSyntaxRewriter
     {
         public override SyntaxNode VisitUsingDirective(UsingDirectiveSyntax node)
         {

--- a/source/Nuke.GlobalTool/Rewriting/Cake/RenameFieldIdentifierRewriter.cs
+++ b/source/Nuke.GlobalTool/Rewriting/Cake/RenameFieldIdentifierRewriter.cs
@@ -14,7 +14,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Nuke.GlobalTool.Rewriting.Cake
 {
-    internal class RenameFieldIdentifierRewriter : CSharpSyntaxRewriter
+    internal class RenameFieldIdentifierRewriter : SafeSyntaxRewriter
     {
         private readonly Dictionary<string, string> _renames = new();
 

--- a/source/Nuke.GlobalTool/Rewriting/Cake/SafeSyntaxRewriter.cs
+++ b/source/Nuke.GlobalTool/Rewriting/Cake/SafeSyntaxRewriter.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2021 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Nuke.Common;
+
+namespace Nuke.GlobalTool.Rewriting.Cake
+{
+    internal class SafeSyntaxRewriter : CSharpSyntaxRewriter
+    {
+        public override SyntaxNode Visit(SyntaxNode node)
+        {
+            try
+            {
+                return base.Visit(node);
+            }
+            catch (Exception)
+            {
+                Logger.Warn($"Could not handle fragment '{node.ToFullString().Trim()}', skipping...");
+                return node;
+            }
+        }
+    }
+}

--- a/source/Nuke.GlobalTool/Rewriting/Cake/TargetDefinitionRewriter.cs
+++ b/source/Nuke.GlobalTool/Rewriting/Cake/TargetDefinitionRewriter.cs
@@ -13,7 +13,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Nuke.GlobalTool.Rewriting.Cake
 {
-    internal class TargetDefinitionRewriter : CSharpSyntaxRewriter
+    internal class TargetDefinitionRewriter : SafeSyntaxRewriter
     {
         public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
         {

--- a/source/Nuke.GlobalTool/Rewriting/Cake/ToolInvocationRewriter.cs
+++ b/source/Nuke.GlobalTool/Rewriting/Cake/ToolInvocationRewriter.cs
@@ -18,7 +18,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Nuke.GlobalTool.Rewriting.Cake
 {
-    internal class ToolInvocationRewriter : CSharpSyntaxRewriter
+    internal class ToolInvocationRewriter : SafeSyntaxRewriter
     {
         private static IEnumerable<ReplacementData> Replacements =>
             new ReplacementData[]


### PR DESCRIPTION
When executing `--help` to get the parameter descriptions, all KeyVaulSecrets had no description, because it was not possible to set a `Description`. As the `ParameterAttribute` is intended to be derived and it anyway allows to set null as description, we may can allow to use the setter.

This should not break existing implementations. The other option would be, that all derived ParamaterAttributes should have proper c'tors with a description and call the correct base c'tor.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
