### PR TITLE
Add support for OctoVersion

### DIFF
--- a/build/specifications/OctoVersion.json
+++ b/build/specifications/OctoVersion.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://raw.githubusercontent.com/nuke-build/nuke/master/source/Nuke.CodeGeneration/schema.json",
+  "references": [
+    "https://github.com/OctopusDeploy/OctoVersion/blob/main/README.md"
+  ],
+  "name": "OctoVersion",
+  "officialUrl": "https://github.com/OctopusDeploy/OctoVersion",
+  "packageId": "OctoVersion.Tool",
+  "packageExecutable": "OctoVersion.Tool.dll",
+  "customExecutable": true,
+  "tasks": [
+    {
+      "help": "Gets the version information for a project.",
+      "postfix": "GetVersion",
+      "returnType": "OctoVersionInfo",
+      "definiteArgument": "octoversion",
+      "settingsClass": {
+        "properties": [
+          {
+            "name": "CurrentBranch",
+            "type": "string",
+            "format": "--CurrentBranch {value}",
+            "help": "Pass in the name of the branch. If not set, OctoVersion will attempt to derive it, but this may lead to incorrect values."
+          },
+          {
+            "name": "NonPreReleaseTags",
+            "type": "List<string>",
+            "format": "--NonPreReleaseTags {value}",
+            "separator": " ",
+            "help": "Names of branches that will not get a pre-release suffix. Defaults to 'main' (with legacy support for 'master')."
+          },
+          {
+            "name": "RepositoryPath",
+            "type": "string",
+            "format": "--RepositoryPath {value}",
+            "help": "Path to the Git repository. If not set, assumes that the current working folder is the root of the repository"
+          },
+          {
+            "name": "Major",
+            "type": "int",
+            "format": "--Major {value}",
+            "help": "Override the calculated Major with a specific value."
+          },
+          {
+            "name": "Minor",
+            "type": "int",
+            "format": "--Minor {value}",
+            "help": "Override the calculated Minor with a specific value."
+          },
+          {
+            "name": "Patch",
+            "type": "int",
+            "format": "--Patch {value}",
+            "help": "Override the calculated Patch with a specific value."
+          },
+          {
+            "name": "PreReleaseTag",
+            "type": "string",
+            "format": "--PreReleaseTag {value}",
+            "help": "Override the calculated PreReleaseTag with a specific value."
+          },
+          {
+            "name": "BuildMetadata",
+            "type": "string",
+            "format": "--BuildMetadata {value}",
+            "help": "Override the calculated build metadata with a specific value."
+          },
+          {
+            "name": "FullSemVer",
+            "type": "string",
+            "format": "--FullSemVer {value}",
+            "help": "If set, this version number will override all of the other values and OctoVersion will just adopt it wholesale."
+          },
+          {
+            "name": "OutputFormats",
+            "type": "List<OctoVersionOutputFormatter>",
+            "format": "--OutputFormats {value}",
+            "help": "How to format the output. Defaults to Console."
+          },
+          {
+            "name": "Framework",
+            "type": "string",
+            "noArgument": true
+          }
+        ]
+      }
+    }
+  ],
+  "dataClasses": [
+    {
+      "name": "OctoVersionInfo",
+      "properties": [
+        {
+          "name": "Major",
+          "type": "int"
+        },
+        {
+          "name": "Minor",
+          "type": "int"
+        },
+        {
+          "name": "Patch",
+          "type": "int"
+        },
+        {
+          "name": "PreReleaseTag",
+          "type": "string"
+        },
+        {
+          "name": "PreReleaseTagWithDash",
+          "type": "string"
+        },
+        {
+          "name": "BuildMetaData",
+          "type": "string"
+        },
+        {
+          "name": "BuildMetadataWithPlus",
+          "type": "string"
+        },
+        {
+          "name": "MajorMinorPatch",
+          "type": "string"
+        },
+        {
+          "name": "NuGetCompatiblePreReleaseWithDash",
+          "type": "string"
+        },
+        {
+          "name": "FullSemVer",
+          "type": "string"
+        },
+        {
+          "name": "InformationalVersion",
+          "type": "string"
+        },
+        {
+          "name": "NuGetVersion",
+          "type": "string"
+        }
+      ]
+    }
+  ],
+  "enumerations": [
+    {
+      "name": "OctoVersionOutputFormatter",
+      "values": [
+        "Nuke",
+        "Cake",
+        "Console",
+        "QuietConsole",
+        "Environment",
+        "Json",
+        "TeamCity"
+      ]
+    }
+  ]
+}

