### PR TITLE
Update gitversion framework to net5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [vNext]
+- Added telemetry data collection
+- Added unified `NukeBuild.Partition` property
+- Added `Rider`, `VisualStudio`, `VSCode` as `Host` implementations
+- Added `GitRepository.IsOnMainBranch` and `IsOnMainOrMasterBranch`
+- Added `AbsolutePath` equality operators
+- Fixed SpaceAutomation to generate default `refSpec`
+- Changed `Microsoft.CodeAnalysis.CSharp` package version to `3.9.0`
+- Removed `Refit` reference and `ITeamCityRestClient` interface
+- Removed `Colorful.Console` reference and embedded figlet fonts
 
 ## [5.1.4] / 2021-06-01
 - Fixed `StronglyTypedSolutionGenerator` to resolve root directory only on demand

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -15,6 +15,7 @@ using Nuke.Common.Execution;
 using Nuke.Common.Git;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
+using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Tools.GitVersion;
 using Nuke.Common.Utilities.Collections;
@@ -87,6 +88,9 @@ partial class Build
         select (project, framework);
 
     IEnumerable<Project> ITest.TestProjects => Partition.GetCurrent(Solution.GetProjects("*.Tests"));
+
+    Configure<DotNetTestSettings> ITest.TestSettings => _ => _
+        .AddProcessEnvironmentVariable("NUKE_TELEMETRY_OPTOUT", bool.TrueString);
 
     Target ITest.Test => _ => _
         .Inherit<ITest>()

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -8,6 +8,7 @@
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>.\..</NukeRootDirectory>
+    <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="Exists('..\external\enterprise\.gitignore')">

--- a/source/Nuke.Common/CI/InvokeBuildServerConfigurationGenerationAttribute.cs
+++ b/source/Nuke.Common/CI/InvokeBuildServerConfigurationGenerationAttribute.cs
@@ -25,7 +25,7 @@ namespace Nuke.Common.CI
             var hasConfigurationChanged = GetGenerators(build)
                 .Where(x => x.AutoGenerate)
                 .AsParallel()
-                .Select(HasConfigurationChanged).ToList();
+                .Select(x => HasConfigurationChanged(x, build)).ToList();
             if (hasConfigurationChanged.All(x => !x))
                 return;
 
@@ -36,7 +36,7 @@ namespace Nuke.Common.CI
             Console.ReadKey();
         }
 
