### PR TITLE
Allow other assemblies to implement OutputSink.

### DIFF
--- a/source/Nuke.Common/OutputSinks/OutputSink.cs
+++ b/source/Nuke.Common/OutputSinks/OutputSink.cs
@@ -1,4 +1,4 @@
-// Copyright 2019 Maintainers of NUKE.
+﻿// Copyright 2019 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -207,10 +207,10 @@ namespace Nuke.Common.OutputSinks
             WriteNormal(string.Empty);
         }
 
-        internal abstract void WriteNormal(string text);
-        internal abstract void WriteSuccess(string text);
-        internal abstract void WriteTrace(string text);
-        internal abstract void WriteInformation(string text);
+        protected internal abstract void WriteNormal(string text);
+        protected internal abstract void WriteSuccess(string text);
+        protected internal abstract void WriteTrace(string text);
+        protected internal abstract void WriteInformation(string text);
 
         protected abstract void WriteWarning(string text, string details = null);
         protected abstract void WriteError(string text, string details = null);


### PR DESCRIPTION
As it's a 5 lines PR I want ahead and made it.

Simply, there is 4 `internal abstract` methods on OutputSink making it impossible to implement it in other assemblies.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
