### PR TITLE
Add Unity version auto-detection

### DIFF
--- a/source/Nuke.Common/Tools/Unity/UnityTasks.cs
+++ b/source/Nuke.Common/Tools/Unity/UnityTasks.cs
@@ -3,10 +3,12 @@
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
+using Nuke.Common.IO;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.Unity.Logging;
 using Nuke.Common.Utilities;
@@ -65,7 +67,37 @@ namespace Nuke.Common.Tools.Unity
             if (unitySettings.ProjectPath == null)
                 Log.Warning("ProjectPath is not set, using last opened/built project");
 
+            DetectUnityVersion(ref unitySettings);
             PreProcess<UnitySettings>(ref unitySettings);
+        }
+
+        private static void DetectUnityVersion(ref UnitySettings unitySettings)
+        {
+            if (unitySettings.HubVersion != null)
+                return;
+
+            if (unitySettings.ProjectPath == null)
+                return;
+
+            var editorVersion = ReadUnityEditorVersion(unitySettings.ProjectPath);
+            var hubToolPath = (AbsolutePath) GetToolPathViaHubVersion(editorVersion);
+            if (hubToolPath.Exists())
+            {
+                unitySettings.HubVersion = editorVersion;
+                return;
+            }
+
+            var manualInstallationToolPath = (AbsolutePath) GetToolPathViaManualInstallation();
+            ControlFlow.Assert(
+                manualInstallationToolPath.Exists(),
+                $"Required Unity Hub installation for version '{editorVersion}' was not found");
+        }
+
+        private static string ReadUnityEditorVersion(string projectPath)
+        {
+            var projectVersionPath = Path.Combine(projectPath, "ProjectSettings", "ProjectVersion.txt");
+            var properties = SerializationTasks.YamlDeserializeFromFile<Dictionary<string, string>>(projectVersionPath);
+            return properties["m_EditorVersion"];
         }
 
         private static void PreProcess<T>(ref T unitySettings)


### PR DESCRIPTION
Unity projects have a `{ProjectPath}/ProjectSettings/ProjectVersion.txt` file which shows the version of Unity last used to open the project. We can leverage this to guess the installed Unity version in Unity Hub.

Since Unity Hub is a standard way to install Unity distributions, `.SetHubVersion()` is required for the majority of projects. With this auto-detection feature, it will be possible to omit this setup step.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
