### PR TITLE
Improve docs and warning text for CheckBuildProjectConfigurations

### DIFF
--- a/source/Nuke.Common/Execution/CheckBuildProjectConfigurationsAttribute.cs
+++ b/source/Nuke.Common/Execution/CheckBuildProjectConfigurationsAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2019 Maintainers of NUKE.
+// Copyright 2022 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -13,6 +13,10 @@ using Nuke.Common.Utilities.Collections;
 
 namespace Nuke.Common.Execution
 {
+    /// <summary>
+    ///     Specifies that NUKE should verify that the build project itself is excluded from the build in the solution
+    ///     and logs a warning if it is not.
+    /// </summary>
     [PublicAPI]
     [AttributeUsage(AttributeTargets.Class)]
     public class CheckBuildProjectConfigurationsAttribute : Attribute, IOnAfterLogo
@@ -24,8 +28,10 @@ namespace Nuke.Common.Execution
             IReadOnlyCollection<ExecutableTarget> executableTargets,
             IReadOnlyCollection<ExecutableTarget> executionPlan)
         {
-            ControlFlow.AssertWarn(Task.Run(CheckConfiguration).Wait(TimeoutInMilliseconds),
-                $"Could not complete checking build configurations within {TimeoutInMilliseconds} milliseconds.");
+            ControlFlow.AssertWarn(
+                Task.Run(CheckConfiguration).Wait(TimeoutInMilliseconds),
+                $"Could not complete build consistency verification within {TimeoutInMilliseconds} milliseconds, consider increasing the timeout "
+              + $"of the {nameof(CheckBuildProjectConfigurationsAttribute)} or remove the attribute to turn verification off.");
 
             Task CheckConfiguration()
             {


### PR DESCRIPTION
It has been a while since I got to play with nuke. Setting um some new build projects, I stumbled across the warning 
> Could not complete checking build configurations within 500 milliseconds.

again and couldn't remember what the warning tries to tell me. So to save my future me and others from scratching their head,
I'd suggest to be slightly more helpful.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
