### PR TITLE
Improve docs and warning for CheckBuildProjectConfigurationsAttribute

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -74,7 +74,7 @@ else {
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
 }
 
-Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -67,7 +67,7 @@ else
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
 fi
 
-echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/source/Nuke.Common/Execution/CheckBuildProjectConfigurationsAttribute.cs
+++ b/source/Nuke.Common/Execution/CheckBuildProjectConfigurationsAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2021 Maintainers of NUKE.
+// Copyright 2022 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -12,8 +12,14 @@ using Nuke.Common.ProjectModel;
 using Nuke.Common.Utilities.Collections;
 using Serilog;
 
+
 namespace Nuke.Common.Execution
 {
+
+    /// <summary>
+    ///     Specifies that NUKE should verify that the build project itself is excluded from the build in the solution
+    ///     and logs a warning if it is not.
+    /// </summary>
     [PublicAPI]
     public class CheckBuildProjectConfigurationsAttribute : BuildExtensionAttributeBase, IOnBuildInitialized
     {
@@ -25,7 +31,12 @@ namespace Nuke.Common.Execution
             IReadOnlyCollection<ExecutableTarget> executionPlan)
         {
             if (!Task.Run(CheckConfiguration).Wait(TimeoutInMilliseconds))
-                Log.Warning("Could not complete checking build configurations within {Timeout} milliseconds", TimeoutInMilliseconds);
+            {
+                Log.Warning(
+                    "Could not complete build consistency verification within {TimeoutInMilliseconds} milliseconds, consider increasing the timeout "
+                  + "of the CheckBuildProjectConfigurations attribute or remove the attribute to turn off verification",
+                    TimeoutInMilliseconds);
+            }
 
             static Task CheckConfiguration()
             {

--- a/source/Nuke.GlobalTool/templates/build.netcore.ps1
+++ b/source/Nuke.GlobalTool/templates/build.netcore.ps1
@@ -63,7 +63,7 @@ else {
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
 }
 
-Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/source/Nuke.GlobalTool/templates/build.netcore.sh
+++ b/source/Nuke.GlobalTool/templates/build.netcore.sh
@@ -56,7 +56,7 @@ else
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
 fi
 
-echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"


### PR DESCRIPTION
It has been a while since I got to play with nuke. Setting up some new build projects, I stumbled across the warning 
> Could not complete checking build configurations within 500 milliseconds.

again and couldn't remember what the warning tries to tell me. So to save my future me and others from scratching their head,
I'd suggest to be slightly more helpful.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
