### PR TITLE
Add support for Octopus CreateRelease on version controlled projects 

### DIFF
--- a/source/Nuke.Common/Tools/Octopus/Octopus.Generated.cs
+++ b/source/Nuke.Common/Tools/Octopus/Octopus.Generated.cs
@@ -233,6 +233,8 @@ namespace Nuke.Common.Tools.Octopus
         ///     <li><c>--enableServiceMessages</c> via <see cref="OctopusCreateReleaseSettings.EnableServiceMessages"/></li>
         ///     <li><c>--force</c> via <see cref="OctopusCreateReleaseSettings.Force"/></li>
         ///     <li><c>--forcepackagedownload</c> via <see cref="OctopusCreateReleaseSettings.ForcePackageDownload"/></li>
+        ///     <li><c>--gitCommit</c> via <see cref="OctopusCreateReleaseSettings.GitCommit"/></li>
+        ///     <li><c>--gitRef</c> via <see cref="OctopusCreateReleaseSettings.GitRef"/></li>
         ///     <li><c>--guidedfailure</c> via <see cref="OctopusCreateReleaseSettings.GuidedFailure"/></li>
         ///     <li><c>--ignorechannelrules</c> via <see cref="OctopusCreateReleaseSettings.IgnoreChannelRules"/></li>
         ///     <li><c>--ignoreexisting</c> via <see cref="OctopusCreateReleaseSettings.IgnoreExisting"/></li>
@@ -292,6 +294,8 @@ namespace Nuke.Common.Tools.Octopus
         ///     <li><c>--enableServiceMessages</c> via <see cref="OctopusCreateReleaseSettings.EnableServiceMessages"/></li>
         ///     <li><c>--force</c> via <see cref="OctopusCreateReleaseSettings.Force"/></li>
         ///     <li><c>--forcepackagedownload</c> via <see cref="OctopusCreateReleaseSettings.ForcePackageDownload"/></li>
+        ///     <li><c>--gitCommit</c> via <see cref="OctopusCreateReleaseSettings.GitCommit"/></li>
+        ///     <li><c>--gitRef</c> via <see cref="OctopusCreateReleaseSettings.GitRef"/></li>
         ///     <li><c>--guidedfailure</c> via <see cref="OctopusCreateReleaseSettings.GuidedFailure"/></li>
         ///     <li><c>--ignorechannelrules</c> via <see cref="OctopusCreateReleaseSettings.IgnoreChannelRules"/></li>
         ///     <li><c>--ignoreexisting</c> via <see cref="OctopusCreateReleaseSettings.IgnoreExisting"/></li>
@@ -348,6 +352,8 @@ namespace Nuke.Common.Tools.Octopus
         ///     <li><c>--enableServiceMessages</c> via <see cref="OctopusCreateReleaseSettings.EnableServiceMessages"/></li>
         ///     <li><c>--force</c> via <see cref="OctopusCreateReleaseSettings.Force"/></li>
         ///     <li><c>--forcepackagedownload</c> via <see cref="OctopusCreateReleaseSettings.ForcePackageDownload"/></li>
+        ///     <li><c>--gitCommit</c> via <see cref="OctopusCreateReleaseSettings.GitCommit"/></li>
+        ///     <li><c>--gitRef</c> via <see cref="OctopusCreateReleaseSettings.GitRef"/></li>
         ///     <li><c>--guidedfailure</c> via <see cref="OctopusCreateReleaseSettings.GuidedFailure"/></li>
         ///     <li><c>--ignorechannelrules</c> via <see cref="OctopusCreateReleaseSettings.IgnoreChannelRules"/></li>
         ///     <li><c>--ignoreexisting</c> via <see cref="OctopusCreateReleaseSettings.IgnoreExisting"/></li>
@@ -845,6 +851,14 @@ namespace Nuke.Common.Tools.Octopus
         /// </summary>
         public virtual string DefaultPackageVersion { get; internal set; }
         /// <summary>
