### PR TITLE
Adds other supported targets to NSwag

### DIFF
--- a/source/Nuke.Common/Tools/NSwag/NSwagSettings.cs
+++ b/source/Nuke.Common/Tools/NSwag/NSwagSettings.cs
@@ -17,9 +17,9 @@ namespace Nuke.Common.Tools.NSwag
     public class NSwagSettings : ToolSettings
     {
         /// <summary>The runtime of the nswag tool to use.</summary>
-        public string NSwagRuntime { get; set; } = NSwagTasks.Runtime.Win.ToString();
+        public string NSwagRuntime { get; set; } = NSwagTasks.Runtime.Net60.ToString();
 
-        private bool IsNetCore => NSwagRuntime != null && NSwagRuntime.StartsWith("NetCore", StringComparison.OrdinalIgnoreCase);
+        private bool IsNetCore => NSwagRuntime != null && NSwagRuntime.StartsWith("Net", StringComparison.OrdinalIgnoreCase);
 
         public override Action<OutputType, string> ProcessCustomLogger { get; }
 

--- a/source/Nuke.Common/Tools/NSwag/NSwagTasks.cs
+++ b/source/Nuke.Common/Tools/NSwag/NSwagTasks.cs
@@ -21,6 +21,9 @@ namespace Nuke.Common.Tools.NSwag
             NetCore11,
             NetCore20,
             NetCore21,
+            NetCore31,
+            Net50,
+            Net60,
             Win
         }
     }


### PR DESCRIPTION
Resolves #856

<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
This adds some of the other documented target frameworks to NSwag settings and thus allows it to run on linux too by using one of the .Net options instead of the Win option across different platforms.

I have tested this in a project of mine by putting a local .nuget package of a build from this commit on it and can confirm it works on both Ubuntu and Windows


<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
