### PR TITLE
Add completer registrations to global tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `PowerShellTasks`
 - Added `BootsTasks`
 - Added `NetlifyTasks`
+- Added `RegisterCompleter` command to global tool
 - Fixed check for executables compiled with `PublishSingleFile`
 - Fixed `MSBuild` localization using `MSBuildLocator`
 - Fixed Azure Pipelines caching
@@ -955,4 +956,3 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [0.3.1]: https://github.com/nuke-build/nuke/compare/0.2.10...0.3.1
 [0.2.10]: https://github.com/nuke-build/nuke/compare/0.2.0...0.2.10
 [0.2.0]: https://github.com/nuke-build/nuke/tree/0.2.0
-

--- a/source/Nuke.GlobalTool/Program.RegisterCompleter.cs
+++ b/source/Nuke.GlobalTool/Program.RegisterCompleter.cs
@@ -1,0 +1,46 @@
+﻿// Copyright 2021 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Nuke.Common;
+using Nuke.Common.IO;
+using Nuke.Common.Utilities;
+
+namespace Nuke.GlobalTool;
+
+public partial class Program
+{
+    [UsedImplicitly]
+    public static int RegisterCompleter(string[] args, [CanBeNull] AbsolutePath rootDirectory, [CanBeNull] AbsolutePath buildScript)
+    {
+        var shellArg = args.FirstOrDefault();
+
+        IEnumerable<string> SupportedShells()
+        {
+            foreach (var value in Enum.GetValues(typeof(CompletionUtility.CompletionSupportedShells)))
+            {
+                yield return value.ToString();
+            }
+        }
+
+        var shellValid =
+            CompletionUtility.CompletionSupportedShells.TryParse(shellArg, ignoreCase: true, out CompletionUtility.CompletionSupportedShells shell);
+
+        if (!shellValid)
+        {
+            Assert.Fail(@$"
+Usage: nuke {CommandPrefix}RegisterCompleter <shell>
+
+    shell: {SupportedShells().JoinCommaSpace()}
+");
+            return -1;
+        }
+
+        Console.Write(CompletionUtility.RegisterCompleter(shell));
+        return 0;
+    }
+}


### PR DESCRIPTION
I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer

----

Resolve #597 

- New :RegisterCompleter command
- Simple implementation to echo code for supported shells
- Supports "invoke expression" style invocation,

e.g. for Powershell:

```powershell
(nuke ':RegisterCompleter' pwsh) -join "`n" | Invoke-Expression
```
