### PR TITLE
RelativePath generation failed if same folder reoccured, even after a…

### DIFF
--- a/source/Nuke.Common.Tests/PathConstructionTest.cs
+++ b/source/Nuke.Common.Tests/PathConstructionTest.cs
@@ -38,7 +38,10 @@ namespace Nuke.Common.Tests
         [InlineData("C:\\A\\B\\C", "C:\\A\\B", "..")]
         [InlineData("C:\\A\\B\\", "C:\\A\\B\\C", "C")]
         [InlineData("C:\\A\\B\\C", "C:\\A\\B\\D\\E", "..\\D\\E")]
+        [InlineData("C:\\A\\B\\C\\B", "C:\\A\\B\\D\\B", "..\\..\\D\\B")]
         [InlineData("/bin/etc", "/bin/tmp", "../tmp")]
+        [InlineData("/bin/etc/bin", "/bin/tmp/bin", "../../tmp/bin")]
+        [InlineData("/same1/diff1/same2", "/diff1/diff2/same2", "../../../diff1/diff2/same2")]
         public void TestGetRelativePath(string basePath, string destinationPath, string expected)
         {
             GetRelativePath(basePath, destinationPath).Should().Be(expected);

--- a/source/Nuke.Common/IO/PathConstruction.cs
+++ b/source/Nuke.Common/IO/PathConstruction.cs
@@ -110,7 +110,7 @@ namespace Nuke.Common.IO
             var destinationParts = destinationPath.Split(new[] { separator }, StringSplitOptions.RemoveEmptyEntries);
 
             var sameParts = baseParts.Zip(destinationParts, (a, b) => new { Base = a, Destination = b })
-                .Count(x => x.Base.EqualsOrdinalIgnoreCase(x.Destination));
+                .TakeWhile(x => x.Base.EqualsOrdinalIgnoreCase(x.Destination)).Count();
             return Enumerable.Repeat("..", baseParts.Length - sameParts).ToList()
                 .Concat(destinationParts.Skip(sameParts).ToList()).Join(separator);
         }


### PR DESCRIPTION
I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

I know I am neither a sponsor (yet) nor a contributor.
I have simply found a bug, that is proven with the added unit tests, and a fix for the bug.

Feel free to accept the PR or fix the bug how you see fit.
Take this as a suggestion.

BTW the EqualsOrdinalIgnoreCase seems dangerous when used on unix?