### PR TITLE
Add support for Name and Parameters in Azure Pipelines

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -74,7 +74,7 @@ else {
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
 }
 
-Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -67,7 +67,7 @@ else
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
 fi
 
-echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/Build.CI.AzurePipelines.cs
+++ b/build/Build.CI.AzurePipelines.cs
@@ -37,9 +37,10 @@ partial class Build
             ExecutableTarget executableTarget,
             LookupTable<ExecutableTarget, AzurePipelinesJob> jobs,
             IReadOnlyCollection<ExecutableTarget> relevantTargets,
-            AzurePipelinesImage image)
+            AzurePipelinesImage image,
+            AzurePipelinesParameter[] parameters)
         {
-            var job = base.GetJob(executableTarget, jobs, relevantTargets, image);
+            var job = base.GetJob(executableTarget, jobs, relevantTargets, image, parameters);
 
             var symbol = CustomNames.GetValueOrDefault(job.Name);
             job.DisplayName = (job.Parallel == 0

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
@@ -14,8 +14,36 @@
 # </auto-generated>
 # ------------------------------------------------------------------------------
 
+name: test_build
+
 variables:
   - group: variable-group-1
+
+parameters:
+  - name: Configuration
+    displayName: Configuration for compilation
+    type: string
+    default: Debug
+  - name: ConfigurationArray
+    type: string
+    default: Debug Release
+  - name: IgnoreFailedSources
+    type: boolean
+    default: false
+  - name: IntegerArray
+    type: number
+    default: 1 2
+  - name: Source
+    displayName: NuGet Source for Packages
+    type: string
+    default: https://api.nuget.org/v3/index.json
+  - name: StringArray
+    type: string
+    default: first second
+  - name: Verbosity
+    displayName: Logging verbosity during build execution. Default is 'Normal'.
+    type: string
+    default: Normal
 
 trigger:
   batch: true
@@ -65,7 +93,7 @@ stages:
               path: $(HOME)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Restore --skip'
+              script: './build.cmd Restore --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}})'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -96,7 +124,7 @@ stages:
               path: $(HOME)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Compile --skip'
+              script: './build.cmd Compile --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}})'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -129,7 +157,7 @@ stages:
               path: $(HOME)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Test --skip --partition $(System.JobPositionInPhase)/2'
+              script: './build.cmd Test --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}}) --partition $(System.JobPositionInPhase)/2'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -160,7 +188,7 @@ stages:
               path: $(HOME)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Coverage --skip'
+              script: './build.cmd Coverage --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}})'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -197,7 +225,7 @@ stages:
               path: $(USERPROFILE)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Restore --skip'
+              script: './build.cmd Restore --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}})'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -228,7 +256,7 @@ stages:
               path: $(USERPROFILE)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Compile --skip'
+              script: './build.cmd Compile --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}})'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -261,7 +289,7 @@ stages:
               path: $(USERPROFILE)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Test --skip --partition $(System.JobPositionInPhase)/2'
+              script: './build.cmd Test --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}}) --partition $(System.JobPositionInPhase)/2'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -292,7 +320,7 @@ stages:
               path: $(USERPROFILE)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Coverage --skip'
+              script: './build.cmd Coverage --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}})'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
@@ -124,7 +124,7 @@ stages:
               path: $(HOME)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Compile --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}})'
+              script: './build.cmd Compile --skip --Configuration ${{ parameters.Configuration }} --ConfigurationArray ${{ parameters.ConfigurationArray }} --IgnoreFailedSources ${{ parameters.IgnoreFailedSources }} --IntegerArray ${{ parameters.IntegerArray }} --Source ${{ parameters.Source }} --StringArray ${{ parameters.StringArray }} --Verbosity ${{ parameters.Verbosity }}'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -157,7 +157,7 @@ stages:
               path: $(HOME)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Test --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}}) --partition $(System.JobPositionInPhase)/2'
+              script: './build.cmd Test --skip --Configuration ${{ parameters.Configuration }} --ConfigurationArray ${{ parameters.ConfigurationArray }} --IgnoreFailedSources ${{ parameters.IgnoreFailedSources }} --IntegerArray ${{ parameters.IntegerArray }} --Source ${{ parameters.Source }} --StringArray ${{ parameters.StringArray }} --Verbosity ${{ parameters.Verbosity }} --partition $(System.JobPositionInPhase)/2'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -188,7 +188,7 @@ stages:
               path: $(HOME)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Coverage --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}})'