--- a/source/Nuke.Common/Execution/Telemetry.cs
+++ b/source/Nuke.Common/Execution/Telemetry.cs
@@ -39,6 +39,7 @@ namespace Nuke.Common.Execution
             if (optoutParameter == "1" || optoutParameter.EqualsOrdinalIgnoreCase(bool.TrueString))
                 return;
 
+            throw new Exception();
             s_confirmedVersion = SuppressErrors(CheckAwareness, includeStackTrace: true);
             if (s_confirmedVersion == null)
                 return;

--- a/source/Nuke.Common/Tools/OctoVersion/OctoVersion.Generated.cs
+++ b/source/Nuke.Common/Tools/OctoVersion/OctoVersion.Generated.cs
@@ -1,0 +1,624 @@
+// Generated from https://github.com/nuke-build/nuke/blob/master/build/specifications/OctoVersion.json
+
+using JetBrains.Annotations;
+using Newtonsoft.Json;
+using Nuke.Common;
+using Nuke.Common.Execution;
+using Nuke.Common.Tooling;
+using Nuke.Common.Tools;
+using Nuke.Common.Utilities.Collections;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Nuke.Common.Tools.OctoVersion
+{
+    /// <summary>
+    ///   <p>For more details, visit the <a href="https://github.com/OctopusDeploy/OctoVersion">official website</a>.</p>
+    /// </summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    public static partial class OctoVersionTasks
+    {
+        /// <summary>
+        ///   Path to the OctoVersion executable.
+        /// </summary>
+        public static string OctoVersionPath =>
+            ToolPathResolver.TryGetEnvironmentExecutable("OCTOVERSION_EXE") ??
+            ToolPathResolver.GetPackageExecutable("OctoVersion.Tool", "OctoVersion.Tool.dll");
+        public static Action<OutputType, string> OctoVersionLogger { get; set; } = ProcessTasks.DefaultLogger;
+        /// <summary>
+        ///   <p>For more details, visit the <a href="https://github.com/OctopusDeploy/OctoVersion">official website</a>.</p>
+        /// </summary>
+        public static IReadOnlyCollection<Output> OctoVersion(string arguments, string workingDirectory = null, IReadOnlyDictionary<string, string> environmentVariables = null, int? timeout = null, bool? logOutput = null, bool? logInvocation = null, bool? logTimestamp = null, string logFile = null, Func<string, string> outputFilter = null)
+        {
+            using var process = ProcessTasks.StartProcess(OctoVersionPath, arguments, workingDirectory, environmentVariables, timeout, logOutput, logInvocation, logTimestamp, logFile, OctoVersionLogger, outputFilter);
+            process.AssertZeroExitCode();
+            return process.Output;
+        }
+        /// <summary>
+        ///   <p>Gets the version information for a project.</p>
+        ///   <p>For more details, visit the <a href="https://github.com/OctopusDeploy/OctoVersion">official website</a>.</p>
+        /// </summary>
+        /// <remarks>
+        ///   <p>This is a <a href="http://www.nuke.build/docs/authoring-builds/cli-tools.html#fluent-apis">CLI wrapper with fluent API</a> that allows to modify the following arguments:</p>
+        ///   <ul>
+        ///     <li><c>--BuildMetadata</c> via <see cref="OctoVersionGetVersionSettings.BuildMetadata"/></li>
+        ///     <li><c>--CurrentBranch</c> via <see cref="OctoVersionGetVersionSettings.CurrentBranch"/></li>
+        ///     <li><c>--FullSemVer</c> via <see cref="OctoVersionGetVersionSettings.FullSemVer"/></li>
+        ///     <li><c>--Major</c> via <see cref="OctoVersionGetVersionSettings.Major"/></li>
+        ///     <li><c>--Minor</c> via <see cref="OctoVersionGetVersionSettings.Minor"/></li>
+        ///     <li><c>--NonPreReleaseTags</c> via <see cref="OctoVersionGetVersionSettings.NonPreReleaseTags"/></li>
+        ///     <li><c>--OutputFormats</c> via <see cref="OctoVersionGetVersionSettings.OutputFormats"/></li>
+        ///     <li><c>--Patch</c> via <see cref="OctoVersionGetVersionSettings.Patch"/></li>
+        ///     <li><c>--PreReleaseTag</c> via <see cref="OctoVersionGetVersionSettings.PreReleaseTag"/></li>
+        ///     <li><c>--RepositoryPath</c> via <see cref="OctoVersionGetVersionSettings.RepositoryPath"/></li>
+        ///   </ul>
+        /// </remarks>
+        public static (OctoVersionInfo Result, IReadOnlyCollection<Output> Output) OctoVersionGetVersion(OctoVersionGetVersionSettings toolSettings = null)
+        {
+            toolSettings = toolSettings ?? new OctoVersionGetVersionSettings();
+            using var process = ProcessTasks.StartProcess(toolSettings);
+            process.AssertZeroExitCode();
+            return (GetResult(process, toolSettings), process.Output);
+        }
+        /// <summary>
+        ///   <p>Gets the version information for a project.</p>
+        ///   <p>For more details, visit the <a href="https://github.com/OctopusDeploy/OctoVersion">official website</a>.</p>
+        /// </summary>
+        /// <remarks>
+        ///   <p>This is a <a href="http://www.nuke.build/docs/authoring-builds/cli-tools.html#fluent-apis">CLI wrapper with fluent API</a> that allows to modify the following arguments:</p>
+        ///   <ul>
+        ///     <li><c>--BuildMetadata</c> via <see cref="OctoVersionGetVersionSettings.BuildMetadata"/></li>
+        ///     <li><c>--CurrentBranch</c> via <see cref="OctoVersionGetVersionSettings.CurrentBranch"/></li>
+        ///     <li><c>--FullSemVer</c> via <see cref="OctoVersionGetVersionSettings.FullSemVer"/></li>
+        ///     <li><c>--Major</c> via <see cref="OctoVersionGetVersionSettings.Major"/></li>
+        ///     <li><c>--Minor</c> via <see cref="OctoVersionGetVersionSettings.Minor"/></li>
+        ///     <li><c>--NonPreReleaseTags</c> via <see cref="OctoVersionGetVersionSettings.NonPreReleaseTags"/></li>
+        ///     <li><c>--OutputFormats</c> via <see cref="OctoVersionGetVersionSettings.OutputFormats"/></li>
+        ///     <li><c>--Patch</c> via <see cref="OctoVersionGetVersionSettings.Patch"/></li>
+        ///     <li><c>--PreReleaseTag</c> via <see cref="OctoVersionGetVersionSettings.PreReleaseTag"/></li>
+        ///     <li><c>--RepositoryPath</c> via <see cref="OctoVersionGetVersionSettings.RepositoryPath"/></li>
+        ///   </ul>
+        /// </remarks>
+        public static (OctoVersionInfo Result, IReadOnlyCollection<Output> Output) OctoVersionGetVersion(Configure<OctoVersionGetVersionSettings> configurator)
+        {
+            return OctoVersionGetVersion(configurator(new OctoVersionGetVersionSettings()));
+        }
+        /// <summary>
+        ///   <p>Gets the version information for a project.</p>
+        ///   <p>For more details, visit the <a href="https://github.com/OctopusDeploy/OctoVersion">official website</a>.</p>
+        /// </summary>
+        /// <remarks>
+        ///   <p>This is a <a href="http://www.nuke.build/docs/authoring-builds/cli-tools.html#fluent-apis">CLI wrapper with fluent API</a> that allows to modify the following arguments:</p>
+        ///   <ul>
+        ///     <li><c>--BuildMetadata</c> via <see cref="OctoVersionGetVersionSettings.BuildMetadata"/></li>
+        ///     <li><c>--CurrentBranch</c> via <see cref="OctoVersionGetVersionSettings.CurrentBranch"/></li>
+        ///     <li><c>--FullSemVer</c> via <see cref="OctoVersionGetVersionSettings.FullSemVer"/></li>
+        ///     <li><c>--Major</c> via <see cref="OctoVersionGetVersionSettings.Major"/></li>
+        ///     <li><c>--Minor</c> via <see cref="OctoVersionGetVersionSettings.Minor"/></li>
+        ///     <li><c>--NonPreReleaseTags</c> via <see cref="OctoVersionGetVersionSettings.NonPreReleaseTags"/></li>
+        ///     <li><c>--OutputFormats</c> via <see cref="OctoVersionGetVersionSettings.OutputFormats"/></li>
+        ///     <li><c>--Patch</c> via <see cref="OctoVersionGetVersionSettings.Patch"/></li>
+        ///     <li><c>--PreReleaseTag</c> via <see cref="OctoVersionGetVersionSettings.PreReleaseTag"/></li>
+        ///     <li><c>--RepositoryPath</c> via <see cref="OctoVersionGetVersionSettings.RepositoryPath"/></li>
+        ///   </ul>
+        /// </remarks>
+        public static IEnumerable<(OctoVersionGetVersionSettings Settings, OctoVersionInfo Result, IReadOnlyCollection<Output> Output)> OctoVersionGetVersion(CombinatorialConfigure<OctoVersionGetVersionSettings> configurator, int degreeOfParallelism = 1, bool completeOnFailure = false)
+        {
+            return configurator.Invoke(OctoVersionGetVersion, OctoVersionLogger, degreeOfParallelism, completeOnFailure);
+        }
+    }
+    #region OctoVersionGetVersionSettings
+    /// <summary>
+    ///   Used within <see cref="OctoVersionTasks"/>.
+    /// </summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public partial class OctoVersionGetVersionSettings : ToolSettings
+    {
+        /// <summary>
+        ///   Path to the OctoVersion executable.
+        /// </summary>
+        public override string ProcessToolPath => base.ProcessToolPath ?? GetProcessToolPath();
+        public override Action<OutputType, string> ProcessCustomLogger => OctoVersionTasks.OctoVersionLogger;
+        /// <summary>
+        ///   Pass in the name of the branch. If not set, OctoVersion will attempt to derive it, but this may lead to incorrect values.
+        /// </summary>
+        public virtual string CurrentBranch { get; internal set; }
+        /// <summary>
+        ///   Names of branches that will not get a pre-release suffix. Defaults to 'main' (with legacy support for 'master').
+        /// </summary>
+        public virtual IReadOnlyList<string> NonPreReleaseTags => NonPreReleaseTagsInternal.AsReadOnly();
+        internal List<string> NonPreReleaseTagsInternal { get; set; } = new List<string>();
+        /// <summary>
+        ///   Path to the Git repository. If not set, assumes that the current working folder is the root of the repository
+        /// </summary>
+        public virtual string RepositoryPath { get; internal set; }
+        /// <summary>
+        ///   Override the calculated Major with a specific value.
+        /// </summary>
+        public virtual int? Major { get; internal set; }
+        /// <summary>
+        ///   Override the calculated Minor with a specific value.
+        /// </summary>
+        public virtual int? Minor { get; internal set; }
+        /// <summary>
+        ///   Override the calculated Patch with a specific value.
+        /// </summary>
+        public virtual int? Patch { get; internal set; }
+        /// <summary>
+        ///   Override the calculated PreReleaseTag with a specific value.
+        /// </summary>
+        public virtual string PreReleaseTag { get; internal set; }
+        /// <summary>
+        ///   Override the calculated build metadata with a specific value.
+        /// </summary>
+        public virtual string BuildMetadata { get; internal set; }
+        /// <summary>
+        ///   If set, this version number will override all of the other values and OctoVersion will just adopt it wholesale.
+        /// </summary>
+        public virtual string FullSemVer { get; internal set; }
+        /// <summary>
+        ///   How to format the output. Defaults to Console.
+        /// </summary>
+        public virtual IReadOnlyList<OctoVersionOutputFormatter> OutputFormats => OutputFormatsInternal.AsReadOnly();
+        internal List<OctoVersionOutputFormatter> OutputFormatsInternal { get; set; } = new List<OctoVersionOutputFormatter>();
+        public virtual string Framework { get; internal set; }
+        protected override Arguments ConfigureProcessArguments(Arguments arguments)
+        {
+            arguments
+              .Add("octoversion")
+              .Add("--CurrentBranch {value}", CurrentBranch)
+              .Add("--NonPreReleaseTags {value}", NonPreReleaseTags, separator: ' ')
+              .Add("--RepositoryPath {value}", RepositoryPath)
+              .Add("--Major {value}", Major)
+              .Add("--Minor {value}", Minor)
+              .Add("--Patch {value}", Patch)
+              .Add("--PreReleaseTag {value}", PreReleaseTag)
+              .Add("--BuildMetadata {value}", BuildMetadata)
+              .Add("--FullSemVer {value}", FullSemVer)
+              .Add("--OutputFormats {value}", OutputFormats);
+            return base.ConfigureProcessArguments(arguments);
+        }
+    }
+    #endregion
+    #region OctoVersionInfo
+    /// <summary>
+    ///   Used within <see cref="OctoVersionTasks"/>.
+    /// </summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    [Serializable]
+    public partial class OctoVersionInfo : ISettingsEntity
+    {
+        public virtual int? Major { get; internal set; }
+        public virtual int? Minor { get; internal set; }
+        public virtual int? Patch { get; internal set; }
+        public virtual string PreReleaseTag { get; internal set; }
+        public virtual string PreReleaseTagWithDash { get; internal set; }
+        public virtual string BuildMetaData { get; internal set; }
+        public virtual string BuildMetadataWithPlus { get; internal set; }
+        public virtual string MajorMinorPatch { get; internal set; }
+        public virtual string NuGetCompatiblePreReleaseWithDash { get; internal set; }
+        public virtual string FullSemVer { get; internal set; }
+        public virtual string InformationalVersion { get; internal set; }
+        public virtual string NuGetVersion { get; internal set; }
+    }
+    #endregion
+    #region OctoVersionGetVersionSettingsExtensions
+    /// <summary>
+    ///   Used within <see cref="OctoVersionTasks"/>.
+    /// </summary>
+    [PublicAPI]
+    [ExcludeFromCodeCoverage]
+    public static partial class OctoVersionGetVersionSettingsExtensions
+    {
+        #region CurrentBranch
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctoVersionGetVersionSettings.CurrentBranch"/></em></p>
+        ///   <p>Pass in the name of the branch. If not set, OctoVersion will attempt to derive it, but this may lead to incorrect values.</p>
+        /// </summary>
+        [Pure]
+        public static T SetCurrentBranch<T>(this T toolSettings, string currentBranch) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.CurrentBranch = currentBranch;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="OctoVersionGetVersionSettings.CurrentBranch"/></em></p>
+        ///   <p>Pass in the name of the branch. If not set, OctoVersion will attempt to derive it, but this may lead to incorrect values.</p>
+        /// </summary>
+        [Pure]
+        public static T ResetCurrentBranch<T>(this T toolSettings) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.CurrentBranch = null;
+            return toolSettings;
+        }
+        #endregion
+        #region NonPreReleaseTags
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctoVersionGetVersionSettings.NonPreReleaseTags"/> to a new list</em></p>
+        ///   <p>Names of branches that will not get a pre-release suffix. Defaults to 'main' (with legacy support for 'master').</p>
+        /// </summary>
+        [Pure]
+        public static T SetNonPreReleaseTags<T>(this T toolSettings, params string[] nonPreReleaseTags) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NonPreReleaseTagsInternal = nonPreReleaseTags.ToList();
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctoVersionGetVersionSettings.NonPreReleaseTags"/> to a new list</em></p>
+        ///   <p>Names of branches that will not get a pre-release suffix. Defaults to 'main' (with legacy support for 'master').</p>
+        /// </summary>
+        [Pure]
+        public static T SetNonPreReleaseTags<T>(this T toolSettings, IEnumerable<string> nonPreReleaseTags) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NonPreReleaseTagsInternal = nonPreReleaseTags.ToList();
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Adds values to <see cref="OctoVersionGetVersionSettings.NonPreReleaseTags"/></em></p>
+        ///   <p>Names of branches that will not get a pre-release suffix. Defaults to 'main' (with legacy support for 'master').</p>
+        /// </summary>
+        [Pure]
+        public static T AddNonPreReleaseTags<T>(this T toolSettings, params string[] nonPreReleaseTags) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NonPreReleaseTagsInternal.AddRange(nonPreReleaseTags);
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Adds values to <see cref="OctoVersionGetVersionSettings.NonPreReleaseTags"/></em></p>
+        ///   <p>Names of branches that will not get a pre-release suffix. Defaults to 'main' (with legacy support for 'master').</p>
+        /// </summary>
+        [Pure]
+        public static T AddNonPreReleaseTags<T>(this T toolSettings, IEnumerable<string> nonPreReleaseTags) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NonPreReleaseTagsInternal.AddRange(nonPreReleaseTags);
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Clears <see cref="OctoVersionGetVersionSettings.NonPreReleaseTags"/></em></p>
+        ///   <p>Names of branches that will not get a pre-release suffix. Defaults to 'main' (with legacy support for 'master').</p>
+        /// </summary>
+        [Pure]
+        public static T ClearNonPreReleaseTags<T>(this T toolSettings) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.NonPreReleaseTagsInternal.Clear();
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Removes values from <see cref="OctoVersionGetVersionSettings.NonPreReleaseTags"/></em></p>
+        ///   <p>Names of branches that will not get a pre-release suffix. Defaults to 'main' (with legacy support for 'master').</p>
+        /// </summary>
+        [Pure]
+        public static T RemoveNonPreReleaseTags<T>(this T toolSettings, params string[] nonPreReleaseTags) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            var hashSet = new HashSet<string>(nonPreReleaseTags);
+            toolSettings.NonPreReleaseTagsInternal.RemoveAll(x => hashSet.Contains(x));
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Removes values from <see cref="OctoVersionGetVersionSettings.NonPreReleaseTags"/></em></p>
+        ///   <p>Names of branches that will not get a pre-release suffix. Defaults to 'main' (with legacy support for 'master').</p>
+        /// </summary>
+        [Pure]
+        public static T RemoveNonPreReleaseTags<T>(this T toolSettings, IEnumerable<string> nonPreReleaseTags) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            var hashSet = new HashSet<string>(nonPreReleaseTags);
+            toolSettings.NonPreReleaseTagsInternal.RemoveAll(x => hashSet.Contains(x));
+            return toolSettings;
+        }
+        #endregion
+        #region RepositoryPath
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctoVersionGetVersionSettings.RepositoryPath"/></em></p>
+        ///   <p>Path to the Git repository. If not set, assumes that the current working folder is the root of the repository</p>
+        /// </summary>
+        [Pure]
+        public static T SetRepositoryPath<T>(this T toolSettings, string repositoryPath) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.RepositoryPath = repositoryPath;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="OctoVersionGetVersionSettings.RepositoryPath"/></em></p>
+        ///   <p>Path to the Git repository. If not set, assumes that the current working folder is the root of the repository</p>
+        /// </summary>
+        [Pure]
+        public static T ResetRepositoryPath<T>(this T toolSettings) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.RepositoryPath = null;
+            return toolSettings;
+        }
+        #endregion
+        #region Major
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctoVersionGetVersionSettings.Major"/></em></p>
+        ///   <p>Override the calculated Major with a specific value.</p>
+        /// </summary>
+        [Pure]
+        public static T SetMajor<T>(this T toolSettings, int? major) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Major = major;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="OctoVersionGetVersionSettings.Major"/></em></p>
+        ///   <p>Override the calculated Major with a specific value.</p>
+        /// </summary>
+        [Pure]
+        public static T ResetMajor<T>(this T toolSettings) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Major = null;
+            return toolSettings;
+        }
+        #endregion
+        #region Minor
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctoVersionGetVersionSettings.Minor"/></em></p>
+        ///   <p>Override the calculated Minor with a specific value.</p>
+        /// </summary>
+        [Pure]
+        public static T SetMinor<T>(this T toolSettings, int? minor) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Minor = minor;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="OctoVersionGetVersionSettings.Minor"/></em></p>
+        ///   <p>Override the calculated Minor with a specific value.</p>
+        /// </summary>
+        [Pure]
+        public static T ResetMinor<T>(this T toolSettings) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Minor = null;
+            return toolSettings;
+        }
+        #endregion
+        #region Patch
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctoVersionGetVersionSettings.Patch"/></em></p>
+        ///   <p>Override the calculated Patch with a specific value.</p>
+        /// </summary>
+        [Pure]
+        public static T SetPatch<T>(this T toolSettings, int? patch) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Patch = patch;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="OctoVersionGetVersionSettings.Patch"/></em></p>
+        ///   <p>Override the calculated Patch with a specific value.</p>
+        /// </summary>
+        [Pure]
+        public static T ResetPatch<T>(this T toolSettings) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Patch = null;
+            return toolSettings;
+        }
+        #endregion
+        #region PreReleaseTag
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctoVersionGetVersionSettings.PreReleaseTag"/></em></p>
+        ///   <p>Override the calculated PreReleaseTag with a specific value.</p>
+        /// </summary>
+        [Pure]
+        public static T SetPreReleaseTag<T>(this T toolSettings, string preReleaseTag) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.PreReleaseTag = preReleaseTag;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="OctoVersionGetVersionSettings.PreReleaseTag"/></em></p>
+        ///   <p>Override the calculated PreReleaseTag with a specific value.</p>
+        /// </summary>
+        [Pure]
+        public static T ResetPreReleaseTag<T>(this T toolSettings) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.PreReleaseTag = null;
+            return toolSettings;
+        }
+        #endregion
+        #region BuildMetadata
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctoVersionGetVersionSettings.BuildMetadata"/></em></p>
+        ///   <p>Override the calculated build metadata with a specific value.</p>
+        /// </summary>
+        [Pure]
+        public static T SetBuildMetadata<T>(this T toolSettings, string buildMetadata) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.BuildMetadata = buildMetadata;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="OctoVersionGetVersionSettings.BuildMetadata"/></em></p>
+        ///   <p>Override the calculated build metadata with a specific value.</p>
+        /// </summary>
+        [Pure]
+        public static T ResetBuildMetadata<T>(this T toolSettings) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.BuildMetadata = null;
+            return toolSettings;
+        }
+        #endregion
+        #region FullSemVer
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctoVersionGetVersionSettings.FullSemVer"/></em></p>
+        ///   <p>If set, this version number will override all of the other values and OctoVersion will just adopt it wholesale.</p>
+        /// </summary>
+        [Pure]
+        public static T SetFullSemVer<T>(this T toolSettings, string fullSemVer) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.FullSemVer = fullSemVer;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="OctoVersionGetVersionSettings.FullSemVer"/></em></p>
+        ///   <p>If set, this version number will override all of the other values and OctoVersion will just adopt it wholesale.</p>
+        /// </summary>
+        [Pure]
+        public static T ResetFullSemVer<T>(this T toolSettings) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.FullSemVer = null;
+            return toolSettings;
+        }
+        #endregion
+        #region OutputFormats
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctoVersionGetVersionSettings.OutputFormats"/> to a new list</em></p>
+        ///   <p>How to format the output. Defaults to Console.</p>
+        /// </summary>
+        [Pure]
+        public static T SetOutputFormats<T>(this T toolSettings, params OctoVersionOutputFormatter[] outputFormats) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.OutputFormatsInternal = outputFormats.ToList();
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctoVersionGetVersionSettings.OutputFormats"/> to a new list</em></p>
+        ///   <p>How to format the output. Defaults to Console.</p>
+        /// </summary>
+        [Pure]
+        public static T SetOutputFormats<T>(this T toolSettings, IEnumerable<OctoVersionOutputFormatter> outputFormats) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.OutputFormatsInternal = outputFormats.ToList();
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Adds values to <see cref="OctoVersionGetVersionSettings.OutputFormats"/></em></p>
+        ///   <p>How to format the output. Defaults to Console.</p>
+        /// </summary>
+        [Pure]
+        public static T AddOutputFormats<T>(this T toolSettings, params OctoVersionOutputFormatter[] outputFormats) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.OutputFormatsInternal.AddRange(outputFormats);
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Adds values to <see cref="OctoVersionGetVersionSettings.OutputFormats"/></em></p>
+        ///   <p>How to format the output. Defaults to Console.</p>
+        /// </summary>
+        [Pure]
+        public static T AddOutputFormats<T>(this T toolSettings, IEnumerable<OctoVersionOutputFormatter> outputFormats) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.OutputFormatsInternal.AddRange(outputFormats);
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Clears <see cref="OctoVersionGetVersionSettings.OutputFormats"/></em></p>
+        ///   <p>How to format the output. Defaults to Console.</p>
+        /// </summary>
+        [Pure]
+        public static T ClearOutputFormats<T>(this T toolSettings) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.OutputFormatsInternal.Clear();
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Removes values from <see cref="OctoVersionGetVersionSettings.OutputFormats"/></em></p>
+        ///   <p>How to format the output. Defaults to Console.</p>
+        /// </summary>
+        [Pure]
+        public static T RemoveOutputFormats<T>(this T toolSettings, params OctoVersionOutputFormatter[] outputFormats) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            var hashSet = new HashSet<OctoVersionOutputFormatter>(outputFormats);
+            toolSettings.OutputFormatsInternal.RemoveAll(x => hashSet.Contains(x));
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Removes values from <see cref="OctoVersionGetVersionSettings.OutputFormats"/></em></p>
+        ///   <p>How to format the output. Defaults to Console.</p>
+        /// </summary>
+        [Pure]
+        public static T RemoveOutputFormats<T>(this T toolSettings, IEnumerable<OctoVersionOutputFormatter> outputFormats) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            var hashSet = new HashSet<OctoVersionOutputFormatter>(outputFormats);
+            toolSettings.OutputFormatsInternal.RemoveAll(x => hashSet.Contains(x));
+            return toolSettings;
+        }
+        #endregion
+        #region Framework
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctoVersionGetVersionSettings.Framework"/></em></p>
+        /// </summary>
+        [Pure]
+        public static T SetFramework<T>(this T toolSettings, string framework) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Framework = framework;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="OctoVersionGetVersionSettings.Framework"/></em></p>
+        /// </summary>
+        [Pure]
+        public static T ResetFramework<T>(this T toolSettings) where T : OctoVersionGetVersionSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.Framework = null;
+            return toolSettings;
+        }
+        #endregion
+    }
+    #endregion
+    #region OctoVersionOutputFormatter
+    /// <summary>
+    ///   Used within <see cref="OctoVersionTasks"/>.
+    /// </summary>
+    [PublicAPI]
+    [Serializable]
+    [ExcludeFromCodeCoverage]
+    [TypeConverter(typeof(TypeConverter<OctoVersionOutputFormatter>))]
+    public partial class OctoVersionOutputFormatter : Enumeration
+    {
+        public static OctoVersionOutputFormatter Nuke = (OctoVersionOutputFormatter) "Nuke";
+        public static OctoVersionOutputFormatter Cake = (OctoVersionOutputFormatter) "Cake";
+        public static OctoVersionOutputFormatter Console = (OctoVersionOutputFormatter) "Console";
+        public static OctoVersionOutputFormatter QuietConsole = (OctoVersionOutputFormatter) "QuietConsole";
+        public static OctoVersionOutputFormatter Environment = (OctoVersionOutputFormatter) "Environment";
+        public static OctoVersionOutputFormatter Json = (OctoVersionOutputFormatter) "Json";
+        public static OctoVersionOutputFormatter TeamCity = (OctoVersionOutputFormatter) "TeamCity";
+        public static implicit operator OctoVersionOutputFormatter(string value)
+        {
+            return new OctoVersionOutputFormatter { Value = value };
+        }
+    }
+    #endregion
+}

