### PR TITLE
Ability to set kustomize folder

### DIFF
--- a/source/Nuke.Common/Tools/Kubernetes/Kubernetes.json
+++ b/source/Nuke.Common/Tools/Kubernetes/Kubernetes.json
@@ -1836,6 +1836,12 @@
         "baseClass": "KubernetesToolSettings",
         "properties": [
           {
+            "name": "Kustomize",
+            "type": "string",
+            "format": "{value}",
+            "help": "Set the target folder of the kustomize files."
+          },
+          {
             "name": "All",
             "type": "bool",
             "format": "--all={value}",


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Kustomize needs to be able to set a path to a folder containing the deployment. This was missing.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
