### PR TITLE
Added attributes to supress build and target banners.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -74,7 +74,7 @@ else {
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
 }
 
-Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -67,7 +67,7 @@ else
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
 fi
 
-echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/source/Nuke.Common/Execution/Host.cs
+++ b/source/Nuke.Common/Execution/Host.cs
@@ -15,6 +15,7 @@ using Serilog;
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.SystemConsole.Themes;
+// ReSharper disable CheckNamespace
 
 namespace Nuke.Common
 {
@@ -34,6 +35,11 @@ namespace Nuke.Common
 
         protected internal void WriteLogo()
         {
+            if (NoBuildBannerAttribute.IsDeclared)
+            {
+                return;
+            }
+
             Debug();
             new[]
             {
@@ -49,6 +55,11 @@ namespace Nuke.Common
 
         protected internal virtual IDisposable WriteBlock(string text)
         {
+            if (NoBuildBannerAttribute.IsDeclared)
+            {
+                return new DelegateDisposable(static () => {});
+            }
+
             return DelegateDisposable.CreateBracket(
                 () =>
                 {
@@ -79,6 +90,11 @@ namespace Nuke.Common
 
         internal virtual void WriteSummary(NukeBuild build)
         {
+            if (NoBuildBannerAttribute.IsDeclared)
+            {
+                return;
+            }
+
             WriteSevereLogEvents(Logging.InMemorySink.Instance.LogEvents);
             WriteSummaryTable(build);
 
@@ -90,6 +106,11 @@ namespace Nuke.Common
 
         protected virtual void WriteSevereLogEvents(IReadOnlyCollection<LogEvent> instanceLogEvents)
         {
+            if (NoBuildBannerAttribute.IsDeclared)
+            {
+                return;
+            }
+
             if (instanceLogEvents.Count == 0)
                 return;
 
@@ -110,6 +131,11 @@ namespace Nuke.Common
 
         protected virtual void WriteSummaryTable(NukeBuild build)
         {
+            if (NoBuildBannerAttribute.IsDeclared)
+            {
+                return;
+            }
+
             var firstColumn = Math.Max(build.ExecutionPlan.Max(x => x.Name.Length) + 4, val2: 19);
             var secondColumn = 10;
             var thirdColumn = 10;
@@ -175,11 +201,21 @@ namespace Nuke.Common
 
         protected virtual void WriteSuccessfulBuild(NukeBuild build)
         {
+            if (NoBuildBannerAttribute.IsDeclared)
+            {
+                return;
+            }
+
             Success($"Build succeeded on {DateTime.Now.ToString(CultureInfo.CurrentCulture)}. ＼（＾ᴗ＾）／");
         }
 
         protected virtual void WriteFailedBuild()
         {
+            if (NoBuildBannerAttribute.IsDeclared)
+            {
+                return;
+            }
+
             Error($"Build failed on {DateTime.Now.ToString(CultureInfo.CurrentCulture)}. (╯°□°）╯︵ ┻━┻");
         }
 

--- a/source/Nuke.Common/Execution/NoBuildBannerAttribute.cs
+++ b/source/Nuke.Common/Execution/NoBuildBannerAttribute.cs
@@ -1,0 +1,64 @@
+﻿// Copyright 2022 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+// ReSharper disable TemplateIsNotCompileTimeConstantProblem
+// ReSharper disable LoopCanBeConvertedToQuery
+// ReSharper disable PossibleMultipleEnumeration
+// ReSharper disable AssignNullToNotNullAttribute
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable MemberCanBeInternal
+
+namespace Nuke.Common.Execution;
+
+using System;
+using System.Linq;
+
+using Serilog;
+
+[ AttributeUsage(AttributeTargets.Class | AttributeTargets.Module, AllowMultiple = false, Inherited = true) ]
+public sealed class NoBuildBannerAttribute : Attribute
+{
+    private static bool? _isDeclared;
+    public NoBuildBannerAttribute() { }
+
+    public static bool IsDeclared => _isDeclared ??= GetIsDeclared();
+
+    private static bool GetIsDeclared()
+    {
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            var result = IsDefined(assembly, typeof(NoBuildBannerAttribute));
+
+            if (result)
+            {
+                Log.Verbose($"NoBuildBannerAttribute: Found on assembly {assembly.FullName}");
+
+                return true;
+            }
+
+            foreach (var type in assembly.GetTypes())
+            {
+                if (!type.IsSubclassOf(typeof(NukeBuild)))
+                {
+                    continue;
+                }
+
+                result = IsDefined(type, typeof(NoBuildBannerAttribute));
+
+                if (result)
+                {
+                    Log.Verbose($"NoBuildBannerAttribute: Found on type {type.FullName}");
+
+                    return true;
+                }
+
+                Log.Verbose($"NoBuildBannerAttribute: Not found on type {type.FullName}");
+            }
+
+            Log.Verbose($"NoBuildBannerAttribute: Not found on assembly {assembly.FullName}");
+        }
+
+        return false;
+    }
+}

--- a/source/Nuke.Common/Execution/NoTargetBannerAttribute.cs
+++ b/source/Nuke.Common/Execution/NoTargetBannerAttribute.cs
@@ -1,0 +1,33 @@
+﻿// Copyright 2022 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+// ReSharper disable MemberCanBeInternal
+
+namespace Nuke.Common.Execution
+{
+    using System;
+    using System.Linq;
+
+    using JetBrains.Annotations;
+
+    using Serilog;
+
+    [ AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true) ]
+    public sealed class NoTargetBannerAttribute : Attribute
+    {
+        public NoTargetBannerAttribute() {
+        }
+        
+        public static bool IsDeclaredOn([ NotNull ] ExecutableTarget target)
+        {
+            var attributes = target.Member.GetCustomAttributes(typeof(NoTargetBannerAttribute), true);
+
+            Log.Verbose($"NoTargetBannerAttribute: rtype: {attributes?.Length}");
+
+            return attributes is
+            {
+                Length: > 0,
+            };
+        }
+    }
+}

--- a/source/Nuke.GlobalTool/templates/build.netcore.ps1
+++ b/source/Nuke.GlobalTool/templates/build.netcore.ps1
@@ -63,7 +63,7 @@ else {
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
 }
 
-Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/source/Nuke.GlobalTool/templates/build.netcore.sh
+++ b/source/Nuke.GlobalTool/templates/build.netcore.sh
@@ -56,7 +56,7 @@ else
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
 fi
 
-echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

1. `NoTargetBannerAttribute` - Attribute that is placed on a target declaration that suppresses the banner box only for that target.

2. `NoBuildBannerAttribute` - Attribute to be placed either on the Build class (which must be descended from `NukeBuild`) or placed on the assembly.  Its presence suppresses all stage output except what is written to Serilog.  It also does not affect the banners for Targets.


<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
