### PR TITLE
Adds LFS and Submodule support to Azure Pipelines YAML

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
@@ -46,6 +46,9 @@ stages:
         displayName: 'Restore'
         dependsOn: [  ]
         steps:
+          - checkout: self
+            lfs: true
+            submodules: true
           - task: Cache@2
             inputs:
               key: $(Agent.OS) | **/global.json, **/*.csproj
@@ -65,6 +68,9 @@ stages:
         displayName: 'Compile'
         dependsOn: [ Restore ]
         steps:
+          - checkout: self
+            lfs: true
+            submodules: true
           - task: Cache@2
             inputs:
               key: $(Agent.OS) | **/global.json, **/*.csproj
@@ -86,6 +92,9 @@ stages:
         strategy:
           parallel: 2
         steps:
+          - checkout: self
+            lfs: true
+            submodules: true
           - task: Cache@2
             inputs:
               key: $(Agent.OS) | **/global.json, **/*.csproj
@@ -105,6 +114,9 @@ stages:
         displayName: 'Coverage'
         dependsOn: [ Test ]
         steps:
+          - checkout: self
+            lfs: true
+            submodules: true
           - task: Cache@2
             inputs:
               key: $(Agent.OS) | **/global.json, **/*.csproj
@@ -130,6 +142,9 @@ stages:
         displayName: 'Restore'
         dependsOn: [  ]
         steps:
+          - checkout: self
+            lfs: true
+            submodules: true
           - task: Cache@2
             inputs:
               key: $(Agent.OS) | **/global.json, **/*.csproj
@@ -149,6 +164,9 @@ stages:
         displayName: 'Compile'
         dependsOn: [ Restore ]
         steps:
+          - checkout: self
+            lfs: true
+            submodules: true
           - task: Cache@2
             inputs:
               key: $(Agent.OS) | **/global.json, **/*.csproj
@@ -170,6 +188,9 @@ stages:
         strategy:
           parallel: 2
         steps:
+          - checkout: self
+            lfs: true
+            submodules: true
           - task: Cache@2
             inputs:
               key: $(Agent.OS) | **/global.json, **/*.csproj
@@ -189,6 +210,9 @@ stages:
         displayName: 'Coverage'
         dependsOn: [ Test ]
         steps:
+          - checkout: self
+            lfs: true
+            submodules: true
           - task: Cache@2
             inputs:
               key: $(Agent.OS) | **/global.json, **/*.csproj

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
@@ -47,7 +47,7 @@ stages:
         dependsOn: [  ]
         steps:
           - checkout: self
-            lfs: true
+            lfs: false
             submodules: true
           - task: Cache@2
             inputs:
@@ -69,7 +69,7 @@ stages:
         dependsOn: [ Restore ]
         steps:
           - checkout: self
-            lfs: true
+            lfs: false
             submodules: true
           - task: Cache@2
             inputs:
@@ -93,7 +93,7 @@ stages:
           parallel: 2
         steps:
           - checkout: self
-            lfs: true
+            lfs: false
             submodules: true
           - task: Cache@2
             inputs:
@@ -115,7 +115,7 @@ stages:
         dependsOn: [ Test ]
         steps:
           - checkout: self
-            lfs: true
+            lfs: false
             submodules: true
           - task: Cache@2
             inputs:
@@ -143,7 +143,7 @@ stages:
         dependsOn: [  ]
         steps:
           - checkout: self
-            lfs: true
+            lfs: false
             submodules: true
           - task: Cache@2
             inputs:
@@ -165,7 +165,7 @@ stages:
         dependsOn: [ Restore ]
         steps:
           - checkout: self
-            lfs: true
+            lfs: false
             submodules: true
           - task: Cache@2
             inputs:
@@ -189,7 +189,7 @@ stages:
           parallel: 2
         steps:
           - checkout: self
-            lfs: true
+            lfs: false
             submodules: true
           - task: Cache@2
             inputs:
@@ -211,7 +211,7 @@ stages:
         dependsOn: [ Test ]
         steps:
           - checkout: self
-            lfs: true
+            lfs: false
             submodules: true
           - task: Cache@2
             inputs:

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -87,7 +87,9 @@ namespace Nuke.Common.Tests.CI
                         TriggerPathsInclude = new[] { "included_path" },
                         TriggerPathsExclude = new[] { "excluded_path" },
                         TriggerTagsInclude = new[] { "included_tags" },
-                        TriggerTagsExclude = new[] { "excluded_tags" }
+                        TriggerTagsExclude = new[] { "excluded_tags" },
+                        Submodules = true,
+                        LargeFileStorage = true
                     }
                 );
 

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -89,7 +89,7 @@ namespace Nuke.Common.Tests.CI
                         TriggerTagsInclude = new[] { "included_tags" },
                         TriggerTagsExclude = new[] { "excluded_tags" },
                         Submodules = true,
-                        LargeFileStorage = true
+                        LargeFileStorage = false
                     }
                 );
 

--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
@@ -25,6 +25,8 @@ namespace Nuke.Common.CI.AzurePipelines
         private readonly AzurePipelinesImage[] _images;
 
         private bool? _triggerBatch;
+        private bool? _submodules;
+        private bool? _largeFileStorage;
 
         public AzurePipelinesAttribute(
             AzurePipelinesImage image,
@@ -55,8 +57,18 @@ namespace Nuke.Common.CI.AzurePipelines
         public string[] InvokedTargets { get; set; } = new string[0];
 
         public bool TriggerDisabled { get; set; }
-        public bool Submodules { get; set; }
-        public bool LargeFileStorage { get; set; }
+
+        public bool Submodules
+        {
+            set => _submodules = value;
+            get => throw new NotSupportedException();
+        }
+
+        public bool LargeFileStorage
+        {
+            set => _largeFileStorage = value;
+            get => throw new NotSupportedException();
+        }
 
         public bool TriggerBatch
         {
@@ -166,12 +178,12 @@ namespace Nuke.Common.CI.AzurePipelines
             ExecutableTarget executableTarget,
             IReadOnlyCollection<ExecutableTarget> relevantTargets)
         {
-            if (Submodules || LargeFileStorage)
+            if (_submodules.HasValue || _largeFileStorage.HasValue)
             {
                 yield return new AzurePipelineCheckoutStep
                              {
-                                 InclueSubmodules = Submodules,
-                                 IncludeLargeFileStorage = LargeFileStorage
+                                 InclueSubmodules = _submodules,
+                                 IncludeLargeFileStorage = _largeFileStorage
                              };
             }
             

--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
@@ -55,6 +55,8 @@ namespace Nuke.Common.CI.AzurePipelines
         public string[] InvokedTargets { get; set; } = new string[0];
 
         public bool TriggerDisabled { get; set; }
+        public bool Submodules { get; set; }
+        public bool LargeFileStorage { get; set; }
 
         public bool TriggerBatch
         {
@@ -164,6 +166,15 @@ namespace Nuke.Common.CI.AzurePipelines
             ExecutableTarget executableTarget,
             IReadOnlyCollection<ExecutableTarget> relevantTargets)
         {
+            if (Submodules || LargeFileStorage)
+            {
+                yield return new AzurePipelineCheckoutStep
+                             {
+                                 InclueSubmodules = Submodules,
+                                 IncludeLargeFileStorage = LargeFileStorage
+                             };
+            }
+            
             if (CacheKeyFiles.Any())
             {
                 yield return new AzurePipelinesCacheStep

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelineCheckoutStep.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelineCheckoutStep.cs
@@ -1,0 +1,33 @@
+// Copyright 2021 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using JetBrains.Annotations;
+using Nuke.Common.Utilities;
+
+namespace Nuke.Common.CI.AzurePipelines.Configuration
+{
+    // https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/pipeline-options-for-git?view=azure-devops&tabs=yaml#checkout-submodules
+    [PublicAPI]
+    public class AzurePipelineCheckoutStep : AzurePipelinesStep
+    {
+        public bool InclueSubmodules { get; set; }
+        public bool IncludeLargeFileStorage { get; set; }
+
+        public override void Write(CustomFileWriter writer)
+        {
+            using (writer.WriteBlock("- checkout: self"))
+            {
+                if (IncludeLargeFileStorage)
+                {
+                    writer.WriteLine($"lfs: true");
+                }
+
+                if (InclueSubmodules)
+                {
+                    writer.WriteLine("submodules: true");
+                }
+            }
+        }
+    }
+}

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelineCheckoutStep.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelineCheckoutStep.cs
@@ -11,21 +11,21 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
     [PublicAPI]
     public class AzurePipelineCheckoutStep : AzurePipelinesStep
     {
-        public bool InclueSubmodules { get; set; }
-        public bool IncludeLargeFileStorage { get; set; }
+        public bool? InclueSubmodules { get; set; }
+        public bool? IncludeLargeFileStorage { get; set; }
 
         public override void Write(CustomFileWriter writer)
         {
             using (writer.WriteBlock("- checkout: self"))
             {
-                if (IncludeLargeFileStorage)
+                if (IncludeLargeFileStorage.HasValue)
                 {
-                    writer.WriteLine($"lfs: true");
+                    writer.WriteLine($"lfs: {IncludeLargeFileStorage.Value}".ToLower());
                 }
 
-                if (InclueSubmodules)
+                if (InclueSubmodules.HasValue)
                 {
-                    writer.WriteLine("submodules: true");
+                    writer.WriteLine($"submodules: {InclueSubmodules.Value}".ToLower());
                 }
             }
         }


### PR DESCRIPTION
I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

In this Pull Request, I've added support for both git LFS (Large File Storage) and git Submodules for Azure Pipelines. The details around azure pipelines lfs and submodule support in yaml can be [found in their documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/pipeline-options-for-git?view=azure-devops&tabs=yaml#checkout-submodules)