### PR TITLE
Improve GetGlobalInstalledPackage performance by reading NuGet metadata directly from nuspec file

### DIFF
--- a/source/Nuke.Common/Tooling/NuGetPackageResolver.cs
+++ b/source/Nuke.Common/Tooling/NuGetPackageResolver.cs
@@ -391,7 +391,11 @@ namespace Nuke.Common.Tooling
             public InstalledPackage(string fileName)
             {
                 FileName = fileName;
-                Metadata = new PackageArchiveReader(fileName).NuspecReader;
+
+                var directory = new DirectoryInfo(Path.GetDirectoryName(fileName));
+                Metadata = directory.GetFiles("*.nuspec").Length == 1
+                    ? new PackageFolderReader(directory).NuspecReader
+                    : new PackageArchiveReader(fileName).NuspecReader;
             }
 
             public string FileName { get; }


### PR DESCRIPTION
Fixes DotNetTestSettingsExtensions.AddTeamCityLogger() causes unwanted delays #913

Currently `NuGetPackageResolver.GetGlobalInstalledPackage()` always reads NuGet metadata from the nupkg file itself. Depending of the amount of referenced NuGet packages and the amount of transitive dependencies this could cause delays as each package needs to be unzipped to access the contained nuspec file.

This change improves the performance for the `PackageReference` case, as the packages are unpacked on disk during restore and the nuspec file can be read directly.

NuGet packages referenced via `packages.config` can not benefit, as they are not unpacked on disk.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