+              script: './build.cmd Coverage --skip --Configuration ${{ parameters.Configuration }} --ConfigurationArray ${{ parameters.ConfigurationArray }} --IgnoreFailedSources ${{ parameters.IgnoreFailedSources }} --IntegerArray ${{ parameters.IntegerArray }} --Source ${{ parameters.Source }} --StringArray ${{ parameters.StringArray }} --Verbosity ${{ parameters.Verbosity }}'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -225,7 +225,7 @@ stages:
               path: $(USERPROFILE)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Restore --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}})'
+              script: './build.cmd Restore --skip --Configuration ${{ parameters.Configuration }} --ConfigurationArray ${{ parameters.ConfigurationArray }} --IgnoreFailedSources ${{ parameters.IgnoreFailedSources }} --IntegerArray ${{ parameters.IntegerArray }} --Source ${{ parameters.Source }} --StringArray ${{ parameters.StringArray }} --Verbosity ${{ parameters.Verbosity }}'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -256,7 +256,7 @@ stages:
               path: $(USERPROFILE)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Compile --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}})'
+              script: './build.cmd Compile --skip --Configuration ${{ parameters.Configuration }} --ConfigurationArray ${{ parameters.ConfigurationArray }} --IgnoreFailedSources ${{ parameters.IgnoreFailedSources }} --IntegerArray ${{ parameters.IntegerArray }} --Source ${{ parameters.Source }} --StringArray ${{ parameters.StringArray }} --Verbosity ${{ parameters.Verbosity }}'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -289,7 +289,7 @@ stages:
               path: $(USERPROFILE)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Test --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}}) --partition $(System.JobPositionInPhase)/2'
+              script: './build.cmd Test --skip --Configuration ${{ parameters.Configuration }} --ConfigurationArray ${{ parameters.ConfigurationArray }} --IgnoreFailedSources ${{ parameters.IgnoreFailedSources }} --IntegerArray ${{ parameters.IntegerArray }} --Source ${{ parameters.Source }} --StringArray ${{ parameters.StringArray }} --Verbosity ${{ parameters.Verbosity }} --partition $(System.JobPositionInPhase)/2'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
@@ -320,7 +320,7 @@ stages:
               path: $(USERPROFILE)/.nuget/packages
           - task: CmdLine@2
             inputs:
-              script: './build.cmd Coverage --skip --Configuration ${{Configuration}}) --ConfigurationArray ${{ConfigurationArray}}) --IgnoreFailedSources ${{IgnoreFailedSources}}) --IntegerArray ${{IntegerArray}}) --Source ${{Source}}) --StringArray ${{StringArray}}) --Verbosity ${{Verbosity}})'
+              script: './build.cmd Coverage --skip --Configuration ${{ parameters.Configuration }} --ConfigurationArray ${{ parameters.ConfigurationArray }} --IgnoreFailedSources ${{ parameters.IgnoreFailedSources }} --IntegerArray ${{ parameters.IntegerArray }} --Source ${{ parameters.Source }} --StringArray ${{ parameters.StringArray }} --Verbosity ${{ parameters.Verbosity }}'
             env:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -78,6 +78,7 @@ namespace Nuke.Common.Tests.CI
                         AzurePipelinesImage.Ubuntu1804,
                         AzurePipelinesImage.Windows2019)
                     {
+                        Name = "test_build",
                         NonEntryTargets = new[] { nameof(Clean) },
                         InvokedTargets = new[] { nameof(Test) },
                         ExcludedTargets = new[] { nameof(Pack) },

--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesParameterValuesAttribute.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesParameterValuesAttribute.cs
@@ -1,0 +1,49 @@
+// Copyright 2022 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Nuke.Common.Utilities.Collections;
+
+namespace Nuke.Common.CI.AzurePipelines
+{
+    [PublicAPI]
+    [AttributeUsage(AttributeTargets.Field)]
+    public class AzurePipelinesParameterValuesAttribute : Attribute
+    {
+        public string[] Values { get; set; }
+
+        public AzurePipelinesParameterValuesAttribute(params string[] values)
+        {
+            Values = values;
+        }
+
+        public string[] GetValues(object defaultValue, Type memberType)
+        {
+            var valuesSet = new HashSet<string>(Values);
+
+            if (defaultValue == null)
+                return valuesSet.ToArray();
+
+            var defaultString = defaultValue?.ToString();
+            if (!string.IsNullOrWhiteSpace(defaultString))
+            {
+                if (memberType.IsArray && defaultValue is IEnumerable enumerable)
+                {
+                    var defaultStringList = enumerable.Cast<object>().Select(x => x.ToString());
+                    defaultStringList.ForEach(x => valuesSet.Add(x));
+                }
+                else
+                {
+                    valuesSet.Add(defaultValue.ToString());
+                }
+            }
+
+            return valuesSet.ToArray();
+        }
+    }
+}

--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesParameterValuesAttribute.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesParameterValuesAttribute.cs
@@ -26,6 +26,12 @@ namespace Nuke.Common.CI.AzurePipelines
         {
             var valuesSet = new HashSet<string>(Values);
 
+            var enumType = memberType.IsArray ? memberType.GetElementType() : memberType;
+            if(valuesSet.IsEmpty() && enumType.IsEnum)
+            {
+                return Enum.GetNames(enumType);
+            }
+
             if (defaultValue == null)
                 return valuesSet.ToArray();
 

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesCmdStep.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesCmdStep.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using JetBrains.Annotations;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
@@ -18,14 +19,20 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
         public string BuildCmdPath { get; set; }
         public int? PartitionSize { get; set; }
         public Dictionary<string, string> Imports { get; set; }
+        public AzurePipelinesParameter[] Parameters { get; set; }
 
         public override void Write(CustomFileWriter writer)
         {
             using (writer.WriteBlock("- task: CmdLine@2"))
             {
-                var arguments = $"{InvokedTargets.JoinSpace()} --skip";
+                var arguments = new StringBuilder();
+                arguments.Append($"{InvokedTargets.JoinSpace()} --skip");
+
+                if (Parameters.Length > 0)
+                    arguments.Append($" {Parameters.Select(x => $"--{x.Name} {x.TemplateVar})").JoinSpace()}");
+
                 if (PartitionSize != null)
-                    arguments += $" --partition $(System.JobPositionInPhase)/{PartitionSize}";
+                    arguments.Append($" --partition $(System.JobPositionInPhase)/{PartitionSize}");
 
                 using (writer.WriteBlock("inputs:"))
                 {

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesCmdStep.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesCmdStep.cs
@@ -29,7 +29,7 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
                 arguments.Append($"{InvokedTargets.JoinSpace()} --skip");
 
                 if (Parameters.Length > 0)
-                    arguments.Append($" {Parameters.Select(x => $"--{x.Name} {x.TemplateVar})").JoinSpace()}");
+                    arguments.Append($" {Parameters.Select(x => $"--{x.Name} {x.TemplateVar}").JoinSpace()}");
 
                 if (PartitionSize != null)
                     arguments.Append($" --partition $(System.JobPositionInPhase)/{PartitionSize}");

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesConfiguration.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesConfiguration.cs
@@ -11,6 +11,9 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
     [PublicAPI]
     public class AzurePipelinesConfiguration : ConfigurationEntity
     {
+        [CanBeNull]
+        public string Name { get; set; }
+
         public string[] VariableGroups { get; set; }
 
         [CanBeNull]
@@ -20,14 +23,30 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
         public AzurePipelinesVcsPushTrigger VcsPullRequestTrigger { get; set; }
 
         public AzurePipelinesStage[] Stages { get; set; }
+        public AzurePipelinesParameter[] Parameters { get; set; }
 
         public override void Write(CustomFileWriter writer)
         {
+            if (!string.IsNullOrWhiteSpace(Name))
+            {
+                writer.WriteLine($"name: {Name}");
+                writer.WriteLine();
+            }
+
             if (VariableGroups.Length > 0)
             {
                 using (writer.WriteBlock("variables:"))
                 {
                     VariableGroups.ForEach(x => writer.WriteLine($"- group: {x}"));
+                    writer.WriteLine();
+                }
+            }
+
+            if (Parameters.Length > 0)
+            {
+                using (writer.WriteBlock("parameters:"))
+                {
+                    Parameters.ForEach(x => x.Write(writer));
                     writer.WriteLine();
                 }
             }

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesParameter.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesParameter.cs
@@ -19,7 +19,18 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
         public string[] Values { get; set; }
 
         // Template expansion form is ${{ parameter.VARNAME }}
-        public string TemplateVar => $"${{{{ parameters.{Name} }}}}";
+        public string TemplateVar
+        {
+            get
+            {
+                var templateVar = $"${{{{ parameters.{Name} }}}}";
+                if (Type == AzurePipelinesParameterType.String)
+                    templateVar = $"\"{templateVar}\"";
+
+                return templateVar;
+            }
+        }
+
         public override void Write(CustomFileWriter writer)
         {
             using (writer.WriteBlock($"- name: {Name}"))

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesParameter.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesParameter.cs
@@ -1,0 +1,64 @@
+﻿// Copyright 2022 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using JetBrains.Annotations;
+using Nuke.Common.Utilities;
+using Nuke.Common.Utilities.Collections;
+
+namespace Nuke.Common.CI.AzurePipelines.Configuration
+{
+    [PublicAPI]
+    public class AzurePipelinesParameter : ConfigurationEntity
+    {
+        public AzurePipelinesParameterType Type { get; set; }
+        public string Name { get; set; }
+        public string DisplayName { get; set; }
+        public string Default { get; set; }
+
+        public string[] Values { get; set; }
+
+        // Template expansion form is ${{ VARNAME }}
+        public string TemplateVar => $"${{{{{Name}}}}}";
+        public override void Write(CustomFileWriter writer)
+        {
+            using (writer.WriteBlock($"- name: {Name}"))
+            {
+                if (!string.IsNullOrWhiteSpace(DisplayName))
+                    writer.WriteLine($"displayName: {DisplayName}");
+
+                switch (Type)
+                {
+                    case AzurePipelinesParameterType.String:
+                        writer.WriteLine("type: string");
+                        break;
+                    case AzurePipelinesParameterType.Number:
+                        writer.WriteLine("type: number");
+                        break;
+                    case AzurePipelinesParameterType.Boolean:
+                        writer.WriteLine("type: boolean");
+                        break;
+                    default:
+                        writer.WriteLine("type: string");
+                        break;
+                }
+
+                if (!string.IsNullOrWhiteSpace(Default))
+                {
+                    if(Type == AzurePipelinesParameterType.Boolean)
+                        writer.WriteLine($"default: {Default.ToLower()}");
+                    else
+                        writer.WriteLine($"default: {Default}");
+                }
+
+                if (Values != null && Values.Length > 0)
+                {
+                    using (writer.WriteBlock("values:"))
+                    {
+                        Values.ForEach(x => writer.WriteLine($"- {x}"));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesParameter.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesParameter.cs
@@ -18,8 +18,8 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
 
         public string[] Values { get; set; }
 
-        // Template expansion form is ${{ VARNAME }}
-        public string TemplateVar => $"${{{{{Name}}}}}";
+        // Template expansion form is ${{ parameter.VARNAME }}
+        public string TemplateVar => $"${{{{ parameters.{Name} }}}}";
         public override void Write(CustomFileWriter writer)
         {
             using (writer.WriteBlock($"- name: {Name}"))

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesParameterType.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesParameterType.cs
@@ -1,0 +1,16 @@
+﻿// Copyright 2022 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using JetBrains.Annotations;
+
+namespace Nuke.Common.CI.AzurePipelines.Configuration
+{
+    [PublicAPI]
+    public enum AzurePipelinesParameterType
+    {
+        String,
+        Number,
+        Boolean
+    }
+}

--- a/source/Nuke.GlobalTool/templates/build.netcore.ps1
+++ b/source/Nuke.GlobalTool/templates/build.netcore.ps1
@@ -63,7 +63,7 @@ else {
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
 }
 
-Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/source/Nuke.GlobalTool/templates/build.netcore.sh
+++ b/source/Nuke.GlobalTool/templates/build.netcore.sh
@@ -56,7 +56,7 @@ else
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
 fi
 
-echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
I had a personal need for slightly more expansive support for Azure Pipelines config generation, so I added in support for generating `Name` and `Parameters` to the `azure-pipelines.yml` file.  The parameters follows the pattern I found in the TeamCityAttribute.cs code.

Notes about parameters: 
- Only string, number, and boolean are supported.
  - As of right now, anything that doesn't fall into those will be set as 
string
- I had to introduce a new attribute to handle `values` in the `azure-pipelines.yml` spec.  These values turn the input into a radio button list in the UI, so it's a way to restrict values on a field to only what you want a CI user to be able to do in the CI.  
  - If applied to an enum type, and no value names are provided, the Enum values will be used instead.
- The parameters have to be passed into the command line call for nuke.  This is due to the way parameters are interpolated into the template (at run time), rather than being environment variables.

Let me know if there's any questions! 🙂 


<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