+        ///   Git commit to use when creating the release. Use in conjunction with the --gitRef parameter to select any previous commit.
+        /// </summary>
+        public virtual string GitCommit { get; internal set; }
+        /// <summary>
+        ///   Git reference to use when creating the release.
+        /// </summary>
+        public virtual string GitRef { get; internal set; }
+        /// <summary>
         ///   Release number to use for the new release.
         /// </summary>
         public virtual string Version { get; internal set; }
@@ -1019,6 +1033,8 @@ namespace Nuke.Common.Tools.Octopus
               .Add("create-release")
               .Add("--project={value}", Project)
               .Add("--packageversion={value}", DefaultPackageVersion)
+              .Add("--gitCommit={value}", GitCommit)
+              .Add("--gitRef={value}", GitRef)
               .Add("--version={value}", Version)
               .Add("--channel={value}", Channel)
               .Add("--package={value}", PackageVersions, "{key}:{value}")
@@ -2504,6 +2520,54 @@ namespace Nuke.Common.Tools.Octopus
         {
             toolSettings = toolSettings.NewInstance();
             toolSettings.DefaultPackageVersion = null;
+            return toolSettings;
+        }
+        #endregion
+        #region GitCommit
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctopusCreateReleaseSettings.GitCommit"/></em></p>
+        ///   <p>Git commit to use when creating the release. Use in conjunction with the --gitRef parameter to select any previous commit.</p>
+        /// </summary>
+        [Pure]
+        public static T SetGitCommit<T>(this T toolSettings, string gitCommit) where T : OctopusCreateReleaseSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.GitCommit = gitCommit;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="OctopusCreateReleaseSettings.GitCommit"/></em></p>
+        ///   <p>Git commit to use when creating the release. Use in conjunction with the --gitRef parameter to select any previous commit.</p>
+        /// </summary>
+        [Pure]
+        public static T ResetGitCommit<T>(this T toolSettings) where T : OctopusCreateReleaseSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.GitCommit = null;
+            return toolSettings;
+        }
+        #endregion
+        #region GitRef
+        /// <summary>
+        ///   <p><em>Sets <see cref="OctopusCreateReleaseSettings.GitRef"/></em></p>
+        ///   <p>Git reference to use when creating the release.</p>
+        /// </summary>
+        [Pure]
+        public static T SetGitRef<T>(this T toolSettings, string gitRef) where T : OctopusCreateReleaseSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.GitRef = gitRef;
+            return toolSettings;
+        }
+        /// <summary>
+        ///   <p><em>Resets <see cref="OctopusCreateReleaseSettings.GitRef"/></em></p>
+        ///   <p>Git reference to use when creating the release.</p>
+        /// </summary>
+        [Pure]
+        public static T ResetGitRef<T>(this T toolSettings) where T : OctopusCreateReleaseSettings
+        {
+            toolSettings = toolSettings.NewInstance();
+            toolSettings.GitRef = null;
             return toolSettings;
         }
         #endregion

--- a/source/Nuke.Common/Tools/Octopus/Octopus.json
+++ b/source/Nuke.Common/Tools/Octopus/Octopus.json
@@ -144,6 +144,18 @@
             "help": "Default version number of all packages to use for this release."
           },
           {
+            "name": "GitCommit",
+            "type": "string",
+            "format": "--gitCommit={value}",
+            "help": "Git commit to use when creating the release. Use in conjunction with the --gitRef parameter to select any previous commit."
+          },
+          {
+            "name": "GitRef",
+            "type": "string",
+            "format": "--gitRef={value}",
+            "help": "Git reference to use when creating the release."
+          },
+          {
             "name": "Version",
             "type": "string",
             "format": "--version={value}",


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
#910 Add support for Octopus version controlled projects

* Added 2 additional parameters for the create release command in the `Octopus.json` tool schema
* Regenerated code for Octopus tool

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