--- a/source/Nuke.Common/Tools/OctoVersion/OctoVersionAttribute.cs
+++ b/source/Nuke.Common/Tools/OctoVersion/OctoVersionAttribute.cs
@@ -1,0 +1,48 @@
+// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Nuke.Common.CI.AppVeyor;
+using Nuke.Common.CI.AzurePipelines;
+using Nuke.Common.CI.TeamCity;
+using Nuke.Common.Tooling;
+using Nuke.Common.Tools.Git;
+using Nuke.Common.ValueInjection;
+
+namespace Nuke.Common.Tools.OctoVersion
+{
+    /// <summary>
+    /// Injects an instance of <see cref="OctoVersion"/> based on the local repository.
+    /// </summary>
+    [PublicAPI]
+    [UsedImplicitly(ImplicitUseKindFlags.Default)]
+    public class OctoVersionAttribute : ValueInjectionAttributeBase
+    {
+        public bool UpdateBuildNumber { get; set; }
+        public string Framework { get; set; } = "net5.0";
+
+        public override object GetValue(MemberInfo member, object instance)
+        {
+            var version = OctoVersionTasks.OctoVersionGetVersion(s => s
+                .DisableProcessLogOutput()
+                .SetOutputFormats(OctoVersionOutputFormatter.Json)
+                .SetFramework(Framework)
+                .When(NukeBuild.IsLocalBuild, settings =>
+                    settings.SetCurrentBranch(GitTasks.GitCurrentBranch()))
+                ).Result;
+
+            if (UpdateBuildNumber)
+            {
+                AzurePipelines.Instance?.UpdateBuildNumber(version.FullSemVer);
+                TeamCity.Instance?.SetBuildNumber(version.FullSemVer);
+                AppVeyor.Instance?.UpdateBuildVersion(version.FullSemVer);
+            }
+
+            return version;
+        }
+    }
+}