-        private bool HasConfigurationChanged(IConfigurationGenerator generator)
+        private bool HasConfigurationChanged(IConfigurationGenerator generator, NukeBuild build)
         {
             generator.GeneratedFiles.ForEach(FileSystemTasks.EnsureExistingParentDirectory);
             var previousHashes = generator.GeneratedFiles
@@ -58,6 +58,7 @@ namespace Nuke.Common.CI
             if (changedFiles.Count == 0)
                 return false;
 
+            Telemetry.ConfigurationGenerated(generator.HostType, generator.Id, build);
             Logger.Warn($"{generator.DisplayName} configuration files have changed.");
             changedFiles.ForEach(x => Logger.Trace($"Updated {x}"));
             return true;

--- a/source/Nuke.Common/CI/TeamCity/TeamCity.cs
+++ b/source/Nuke.Common/CI/TeamCity/TeamCity.cs
@@ -17,7 +17,6 @@ using Nuke.Common.OutputSinks;
 using Nuke.Common.Tools.DotCover;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
-using Refit;
 
 namespace Nuke.Common.CI.TeamCity
 {

--- a/source/Nuke.Common/Execution/Telemetry.Events.cs
+++ b/source/Nuke.Common/Execution/Telemetry.Events.cs
@@ -1,0 +1,85 @@
+﻿// Copyright 2021 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Nuke.Common.Utilities;
+using Nuke.Common.Utilities.Collections;
+
+namespace Nuke.Common.Execution
+{
+    internal partial class Telemetry
+    {
+        public static void BuildStarted(NukeBuild build)
+        {
+            TrackEvent(
+                eventName: nameof(BuildStarted),
+                properties: GetCommonProperties(build)
+                    .AddDictionary(GetBuildProperties(build))
+                    .AddDictionary(GetRepositoryProperties(NukeBuild.RootDirectory)));
+        }
+
+        public static void TargetSucceeded(ExecutableTarget target, NukeBuild build)
+        {
+            if (target.Name.EqualsAnyOrdinalIgnoreCase(s_knownTargets) &&
+                target.Status == ExecutionStatus.Succeeded)
+            {
+                TrackEvent(
+                    eventName: nameof(TargetSucceeded),
+                    properties: GetCommonProperties(build)
+                        .AddDictionary(GetTargetProperties(build, target))
+                        .AddDictionary(GetBuildProperties(build))
+                        .AddDictionary(GetRepositoryProperties(NukeBuild.RootDirectory)));
+            }
+        }
+
+        public static void ConfigurationGenerated(Type hostType, string generatorId, NukeBuild build)
+        {
+            TrackEvent(
+                eventName: nameof(ConfigurationGenerated),
+                properties: GetCommonProperties(build)
+                    .AddDictionary(GetGeneratorProperties(hostType, generatorId))
+                    .AddDictionary(GetBuildProperties(build))
+                    .AddDictionary(GetRepositoryProperties(EnvironmentInfo.WorkingDirectory)));
+        }
+
+        public static void SetupBuild()
+        {
+            TrackEvent(
+                eventName: nameof(SetupBuild),
+                properties: GetCommonProperties()
+                    .AddDictionary(GetRepositoryProperties(EnvironmentInfo.WorkingDirectory)));
+        }
+
+        public static void ConvertCake()
+        {
+            TrackEvent(
+                eventName: nameof(ConvertCake),
+                properties: GetCommonProperties()
+                    .AddDictionary(GetRepositoryProperties(EnvironmentInfo.WorkingDirectory)));
+        }
+
+        public static void AddPackage()
+        {
+            TrackEvent(
+                eventName: nameof(AddPackage),
+                properties: GetCommonProperties()
+                    .AddDictionary(GetRepositoryProperties(EnvironmentInfo.WorkingDirectory)));
+        }
+
+        private static void TrackEvent(
+            string eventName,
+            IDictionary<string, string> properties = null,
+            IDictionary<string, double> metrics = null)
+        {
+            Logger.Trace($"Sending '{eventName}' telemetry event...");
+            var longestPropertyName = properties?.Keys.Max(x => x.Length);
+            properties?.OrderBy(x => x.Key).ForEach(x => Logger.Trace($"  {x.Key.PadRight(longestPropertyName.Value)} = {x.Value ?? "<null>"}"));
+
+            s_client?.TrackEvent(eventName, properties, metrics);
+            s_client?.Flush();
+        }
+    }
+}

--- a/source/Nuke.Common/Execution/Telemetry.Properties.cs
+++ b/source/Nuke.Common/Execution/Telemetry.Properties.cs
@@ -1,0 +1,143 @@
+﻿// Copyright 2021 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Nuke.Common.CI;
+using Nuke.Common.Git;
+using Nuke.Common.Tooling;
+using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Utilities;
+using Nuke.Common.Utilities.Collections;
+using Nuke.Common.ValueInjection;
+
+namespace Nuke.Common.Execution
+{
+    internal partial class Telemetry
+    {
+        private static readonly string[] s_knownTargets = { "Restore", "Compile", "Test" };
+
+        private static IDictionary<string, string> GetCommonProperties(NukeBuild build = null)
+        {
+            var process = ProcessTasks.StartProcess(DotNetTasks.DotNetPath, "--version", logInvocation: false, logOutput: false).AssertWaitForExit();
+
+            return new Dictionary<string, string>
+                   {
+                       ["os_platform"] = EnvironmentInfo.Platform.ToString(),
+                       ["os_architecture"] = RuntimeInformation.OSArchitecture.ToString(),
+                       ["version_dotnet_sdk"] = process.ExitCode == 0 ? process.Output.First().Text : null,
+                       ["version_nuke_common"] = build != null ? typeof(NukeBuild).Assembly.GetVersionText() : null,
+                       ["version_nuke_global_tool"] = build != null
+                           ? EnvironmentInfo.Variables.GetValueOrDefault(Constants.GlobalToolVersionEnvironmentKey)
+                           : Assembly.GetEntryAssembly().GetVersionText()
+                   };
+        }
+
+        private static IDictionary<string, string> GetRepositoryProperties(string directory)
+        {
+            var repository = ControlFlow.SuppressErrors(() => GitRepository.FromLocalDirectory(directory), logWarning: false);
+            if (repository == null)
+                return new Dictionary<string, string>();
+
+            var providers =
+                new List<(Func<bool>, string)>
+                {
+                    (() => repository.Endpoint.ContainsOrdinalIgnoreCase("github.com"), "GitHub"),
+                    (() => repository.Endpoint.ContainsOrdinalIgnoreCase("gitlab.com"), "GitLab"),
+                    (() => repository.Endpoint.ContainsOrdinalIgnoreCase("bitbucket.org"), "Bitbucket"),
+                    (() => repository.Endpoint.ContainsOrdinalIgnoreCase("jetbrains.space"), "JetBrains")
+                };
+
+            var branches =
+                new List<(Func<bool>, string)>
+                {
+                    (() => repository.IsOnMainOrMasterBranch(), "main"),
+                    (() => repository.IsOnDevelopBranch(), "develop"),
+                    (() => repository.IsOnReleaseBranch(), "release"),
+                    (() => repository.IsOnHotfixBranch(), "hotfix")
+                };
+
+            return new Dictionary<string, string>
+                   {
+                       ["repo_provider"] = providers.FirstOrDefault(x => x.Item1.Invoke()).Item2,
+                       ["repo_branch"] = branches.FirstOrDefault(x => x.Item1.Invoke()).Item2,
+                       ["repo_url"] = repository.SshUrl.GetSHA256Hash().Substring(startIndex: 0, length: 6),
+                       ["repo_commit"] = repository.Commit.GetSHA256Hash().Substring(startIndex: 0, length: 6)
+                   };
+        }
+
+        private static IDictionary<string, string> GetBuildProperties(NukeBuild build)
+        {
+            var startTimeString = EnvironmentInfo.Variables.GetValueOrDefault(Constants.GlobalToolStartTimeEnvironmentKey);
+            var compileTime = startTimeString != null
+                ? DateTime.Now.Subtract(DateTime.Parse(startTimeString))
+                : default(TimeSpan?);
+
+            return new Dictionary<string, string>
+                   {
+                       ["compile_time"] = compileTime?.TotalSeconds.ToString("F0"),
+                       ["target_framework"] = EnvironmentInfo.Framework.ToString(),
+                       ["host"] = GetTypeName(NukeBuild.Host),
+                       ["build_type"] = NukeBuild.BuildProjectFile != null ? "Project" : "Global Tool",
+                       ["num_targets"] = build.ExecutableTargets.Count.ToString(),
+                       ["num_custom_extensions"] = build.BuildExtensions.Select(x => x.GetType()).Count(IsCustomType).ToString(),
+                       ["num_custom_components"] = build.GetType().GetInterfaces().Count(IsCustomType).ToString(),
+                       ["num_partitioned_targets"] = build.ExecutableTargets.Count(x => x.PartitionSize.HasValue).ToString(),
+                       ["num_secrets"] = ValueInjectionUtility.GetParameterMembers(build.GetType(), includeUnlisted: true)
+                           .Count(x => x.HasCustomAttribute<SecretAttribute>()).ToString(),
+                       ["config_generators"] = build.GetType().GetCustomAttributes<ConfigurationAttributeBase>()
+                           .Select(GetTypeName).Distinct().OrderBy(x => x).JoinComma(),
+                       ["build_components"] = build.GetType().GetInterfaces().Where(x => IsCommonType(x) && x != typeof(INukeBuild))
+                           .Select(GetTypeName).Distinct().OrderBy(x => x).JoinComma()
+                   };
+        }
+
+        private static IDictionary<string, string> GetTargetProperties(NukeBuild build, ExecutableTarget target)
+        {
+            return new Dictionary<string, string>
+                   {
+                       ["target_name"] = target.Name,
+                       ["target_duration"] = target.Duration.TotalSeconds.ToString("F0"),
+                       ["target_current_partition"] = build.Partition.Part.ToString(),
+                       ["target_total_partitions"] = build.Partition.Total.ToString()
+                   };
+        }
+
+        private static IDictionary<string, string> GetGeneratorProperties(Type hostType, string generatorId)
+        {
+            return new Dictionary<string, string>
+                   {
+                       ["generator_host"] = GetTypeName(hostType),
+                       ["generator_id"] = generatorId.GetSHA256Hash().Substring(startIndex: 0, length: 6)
+                   };
+        }
+
+        private static bool IsCommonType(Type type)
+        {
+            return type.Assembly == typeof(NukeBuild).Assembly;
+        }
+
+        private static bool IsCustomType(Type type)
+        {
+            return !IsCommonType(type);
+        }
+
+        private static string GetTypeName(Type type)
+        {
+            return IsCommonType(type)
+                ? type.Name.TrimEnd(nameof(Attribute))
+                : type.Descendants(x => x.BaseType).FirstOrDefault(IsCommonType) is { } commonType
+                    ? $"{GetTypeName(commonType)} (Custom)"
+                    : "<Custom>";
+        }
+
+        private static string GetTypeName(object obj)
+        {
+            return GetTypeName(obj.GetType());
+        }
+    }
+}

--- a/source/Nuke.Common/Execution/Telemetry.cs
+++ b/source/Nuke.Common/Execution/Telemetry.cs
@@ -1,0 +1,127 @@
+﻿// Copyright 2021 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+using Nuke.Common.Utilities;
+using static Nuke.Common.ControlFlow;
+
+namespace Nuke.Common.Execution
+{
+    internal static partial class Telemetry
+    {
+        // https://docs.microsoft.com/en-us/dotnet/core/tools/telemetry
+        // https://dotnet.microsoft.com/platform/telemetry
+
+        public const int CurrentVersion = 1;
+
+        private const string InstrumentationKey = "4b987be9-f807-4846-b777-4291f3a5ad8b";
+        private const string OptOutEnvironmentKey = "NUKE_TELEMETRY_OPTOUT";
+        private const string VersionPropertyName = "NukeTelemetryVersion";
+
+        private static readonly TelemetryClient s_client;
+        private static readonly int? s_confirmedVersion;
+
+        static Telemetry()
+        {
+            var optoutParameter = EnvironmentInfo.GetParameter<string>(OptOutEnvironmentKey) ?? string.Empty;
+            if (optoutParameter == "1" || optoutParameter.EqualsOrdinalIgnoreCase(bool.TrueString))
+                return;
+
+            s_confirmedVersion = SuppressErrors(CheckAwareness, includeStackTrace: true);
+            if (s_confirmedVersion == null)
+                return;
+
+            var configuration = TelemetryConfiguration.CreateDefault();
+            s_client = new TelemetryClient(configuration) { InstrumentationKey = InstrumentationKey };
+            s_client.Context.Session.Id = Guid.NewGuid().ToString();
+            s_client.Context.Location.Ip = "N/A";
+            s_client.Context.Cloud.RoleInstance = "N/A";
+        }
+
+        private static int? CheckAwareness()
+        {
+            string GetCookieFile(string name, int version)
+                => Constants.GlobalNukeDirectory / "telemetry-awareness" / $"v{version}" / name;
+
+            if (NukeBuild.BuildProjectFile == null)
+            {
+                var cookieName = Assembly.GetEntryAssembly().NotNull().GetName().Name;
+                var cookieFile = GetCookieFile(cookieName, CurrentVersion);
+                if (!File.Exists(cookieFile))
+                {
+                    PrintDisclosure($"to create awareness cookie for {cookieName.SingleQuote()}");
+                    FileSystemTasks.Touch(cookieFile);
+                }
+
+                return CurrentVersion;
+            }
+
+            var project = ProjectModelTasks.ParseProject(NukeBuild.BuildProjectFile);
+            var property = project.Properties.SingleOrDefault(x => x.Name.EqualsOrdinalIgnoreCase(VersionPropertyName));
+            if (property?.EvaluatedValue != CurrentVersion.ToString())
+            {
+                if (NukeBuild.Host is not Terminal)
+                {
+                    PrintDisclosure(action: null);
+                    return null;
+                }
+
+                PrintDisclosure($"to set the {VersionPropertyName.SingleQuote()} property");
+                project.SetProperty(VersionPropertyName, CurrentVersion.ToString());
+                project.Save();
+            }
+
+            for (var version = CurrentVersion; version > 0; version--)
+            {
+                if (File.Exists(GetCookieFile("Nuke.GlobalTool", version)))
+                    return version;
+            }
+
+            return CurrentVersion;
+        }
+
+        private static void PrintDisclosure(string action)
+        {
+            var disclosure =
+                new[]
+                {
+                    $"Telemetry v{CurrentVersion}",
+                    "------------",
+                    "NUKE collects anonymous usage data in order to help us improve your experience.",
+                    string.Empty,
+                    "Read more about scope, data points, and opt-out: https://nuke.build/docs/getting-started/telemetry.html",
+                    string.Empty
+                }.JoinNewLine();
+
+            if (action != null)
+            {
+                Logger.Info(disclosure);
+                Thread.Sleep(3000);
+                Logger.Info($"Press <Enter> to {action}...");
+                WaitForEnter();
+            }
+            else
+            {
+                Logger.Warn(disclosure);
+            }
+        }
+
+        private static void WaitForEnter()
+        {
+            ConsoleKey response;
+            do
+            {
+                response = Console.ReadKey(intercept: true).Key;
+            } while (response != ConsoleKey.Enter);
+        }
+    }
+}

--- a/source/Nuke.Common/Execution/TelemetryAttribute.cs
+++ b/source/Nuke.Common/Execution/TelemetryAttribute.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2021 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nuke.Common.Execution
+{
+    internal class TelemetryAttribute
+        : BuildExtensionAttributeBase,
+            IOnBuildInitialized,
+            IOnTargetSucceeded
+    {
+        public void OnBuildInitialized(
+            NukeBuild build,
+            IReadOnlyCollection<ExecutableTarget> executableTargets,
+            IReadOnlyCollection<ExecutableTarget> executionPlan)
+        {
+            Telemetry.BuildStarted(build);
+        }
+
+        public void OnTargetSucceeded(NukeBuild build, ExecutableTarget target)
+        {
+            Telemetry.TargetSucceeded(target, build);
+        }
+    }
+}

--- a/source/Nuke.Common/Nuke.Common.csproj
+++ b/source/Nuke.Common/Nuke.Common.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NuGet.Packaging" Version="5.3.1" />
     <PackageReference Include="Octokit" Version="0.36.0" />
-    <PackageReference Include="Refit" Version="5.0.23" />
     <PackageReference Include="SharpZipLib" Version="1.1.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />

--- a/source/Nuke.Common/NukeBuild.cs
+++ b/source/Nuke.Common/NukeBuild.cs
@@ -55,6 +55,7 @@ namespace Nuke.Common
     // [LoadBuildProfiles(Priority = 25)]
     // After logo
     [HandleHelpRequests(Priority = 5)]
+    [Telemetry]
     [HandleVisualStudioDebugging]
     [InjectNonParameterValues(Priority = -100)]
     // After finish

--- a/source/Nuke.Common/Tools/GitVersion/GitVersionAttribute.cs
+++ b/source/Nuke.Common/Tools/GitVersion/GitVersionAttribute.cs
@@ -23,7 +23,7 @@ namespace Nuke.Common.Tools.GitVersion
     [UsedImplicitly(ImplicitUseKindFlags.Default)]
     public class GitVersionAttribute : ValueInjectionAttributeBase
     {
-        public string Framework { get; set; } = "netcoreapp3.0";
+        public string Framework { get; set; } = "net5.0";
         public bool DisableOnUnix { get; set; }
         public bool UpdateAssemblyInfo { get; set; }
         public bool UpdateBuildNumber { get; set; } = true;

--- a/source/Nuke.Common/Tools/Slack/SlackTasks.cs
+++ b/source/Nuke.Common/Tools/Slack/SlackTasks.cs
@@ -23,6 +23,7 @@ namespace Nuke.Common.Tools.Slack
     [PublicAPI]
     public static class SlackTasks
     {
+#if NETCORE
         public static void SendSlackMessage(Configure<SlackMessage> configurator, string webhook)
         {
             SendSlackMessageAsync(configurator, webhook).Wait();
@@ -57,6 +58,7 @@ namespace Nuke.Common.Tools.Slack
             var responseText = Encoding.UTF8.GetString(response);
             ControlFlow.Assert(responseText == "ok", $"'{responseText}' == 'ok'");
         }
+#endif
 
         public static async Task<string> SendOrUpdateSlackMessage(Configure<SlackMessage> configurator, string accessToken)
         {

--- a/source/Nuke.GlobalTool/Program.AddPackage.cs
+++ b/source/Nuke.GlobalTool/Program.AddPackage.cs
@@ -6,6 +6,7 @@ using System;
 using System.Linq;
 using JetBrains.Annotations;
 using Nuke.Common;
+using Nuke.Common.Execution;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
@@ -21,6 +22,8 @@ namespace Nuke.GlobalTool
         [UsedImplicitly]
         public static int AddPackage(string[] args, [CanBeNull] AbsolutePath rootDirectory, [CanBeNull] AbsolutePath buildScript)
         {
+            Telemetry.AddPackage();
+
             var packageId = args.ElementAt(0);
             var packageVersion =
                 (EnvironmentInfo.GetParameter<string>("version") ??

--- a/source/Nuke.GlobalTool/Program.Cake.cs
+++ b/source/Nuke.GlobalTool/Program.Cake.cs
@@ -10,6 +10,7 @@ using JetBrains.Annotations;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Nuke.Common;
+using Nuke.Common.Execution;
 using Nuke.Common.IO;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
@@ -27,6 +28,7 @@ namespace Nuke.GlobalTool
         [UsedImplicitly]
         public static int CakeConvert(string[] args, [CanBeNull] AbsolutePath rootDirectory, [CanBeNull] AbsolutePath buildScript)
         {
+            Telemetry.ConvertCake();
             Logger.Warn(
                 new[]
                 {

--- a/source/Nuke.GlobalTool/Program.GetConfiguration.cs
+++ b/source/Nuke.GlobalTool/Program.GetConfiguration.cs
@@ -40,8 +40,8 @@ namespace Nuke.GlobalTool
             string ReplaceScriptDirectory(string value)
                 => evaluate
                     ? value
-                        .Replace("$SCRIPT_DIR", buildScript.NotNull().Parent)
-                        .Replace("$PSScriptRoot", buildScript.NotNull().Parent)
+                        .Replace("$SCRIPT_DIR", buildScript.Parent)
+                        .Replace("$PSScriptRoot", buildScript.Parent)
                     : value;
 
             return File.ReadAllLines(buildScript)

--- a/source/Nuke.GlobalTool/Program.Setup.cs
+++ b/source/Nuke.GlobalTool/Program.Setup.cs
@@ -10,9 +10,9 @@ using System.Reflection;
 using System.Text;
 using JetBrains.Annotations;
 using Nuke.Common;
+using Nuke.Common.Execution;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
-using Nuke.Common.Tools.Git;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
 using static Nuke.Common.Constants;
@@ -58,12 +58,13 @@ namespace Nuke.GlobalTool
         public static int Setup(string[] args, [CanBeNull] AbsolutePath rootDirectory, [CanBeNull] AbsolutePath buildScript)
         {
             PrintInfo();
+            Telemetry.SetupBuild();
 
             #region Basic
 
-            var nukeLatestReleaseVersion = NuGetPackageResolver.GetLatestPackageVersion("Nuke.Common", includePrereleases: false);
-            var nukeLatestPrereleaseVersion = NuGetPackageResolver.GetLatestPackageVersion("Nuke.Common", includePrereleases: true);
-            var nukeLatestLocalVersion = NuGetPackageResolver.GetGlobalInstalledPackage("Nuke.Common", version: null, packagesConfigFile: null)
+            var nukeLatestReleaseVersion = NuGetPackageResolver.GetLatestPackageVersion(NukeCommonPackageId, includePrereleases: false);
+            var nukeLatestPrereleaseVersion = NuGetPackageResolver.GetLatestPackageVersion(NukeCommonPackageId, includePrereleases: true);
+            var nukeLatestLocalVersion = NuGetPackageResolver.GetGlobalInstalledPackage(NukeCommonPackageId, version: null, packagesConfigFile: null)
                 ?.Version.ToString();
 
             if (rootDirectory == null)
@@ -228,6 +229,7 @@ namespace Nuke.GlobalTool
                                 BuildProjectName = buildProjectName,
                                 BuildProjectGuid = buildProjectGuid,
                                 TargetFramework = targetFramework,
+                                TelemetryVersion = Telemetry.CurrentVersion,
                                 NukeVersion = nukeVersion,
                                 NukeVersionMajorMinor = nukeVersion.Split(".").Take(2).Join(".")
                             }))));

--- a/source/Nuke.GlobalTool/templates/_build.sdk.csproj
+++ b/source/Nuke.GlobalTool/templates/_build.sdk.csproj
@@ -7,6 +7,7 @@
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>_ROOT_DIRECTORY_</NukeRootDirectory>
     <NukeScriptDirectory>_SCRIPT_DIRECTORY_</NukeScriptDirectory>
+    <NukeTelemetryVersion>_TELEMETRY_VERSION_</NukeTelemetryVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION

In https://github.com/nuke-build/nuke/pull/766#issuecomment-875151514, it was suggested to make OctoVersion target `netcoreapp3.1` by default, rather than the current `net5.0`, to align with Gitversion.

However, we discovered that GitVersion currently targets `netcoreapp3.0` instead, which is no longer shipped in the [nuget package](https://www.nuget.org/packages/GitVersion.Tool/5.6.11).

This PR bumps the default GitVersion framework to `net5.0`, to match both OctoVersion and GitVersion.

Before this change, adding the line
```
[GitVersion(UpdateBuildNumber = false)] GitVersion GitVersion;
```
resulted in 
```
Assertion failed: Package executable GitVersion.dll or GitVersion.exe [GitVersion.Tool|GitVersion.CommandLine] requires a framework:
 - net5.0
 - netcoreapp3.1
```

Now, it "just works".

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
