### PR TITLE
Add retry for dotnet restore in build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -30,7 +30,7 @@ $env:NUKE_TELEMETRY_OPTOUT = 1
 # EXECUTION
 ###########################################################################
 
-function ExecSafe([scriptblock] $cmd, [int]$maxRetries = 0 ) {
+function ExecSafe([scriptblock] $cmd, [int]$maxRetries = 0) {
     $tryCount = 0
     while ($true) {
         $tryCount++


### PR DESCRIPTION
## Why

Today we experienced a lot of issues when restoring NuGet package. Retrying minimizes the probability of transient errors connected with using remote resources.

## What

Add retry for `dotnet restore` in `build.ps1`.

## Checklist

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

## Remarks

> Follows the contribution guidelines

Where are they?

Should I mention the improvement in the `CHANGELOG.md`?