### PR TITLE
feat: Added a more detailed AssertZeroExitCode error message

### DIFF
--- a/source/Nuke.Common/Tooling/ProcessExtensions.cs
+++ b/source/Nuke.Common/Tooling/ProcessExtensions.cs
@@ -20,7 +20,8 @@ namespace Nuke.Common.Tooling
             [AssertionCondition(AssertionConditionType.IS_NOT_NULL)] [CanBeNull]
             this IProcess process)
         {
-            ControlFlow.Assert(process != null && process.WaitForExit(), "process != null && process.WaitForExit()");
+            ControlFlow.Assert(process != null , "invalid process");
+            ControlFlow.Assert(process.WaitForExit(), "process timeout");
             return process;
         }
 


### PR DESCRIPTION
On AvaloniaUI, the build on CI fails randomly (see [this](https://dev.azure.com/AvaloniaUI/AvaloniaUI/_build/results?buildId=15467&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=f33089cd-d3fe-578c-2c5e-4ee560e10a0d&l=54)).

The purpose of this OR is help to identify reason of failure.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [ ] Is in compliance with my employer
