### PR TITLE
[Enhancement][Azure] adds support for azure yaml [fetchDepth] and [clean]

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
@@ -49,6 +49,8 @@ stages:
           - checkout: self
             lfs: false
             submodules: true
+            fetchDepth: 1
+            clean: true
           - task: Cache@2
             displayName: Cache (nuke-temp)
             inputs:
@@ -78,6 +80,8 @@ stages:
           - checkout: self
             lfs: false
             submodules: true
+            fetchDepth: 1
+            clean: true
           - task: Cache@2
             displayName: Cache (nuke-temp)
             inputs:
@@ -109,6 +113,8 @@ stages:
           - checkout: self
             lfs: false
             submodules: true
+            fetchDepth: 1
+            clean: true
           - task: Cache@2
             displayName: Cache (nuke-temp)
             inputs:
@@ -138,6 +144,8 @@ stages:
           - checkout: self
             lfs: false
             submodules: true
+            fetchDepth: 1
+            clean: true
           - task: Cache@2
             displayName: Cache (nuke-temp)
             inputs:
@@ -173,6 +181,8 @@ stages:
           - checkout: self
             lfs: false
             submodules: true
+            fetchDepth: 1
+            clean: true
           - task: Cache@2
             displayName: Cache (nuke-temp)
             inputs:
@@ -202,6 +212,8 @@ stages:
           - checkout: self
             lfs: false
             submodules: true
+            fetchDepth: 1
+            clean: true
           - task: Cache@2
             displayName: Cache (nuke-temp)
             inputs:
@@ -233,6 +245,8 @@ stages:
           - checkout: self
             lfs: false
             submodules: true
+            fetchDepth: 1
+            clean: true
           - task: Cache@2
             displayName: Cache (nuke-temp)
             inputs:
@@ -262,6 +276,8 @@ stages:
           - checkout: self
             lfs: false
             submodules: true
+            fetchDepth: 1
+            clean: true
           - task: Cache@2
             displayName: Cache (nuke-temp)
             inputs:

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -89,7 +89,9 @@ namespace Nuke.Common.Tests.CI
                         TriggerTagsInclude = new[] { "included_tags" },
                         TriggerTagsExclude = new[] { "excluded_tags" },
                         Submodules = true,
-                        LargeFileStorage = false
+                        LargeFileStorage = false,
+                        Clean = true,
+                        FetchDepth = 1
                     }
                 );
 

--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
@@ -27,6 +27,8 @@ namespace Nuke.Common.CI.AzurePipelines
         private bool? _triggerBatch;
         private bool? _submodules;
         private bool? _largeFileStorage;
+        private int? _fetchDepth;
+        private bool? _clean;
 
         public AzurePipelinesAttribute(
             AzurePipelinesImage image,
@@ -61,6 +63,18 @@ namespace Nuke.Common.CI.AzurePipelines
         public bool Submodules
         {
             set => _submodules = value;
+            get => throw new NotSupportedException();
+        }
+
+        public int FetchDepth
+        {
+            set => _fetchDepth = value;
+            get => throw new NotSupportedException();
+        }
+
+        public bool Clean
+        {
+            set => _clean = value;
             get => throw new NotSupportedException();
         }
 
@@ -180,12 +194,14 @@ namespace Nuke.Common.CI.AzurePipelines
             IReadOnlyCollection<ExecutableTarget> relevantTargets,
             AzurePipelinesImage image)
         {
-            if (_submodules.HasValue || _largeFileStorage.HasValue)
+            if (_submodules.HasValue || _largeFileStorage.HasValue || _fetchDepth.HasValue || _clean.HasValue)
             {
                 yield return new AzurePipelineCheckoutStep
                              {
                                  InclueSubmodules = _submodules,
-                                 IncludeLargeFileStorage = _largeFileStorage
+                                 IncludeLargeFileStorage = _largeFileStorage,
+                                 FetchDepth = _fetchDepth,
+                                 Clean = _clean
                              };
             }
 

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelineCheckoutStep.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelineCheckoutStep.cs
@@ -13,6 +13,8 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
     {
         public bool? InclueSubmodules { get; set; }
         public bool? IncludeLargeFileStorage { get; set; }
+        public int? FetchDepth { get; set; }
+        public bool? Clean { get; set; }
 
         public override void Write(CustomFileWriter writer)
         {
@@ -26,6 +28,16 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
                 if (InclueSubmodules.HasValue)
                 {
                     writer.WriteLine($"submodules: {InclueSubmodules.Value}".ToLower());
+                }
+
+                if (FetchDepth.HasValue)
+                {
+                    writer.WriteLine($"fetchDepth: {FetchDepth.Value}");
+                }
+
+                if (Clean.HasValue)
+                {
+                    writer.WriteLine($"clean: {Clean.Value}".ToLower());
                 }
             }
         }


### PR DESCRIPTION
I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

This pull request adds support for `fetchDepth` and `clean` in the azure-pipeline.yaml as defined in the [checkout schema](https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema%2Cparameter-schema#checkout)