### PR TITLE
Fix missing VS2022 case in MSBuildToolPathResolver

### DIFF
--- a/source/Nuke.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
@@ -100,6 +100,7 @@ namespace Nuke.Common.Tools.MSBuild
         {
             return version switch
             {
+                MSBuildVersion.VS2022 => "Current",
                 MSBuildVersion.VS2019 => "Current",
                 MSBuildVersion.VS2017 => "15.0",
                 MSBuildVersion.VS2015 => "14.0",


### PR DESCRIPTION
Not sure if I'm considered "greatly involved in any other recognized OSS project" but I have contributed a bit to other projects and figured this was fairly low-hanging fruit.

The updates made in #814 appear to be incomplete. We're using VS2022 so I tried pulling `MSBuildToolPathResolver` directly into our project temporarily until Nuke 6.0 is released. However, it seems to always throw `ArgumentOutOfRangeException`.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
