### PR TITLE
Handle empty lines in ProjectModelTasks.ParseSolution

### DIFF
--- a/source/Nuke.Common/ProjectModel/SolutionSerializer.cs
+++ b/source/Nuke.Common/ProjectModel/SolutionSerializer.cs
@@ -31,14 +31,14 @@ namespace Nuke.Common.ProjectModel
             var solution = new T
                            {
                                Path = (AbsolutePath) solutionFile,
-                               Header = content.TakeWhile(x => !x.StartsWith("Project")).ToArray(),
+                               Header = trimmedContent.TakeWhile(x => !x.StartsWith("Project")).ToArray(),
                                Properties = trimmedContent.GetGlobalSection("SolutionProperties", solutionFile),
                                ExtensibilityGlobals = trimmedContent.GetGlobalSection("ExtensibilityGlobals", solutionFile),
                                Configurations = trimmedContent.GetGlobalSection("SolutionConfigurationPlatforms", solutionFile)
                            };
 
-            var configurations = (content.GetGlobalSection("ProjectConfigurationPlatforms", solutionFile) ??
-                                  content.GetGlobalSection("ProjectConfiguration", solutionFile) ??
+            var configurations = (trimmedContent.GetGlobalSection("ProjectConfigurationPlatforms", solutionFile) ??
+                                  trimmedContent.GetGlobalSection("ProjectConfiguration", solutionFile) ??
                                   new Dictionary<string, string>())
                 .Select(x => new
                              {


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Lately we've been using solution file which contained empty line and been recognized by Visual Studio as a valid one. However `ProjectModelTasks.ParseSolution` fails with following stack trace.


```
   at Nuke.Common.ProjectModel.SolutionSerializer.<>c.<GetGlobalSection>b__2_4(String[] x) in D:\Projects\Nuke\source\Nuke.Common\ProjectModel\SolutionSerializer.cs:line 98
   at System.Linq.Lookup`2.Create[TSource](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at System.Linq.Enumerable.ToLookup[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at System.Linq.Enumerable.ToLookup[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
   at Nuke.Common.Utilities.Collections.EnumerableExtensions.ToDictionarySafe[T,TKey,TValue](IEnumerable`1 enumerable, Func`2 keySelector, Func`2 valueSelector, String duplicationMessage) in D:\Projects\Nuke\source\Nuke.Common\Utilities\Collections\Enumerable.ToDictionary.cs:line 46
   at Nuke.Common.ProjectModel.SolutionSerializer.GetGlobalSection(String[] lines, String name, String solutionFile) in D:\Projects\Nuke\source\Nuke.Common\ProjectModel\SolutionSerializer.cs:line 92
   at Nuke.Common.ProjectModel.SolutionSerializer.DeserializeFromContent[T](String[] content, String solutionFile) in D:\Projects\Nuke\source\Nuke.Common\ProjectModel\SolutionSerializer.cs:line 40
   at Nuke.Common.ProjectModel.SolutionSerializer.DeserializeFromFile[T](String solutionFile) in D:\Projects\Nuke\source\Nuke.Common\ProjectModel\SolutionSerializer.cs:line 23
   at Nuke.Common.ProjectModel.ProjectModelTasks.ParseSolution(String solutionFile) in D:\Projects\Nuke\source\Nuke.Common\ProjectModel\ProjectModelTasks.cs:line 93
   at Test.Program.Main(String[] args) in D:\Projects\Nuke\Test\Program.cs:line 13
```
I suggest to use `trimmedContent` wherever possible.



<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
