### PR TITLE
Target .net 6.0

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>.\..</NukeRootDirectory>
@@ -20,28 +20,28 @@
   <PropertyGroup>
     <NukeTasksEnabled Condition="'$(NukeTasksEnabled)' == ''">False</NukeTasksEnabled>
     <NukeTasksDirectory>$(MSBuildThisFileDirectory)\..\source\Nuke.MSBuildTasks\bin\Debug\netcoreapp2.1\publish</NukeTasksDirectory>
-<!--    <PackAsTool>True</PackAsTool>-->
-<!--    <ToolCommandName>build</ToolCommandName>-->
+    <!--    <PackAsTool>True</PackAsTool>-->
+    <!--    <ToolCommandName>build</ToolCommandName>-->
   </PropertyGroup>
 
   <!-- Test properties for external files -->
-<!--  <ItemGroup>-->
-<!--    <NukeExternalFiles Include="https://github.com/nuke-build/common/tree/develop/source/Nuke.GlobalTool/templates" BasePath="..\download">-->
-<!--      <TargetFramework>Bla</TargetFramework>-->
-<!--      <GitVersion />-->
-<!--      <NuGetSource>https://www.myget.org/F/matkoch/api/v2/package</NuGetSource>-->
-<!--      <NukeVersion>9999.0.0</NukeVersion>-->
-<!--    </NukeExternalFiles>-->
-<!--  </ItemGroup>-->
-  
+  <!--  <ItemGroup>-->
+  <!--    <NukeExternalFiles Include="https://github.com/nuke-build/common/tree/develop/source/Nuke.GlobalTool/templates" BasePath="..\download">-->
+  <!--      <TargetFramework>Bla</TargetFramework>-->
+  <!--      <GitVersion />-->
+  <!--      <NuGetSource>https://www.myget.org/F/matkoch/api/v2/package</NuGetSource>-->
+  <!--      <NukeVersion>9999.0.0</NukeVersion>-->
+  <!--    </NukeExternalFiles>-->
+  <!--  </ItemGroup>-->
+
   <!-- Test properties for source generators -->
-<!--  <PropertyGroup>-->
-<!--    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>-->
-<!--    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>-->
-<!--  </PropertyGroup>-->
-<!--  <ItemGroup>-->
-<!--    <PackageReference Include="Nuke.SourceGenerators" Version="1.0.0-beta01" OutputItemType="Analyzer" />-->
-<!--  </ItemGroup>-->
+  <!--  <PropertyGroup>-->
+  <!--    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>-->
+  <!--    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>-->
+  <!--  </PropertyGroup>-->
+  <!--  <ItemGroup>-->
+  <!--    <PackageReference Include="Nuke.SourceGenerators" Version="1.0.0-beta01" OutputItemType="Analyzer" />-->
+  <!--  </ItemGroup>-->
 
   <PropertyGroup>
     <DefineConstants>$(Configuration.ToUpper())</DefineConstants>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.200",
+    "version": "6.0.100-rc.1.21463.6",
     "rollForward": "latestMinor"
   }
 }

--- a/source/Nuke.CodeGeneration/Nuke.CodeGeneration.csproj
+++ b/source/Nuke.CodeGeneration/Nuke.CodeGeneration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp2.1;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Nuke.Common.Tests/Nuke.Common.Tests.csproj
+++ b/source/Nuke.Common.Tests/Nuke.Common.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Nuke.Common/Nuke.Common.csproj
+++ b/source/Nuke.Common/Nuke.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net6.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Nuke.Components/Nuke.Components.csproj
+++ b/source/Nuke.Components/Nuke.Components.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
 

--- a/source/Nuke.GlobalTool.Tests/Nuke.GlobalTool.Tests.csproj
+++ b/source/Nuke.GlobalTool.Tests/Nuke.GlobalTool.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Nuke.GlobalTool/Nuke.GlobalTool.csproj
+++ b/source/Nuke.GlobalTool/Nuke.GlobalTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>nuke</ToolCommandName>
   </PropertyGroup>

--- a/source/Nuke.MSBuildTasks/Nuke.MSBuildTasks.csproj
+++ b/source/Nuke.MSBuildTasks/Nuke.MSBuildTasks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp2.1;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Nuke.SourceGenerators.Tests/Nuke.SourceGenerators.Tests.csproj
+++ b/source/Nuke.SourceGenerators.Tests/Nuke.SourceGenerators.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <CopyRefAssembliesToPublishDirectory>true</CopyRefAssembliesToPublishDirectory>
   </PropertyGroup>


### PR DESCRIPTION
To Target .Net Core 6.0 on any project, it needs only to add a global.json file to the root folder, and then the build.[sh,bat,ps1] will install the respective framework.

So actually this pull request is not at all a priority.

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer
