### PR TITLE
Add ResourceTrigger build reason for AzureDevops

### DIFF
--- a/PUBLIC_API.md
+++ b/PUBLIC_API.md
@@ -1722,6 +1722,7 @@
 - PullRequest : AzurePipelinesBuildReason
 - Schedule : AzurePipelinesBuildReason
 - ValidateShelveset : AzurePipelinesBuildReason
+- ResourceTrigger : AzurePipelinesBuildReason
 
 ### Nuke.Common.CI.AzurePipelines.AzurePipelinesCodeCoverageToolType
 

--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesBuildReason.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesBuildReason.cs
@@ -30,6 +30,9 @@ namespace Nuke.Common.CI.AzurePipelines
         CheckInShelveset,
 
         /// <summary>The build was triggered by a Git branch policy that requires a build.</summary>
-        PullRequest
+        PullRequest,
+
+        /// <summary>The build was triggered by a resource trigger or it was triggered by another build.</summary>
+        ResourceTrigger
     }
 }


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Adding a missing value to fix this issue: https://github.com/nuke-build/nuke/issues/712

I'm not sure why that issue was closed when it is a real issue and such a simple issue to fix. Seems like there was an argument and the issue was closed out of spite. Regardless, this will help myself and hopefully others. I am not a sponsor which I know the contribution guidelines asks for but this is a simple change so I hope that can be overlooked.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
