### PR TITLE
Support resolving tools for a specific paket group

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ NUKE builds and tests itself on several different CI servers, which helps ensuri
 
 - [ASP.NET Boilerplate](https://aspnetboilerplate.com/) <sup><a href="https://github.com/aspnetboilerplate/aspnetboilerplate">1</a></sup>
 - [AvaloniaUI](https://avaloniaui.net/) <sup><a href="https://github.com/AvaloniaUI/Avalonia">1</a></sup>
-- **[Aviva Solutions Inc.](https://www.avivasolutions.com/)** <sup><a href="https://github.com/avivasolutionsnl/sitecore-commerce-docker">1</a> <a href="https://github.com/avivasolutionsnl/sitecore-docker">2</a></sup>
+- **[Aviva Solutions B.V.](https://www.avivasolutions.nl/)** <sup><a href="https://github.com/avivasolutionsnl/sitecore-commerce-docker">1</a> <a href="https://github.com/avivasolutionsnl/sitecore-docker">2</a></sup>
 - [ChilliCream](https://chillicream.com/) <sup><a href="https://github.com/ChilliCream/hotchocolate">1</a></sup>
 - [CvsHelper](https://joshclose.github.io/CsvHelper/) <sup><a href="https://github.com/JoshClose/CsvHelper">1</a></sup>
 - [DNN Community](https://dnncommunity.org/) <sup><a href="https://github.com/DNNCommunity/Dnn.ModuleCreator">1</a></sup>
@@ -101,6 +101,7 @@ Thanks to all companies, organizations, and individuals who are sponsoring the f
 [![Anton Wieslander](https://avatars.githubusercontent.com/T0shik?s=60&v=4)](https://github.com/T0shik)
 [![Chase Florell](https://avatars.githubusercontent.com/ChaseFlorell?s=60&v=4)](https://github.com/ChaseFlorell)
 [![business//acts](https://avatars.githubusercontent.com/BusinessActs?s=60&v=4)](https://github.com/BusinessActs)
+[![xsegno GmbH](https://avatars.githubusercontent.com/xsegno?s=60&v=4)](https://github.com/xsegno)
 
 [![Stephan Müller](https://avatars.githubusercontent.com/chaquotay?s=45&v=4)](https://github.com/chaquotay)
 [![Bitbonk](https://avatars.githubusercontent.com/bitbonk?s=45&v=4)](https://github.com/bitbonk)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ Thanks to all companies, organizations, and individuals who are sponsoring the f
 [![Andrei Andreev](https://avatars.githubusercontent.com/Razenpok?s=45&v=4)](https://github.com/Razenpok)
 [![Steven Kuhn](https://avatars.githubusercontent.com/stevenkuhn?s=45&v=4)](https://github.com/stevenkuhn)
 [![Jesus Rodriguez Valencia](https://avatars.githubusercontent.com/jrodrigv?s=45&v=4)](https://github.com/jrodrigv)
-[![Влалислав Лищина](https://avatars.githubusercontent.com/Duskone39?s=45&v=4)](https://github.com/Duskone39)
+[![Vladislav Lischyna](https://avatars.githubusercontent.com/Duskone39?s=45&v=4)](https://github.com/Duskone39)
+[![Adam Renaud](https://avatars.githubusercontent.com/rena0157?s=45&v=4)](https://github.com/rena0157)
 
 ## Technology Sponsors
 

--- a/source/Nuke.Common/Tooling/PaketPackageResolver.cs
+++ b/source/Nuke.Common/Tooling/PaketPackageResolver.cs
@@ -13,15 +13,20 @@ namespace Nuke.Common.Tooling
     [PublicAPI]
     public static class PaketPackageResolver
     {
-        public static string GetLocalInstalledPackageDirectory(string packageId, string packagesConfigFile)
+        public static string GetLocalInstalledPackageDirectory(string packageId, string packagesConfigFile, string packagesGroup)
         {
-            var packagesDirectory = GetPackagesDirectory(packagesConfigFile);
+            var packagesDirectory = GetPackagesDirectory(packagesConfigFile, packagesGroup);
             return Path.Combine(packagesDirectory, packageId);
         }
 
-        private static string GetPackagesDirectory(string packagesConfigFile)
+        private static string GetPackagesDirectory(string packagesConfigFile, string packagesGroup)
         {
-            return Path.Combine(Path.GetDirectoryName(packagesConfigFile).NotNull(), "packages");
+            if (string.IsNullOrWhiteSpace(packagesGroup))
+            {
+                return Path.Combine(Path.GetDirectoryName(packagesConfigFile).NotNull(), "packages");
+            }
+
+            return Path.Combine(Path.GetDirectoryName(packagesConfigFile).NotNull(), "packages", packagesGroup);
         }
     }
 }

--- a/source/Nuke.Common/Tooling/ToolPathResolver.cs
+++ b/source/Nuke.Common/Tooling/ToolPathResolver.cs
@@ -19,6 +19,7 @@ namespace Nuke.Common.Tooling
         public static string NuGetPackagesConfigFile;
         public static string NuGetAssetsConfigFile;
         public static string PaketPackagesConfigFile;
+        public static string PaketCliToolGroup;
 
         internal const string MissingPackageDefaultVersion = "latest";
 
@@ -105,7 +106,7 @@ namespace Nuke.Common.Tooling
                                 ? NuGetPackageResolver.GetLocalInstalledPackage(x, NuGetPackagesConfigFile, version)?.Directory
                                 : null,
                             () => PaketPackagesConfigFile != null
-                                ? PaketPackageResolver.GetLocalInstalledPackageDirectory(x, PaketPackagesConfigFile)
+                                ? PaketPackageResolver.GetLocalInstalledPackageDirectory(x, PaketPackagesConfigFile, PaketCliToolGroup)
                                 : null
                         })
                     .Select(x => x.Invoke())
@@ -131,6 +132,9 @@ namespace Nuke.Common.Tooling
                                         : null,
                                     PaketPackagesConfigFile != null
                                         ? $"Paket packages config '{PaketPackagesConfigFile}'"
+                                        : null,
+                                    PaketCliToolGroup != null
+                                        ? $"Paket cli tool group '{PaketCliToolGroup}'"
                                         : null
                                 }.WhereNotNull().Select(x => $" - {x}")).JoinNewLine());
             }

--- a/source/Nuke.Components/ICreateGitHubRelease.cs
+++ b/source/Nuke.Components/ICreateGitHubRelease.cs
@@ -1,37 +1,61 @@
-﻿// Copyright 2021 Maintainers of NUKE.
+﻿// Copyright 2022 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
-// using System.Linq;
-//
-// using Nuke.Common;
-// using Nuke.Common.Tools.GitHub;
-// using Nuke.GitHub;
-//
-// using static Nuke.Common.ValueInjection.ValueInjectionUtility;
-// using static Nuke.GitHub.GitHubTasks;
-//
-// public interface ICreateGitHubRelease : INukeBuild
-// {
-//     [Parameter]
-//     string GitHubToken => TryGetValue(() => GitHubToken);
-//
-//     Target CreateGitHubRelease => _ => _
-//         .Requires(() => GitHubToken)
-//         .Executes(async () =>
-//         {
-//             await PublishRelease(_ => _
-//                 .SetToken(GitHubToken)
-//                 .WhenNotNull((this as IHazGitRepository)?.GitRepository, (_, repository) => _
-//                     .SetRepositoryOwner(repository.GetGitHubOwner())
-//                     .SetRepositoryName(repository.GetGitHubName())
-//                     .WhenNotNull(repository.Tags.FirstOrDefault(), (_, tag) => _
-//                         .SetName($"v{tag}")
-//                         .SetTag(tag)))
-//                 .WhenNotNull(this as IHazChangelog, (_, o) => _
-//                     .SetReleaseNotes(o.ReleaseNotes))
-//                 .SetArtifactPaths(new string[0]));
-//         });
-// }
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Nuke.Common;
+using Nuke.Common.ChangeLog;
+using Nuke.Common.CI.GitHubActions;
+using Nuke.Common.IO;
+using Nuke.Common.Tools.GitHub;
+using Nuke.Common.Utilities;
+using Octokit;
 
+namespace Nuke.Components
+{
+    [PublicAPI]
+    [ParameterPrefix(GitHubRelease)]
+    public interface ICreateGitHubRelease : IHazGitRepository, IHazChangelog
+    {
+        public const string GitHubRelease = nameof(GitHubRelease);
 
+        [Parameter] [Secret] string Token => TryGetValue(() => Token) ?? GitHubActions.Instance.Token;
+        string Version { get; }
+        IEnumerable<AbsolutePath> AssetFiles { get; }
+
+        Target CreateGitHubRelease => _ => _
+            .Requires(() => Token)
+            .Executes(async () =>
+            {
+                GitHubTasks.GitHubClient.Credentials = new Credentials(Token);
+
+                var release = await GitHubTasks.GitHubClient.Repository.Release.Create(
+                    GitRepository.GetGitHubOwner(),
+                    GitRepository.GetGitHubName(),
+                    new NewRelease(Version)
+                    {
+                        Name = $"v{Version}",
+                        Body = ChangelogTasks.ExtractChangelogSectionNotes(NuGetReleaseNotes).JoinNewLine()
+                    });
+
+                var uploadTasks = AssetFiles.Select(async x =>
+                {
+                    await using var assetFile = File.OpenRead(x);
+                    var asset = new ReleaseAssetUpload
+                                {
+                                    FileName = x.Name,
+                                    ContentType = "application/octet-stream",
+                                    RawData = assetFile
+                                };
+                    await GitHubTasks.GitHubClient.Repository.Release.UploadAsset(release, asset);
+                }).ToArray();
+
+                Task.WaitAll(uploadTasks);
+            });
+    }
+}


### PR DESCRIPTION
To address #583 
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Addition of ToolPathResolver.PaketCliToolGroup to specify a specific paket group to search for tool packages in. 

given the following `paket.dependecies` file:

```
framework: net6.0
source https://api.nuget.org/v3/index.json
nuget Nuke.Common

group tools
framework: net6.0
source https://api.nuget.org/v3/index.json
nuget Octopus.DotNet.Cli
```

Nuke should be able to resolve octopus cli when using OctopusTasks after ammending build:

```
class Build : NukeBuild
{
    static Build()
        {
            // Required to use paket to resolve tools
            ToolPathResolver.PaketPackagesConfigFile = RootDirectory / "paket.lock";
            // Optionally: specify the group to locate package tools in (defualt is main group)
            ToolPathResolver.PaketCliToolGroup = "tools";
        }
    // the rest of your build
}
```

without this the paket.dependecies file has to look like this:

```
framework: net6.0
source https://api.nuget.org/v3/index.json
nuget Nuke.Common
nuget Octopus.DotNet.Cli
```


<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [ ] Follows the contribution guidelines
- [ ] Is based on my own work
- [ ] Is in compliance with my employer
