### PR TITLE
fix for MinimalOutput of UnityTask not working

### DIFF
--- a/source/Nuke.Common/Tools/Unity/UnityTasks.cs
+++ b/source/Nuke.Common/Tools/Unity/UnityTasks.cs
@@ -21,7 +21,6 @@ namespace Nuke.Common.Tools.Unity
         [ThreadStatic]
         private static LogParser s_logParser;
 
-        [ThreadStatic]
         private static bool s_minimalOutput;
 
         public static string GetToolPath(string hubVersion = null)


### PR DESCRIPTION
`s_minimalOutput` is written by one thread and read by `FileWatcher` thread but is [ThreadStatic]. `FileWatcher` never sees a value other than the default `false`.

- [/] Follows the contribution guidelines
- [/] Is based on my own work
- [/] Is in compliance with my employer
