### PR TITLE
Fix environment variable used in Bamboo detection

### DIFF
--- a/source/Nuke.Common/CI/Bamboo/Bamboo.cs
+++ b/source/Nuke.Common/CI/Bamboo/Bamboo.cs
@@ -19,7 +19,7 @@ namespace Nuke.Common.CI.Bamboo
     {
         public new static Bamboo Instance => Host.Instance as Bamboo;
 
-        internal static bool IsRunningBamboo => !Environment.GetEnvironmentVariable("BAMBOO_SERVER").IsNullOrEmpty();
+        internal static bool IsRunningBamboo => !Environment.GetEnvironmentVariable("bamboo_planKey").IsNullOrEmpty();
 
         internal Bamboo()
         {


### PR DESCRIPTION
Bamboo detection wasn't working for our Bamboo instance. Detected builder server was always terminal. I checked the code and it was using `BAMBOO_SERVER` environment variable. There is no such variable described in [the documentation](https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html) and detection started to work only after I manually added such system environment variable.

Changing to use known bamboo environment variable (also use in `PlanKey` property) that is set for builds running under Bamboo.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
