### PR TITLE
Added missing type name parameters for Kubernetes create and delete

### DIFF
--- a/source/Nuke.Common/Tools/Kubernetes/Kubernetes.json
+++ b/source/Nuke.Common/Tools/Kubernetes/Kubernetes.json
@@ -970,6 +970,13 @@
         "baseClass": "KubernetesToolSettings",
         "properties": [
           {
+            "name": "TypeName",
+            "type": "List<string>",
+            "format": "{value}",
+            "separator": " ",
+            "help": "The type (and name) of the resource. When only specifying a type either a --selector or --all needs to be specified"
+          },
+          {
             "name": "All",
             "type": "bool",
             "format": "--all={value}",
@@ -2164,6 +2171,13 @@
         "baseClass": "KubernetesToolSettings",
         "properties": [
           {
+            "name": "TypeName",
+            "type": "List<string>",
+            "format": "{value}",
+            "separator": " ",
+            "help": "The type (and name) of the resource. When only specifying a type either a --selector or --all needs to be specified"
+          },
+          {
             "name": "AllowMissingTemplateKeys",
             "type": "bool",
             "format": "--allow-missing-template-keys={value}",
@@ -2257,7 +2271,7 @@
             "type": "List<string>",
             "format": "{value}",
             "separator": " ",
-            "help": "The type or/and name of the ressource."
+            "help": "The type or/and name of the resource."
           },
           {
             "name": "Ports",


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Added a type / name parameter to both Kubernetes create and delete parameters.
I think the current parameters where generated, and these ones are special, since they don't start with --.
So they are not generated, but currently you always need to specify them using `ConfigureProcessArguments`

As an example you currently can't create this
```bash
kubectl create namespace my-namespace
```
Without using `ConfigureProcessArguments`

This also goes for
```bash
kubectl delete namespace my-namespace
```

When it is added, it also enables you to combine things like:
```bash
kubectl delete pods --all
```
or
```bash
kubectl delete pods pod1,pod2
```

For more information:
https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#create
https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#delete

I created this PR as direct change to the json file. But I could not find the code that was originally used to generate this json with, neither could I find a clear name and description for the parameter besides this part of the documentation:
`kubectl delete ([-f FILENAME] | [-k DIRECTORY] | TYPE [(NAME | -l label | --all)])`
So if you want to have it implemented differently, please let me know.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer
