### PR TITLE
Add files to sign to Azure Sign Tool spec

### DIFF
--- a/build/specifications/AzureSignTool.json
+++ b/build/specifications/AzureSignTool.json
@@ -143,6 +143,12 @@
             "type": "int",
             "format": "--max-degree-of-parallelism {value}",
             "help": "When signing multiple files, specifies the maximum number of concurrent operations. Setting this value does not guarentee that number of concurrent operations will be performed. If this value is unspecified, the system will use the default based on the number of available processor threads. Setting this value to <c>1</c> disable concurrent signing."
+          },
+          {
+            "name": "Files",
+            "type": "List<string>",
+            "format": "{value}",
+            "help": "Files to sign."
           }
         ]
       }


### PR DESCRIPTION
Currently the ways to actually select files to sign either include creating a file with line seperated file paths and supplying that in `SetInputFileList` or using `SetProcessArgumentConfigurator` to add all the files. This added `SetFiles` which is a nicer way of specifying all the files you'd like to sign.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