--- a/source/Nuke.Common/Tools/OctoVersion/OctoVersionTasks.cs
+++ b/source/Nuke.Common/Tools/OctoVersion/OctoVersionTasks.cs
@@ -1,0 +1,48 @@
+// Copyright 2020 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Linq;
+using Newtonsoft.Json;
+using Nuke.Common.Tooling;
+using Nuke.Common.Utilities;
+using Nuke.Common.Utilities.Collections;
+
+namespace Nuke.Common.Tools.OctoVersion
+{
+    public partial class OctoVersionGetVersionSettings
+    {
+        private string GetProcessToolPath()
+        {
+            return OctoVersionTasks.GetToolPath(Framework);
+        }
+    }
+
+    public partial class OctoVersionTasks
+    {
+        internal static string GetToolPath(string framework = null)
+        {
+            return ToolPathResolver.GetPackageExecutable(
+                packageId: "OctoVersion.Tool",
+                packageExecutable: "OctoVersion.Tool.dll",
+                framework: framework);
+        }
+
+        private static OctoVersionInfo GetResult(IProcess process, OctoVersionGetVersionSettings toolSettings)
+        {
+            try
+            {
+                var output = process.Output.EnsureOnlyStd().Select(x => x.Text).ToList();
+                var settings = new JsonSerializerSettings { ContractResolver = new AllWritableContractResolver() };
+                return JsonConvert.DeserializeObject<OctoVersionInfo>(string.Join("\r\n", output), settings);
+            }
+            catch (Exception exception)
+            {
+                throw new Exception($"{nameof(OctoVersion)} exited with code {process.ExitCode}, but cannot parse output as JSON:"
+                        .Concat(process.Output.Select(x => x.Text)).JoinNewLine(),
+                    exception);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for [OctoVersion](https://github.com/OctopusDeploy/OctoVersion) as a built in tool.

This was (briefly) discussed [back in Feb](https://nukebuildnet.slack.com/archives/C9Q99MFU0/p1614107457035200?thread_ts=1614060572.028500&cid=C9Q99MFU0).

The `Nuke.OctoVersion` package (that never got published to nuget) has been removed from OctoVersion (see https://github.com/OctopusDeploy/OctoVersion/pull/38) and this PR replaces it with first class support in Nuke.

I fully expect that there'll be some changes to be done - let me know what you think!

Thanks for reviewing :tada:

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
