### PR TITLE
Make dotnet test logger a list of strings

### DIFF
--- a/build/specifications/DotNet.json
+++ b/build/specifications/DotNet.json
@@ -72,10 +72,10 @@
             "help": "Filters out tests in the current project using the given expression. For more information, see the <a href=\"https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test#filter-option-details\">Filter option details</a> section. For additional information and examples on how to use selective unit test filtering, see <a href=\"https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests\">Running selective unit tests</a>."
           },
           {
-            "name": "Logger",
-            "type": "string",
+            "name": "Loggers",
+            "type": "List<string>",
             "format": "--logger {value}",
-            "help": "Specifies a logger for test results."
+            "help": "Specifies a logger for test results. Specify the parameter multiple times to enable multiple loggers."
           },
           {
             "name": "NoBuild",


### PR DESCRIPTION
According to the [docs](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test#options):
```
-l|--logger <LOGGER>

Specifies a logger for test results. 
Unlike MSBuild, dotnet test doesn't accept abbreviations: instead of -l "console;v=d" use -l "console;verbosity=detailed".
Specify the parameter multiple times to enable multiple loggers.
```
Which means that `dotnet test` supports multiple `--logger` arguments. This is why I want to make it `List<string>`.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
