### PR TITLE
Support TimeSpan for timeout on ToolSettings

### DIFF
--- a/source/Nuke.Common.Tests/SettingsTest.cs
+++ b/source/Nuke.Common.Tests/SettingsTest.cs
@@ -33,7 +33,7 @@ namespace Nuke.Common.Tests
             var settings = new DotNetRunSettings()
                 .SetProcessToolPath("/path/to/dotnet")
                 .SetProcessEnvironmentVariable("key", "value")
-                .SetProcessExecutionTimeout(1_000)
+                .SetProcessExecutionTimeout(TimeSpan.FromMilliseconds(1_000))
                 .SetProcessArgumentConfigurator(_ => _
                     .Add("/switch"))
                 .EnableProcessLogInvocation();
@@ -42,10 +42,6 @@ namespace Nuke.Common.Tests
             settings.ProcessEnvironmentVariables.Should().ContainSingle(x => x.Key == "key" && x.Value == "value");
             settings.ProcessExecutionTimeout.Should().Be(1_000);
             settings.ProcessArgumentConfigurator.Invoke(new Arguments()).RenderForOutput().Should().Be("/switch");
-
-            settings = settings.SetProcessExecutionTimeout(TimeSpan.FromMilliseconds(500));
-
-            settings.ProcessExecutionTimeout.Should().Be(500);
         }
 
         [Fact]

--- a/source/Nuke.Common.Tests/SettingsTest.cs
+++ b/source/Nuke.Common.Tests/SettingsTest.cs
@@ -42,6 +42,10 @@ namespace Nuke.Common.Tests
             settings.ProcessEnvironmentVariables.Should().ContainSingle(x => x.Key == "key" && x.Value == "value");
             settings.ProcessExecutionTimeout.Should().Be(1_000);
             settings.ProcessArgumentConfigurator.Invoke(new Arguments()).RenderForOutput().Should().Be("/switch");
+
+            settings = settings.SetProcessExecutionTimeout(TimeSpan.FromMilliseconds(500));
+
+            settings.ProcessExecutionTimeout.Should().Be(500);
         }
 
         [Fact]

--- a/source/Nuke.Common/Tooling/ToolSettings.Standard.cs
+++ b/source/Nuke.Common/Tooling/ToolSettings.Standard.cs
@@ -67,11 +67,11 @@ namespace Nuke.Common.Tooling
 
         ///<summary>Sets <see cref="ToolSettings.ProcessExecutionTimeout"/> -- <inheritdoc cref="ToolSettings.ProcessExecutionTimeout" /></summary>
         [Pure]
-        public static T SetProcessExecutionTimeout<T>(this T toolSettings, [CanBeNull] TimeSpan? executionTimeout)
+        public static T SetProcessExecutionTimeout<T>(this T toolSettings, TimeSpan executionTimeout)
             where T : ToolSettings
         {
             var newToolSettings = toolSettings.NewInstance();
-            newToolSettings.ProcessExecutionTimeout = (int?)executionTimeout?.TotalMilliseconds;
+            newToolSettings.ProcessExecutionTimeout = (int?)executionTimeout.TotalMilliseconds;
             return newToolSettings;
         }
 

--- a/source/Nuke.Common/Tooling/ToolSettings.Standard.cs
+++ b/source/Nuke.Common/Tooling/ToolSettings.Standard.cs
@@ -65,6 +65,16 @@ namespace Nuke.Common.Tooling
             return newToolSettings;
         }
 
+        ///<summary>Sets <see cref="ToolSettings.ProcessExecutionTimeout"/> -- <inheritdoc cref="ToolSettings.ProcessExecutionTimeout" /></summary>
+        [Pure]
+        public static T SetProcessExecutionTimeout<T>(this T toolSettings, [CanBeNull] TimeSpan? executionTimeout)
+            where T : ToolSettings
+        {
+            var newToolSettings = toolSettings.NewInstance();
+            newToolSettings.ProcessExecutionTimeout = (int?)executionTimeout?.TotalMilliseconds;
+            return newToolSettings;
+        }
+
         ///<summary>Sets <see cref="ToolSettings.ProcessLogOutput"/> -- <inheritdoc cref="ToolSettings.ProcessLogOutput" /></summary>
         [Pure]
         public static T SetProcessLogOutput<T>(this T toolSettings, bool enableOutput)


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Add overload with `TimeSpan` for `SetProcessExecutionTimeout`. Closes #970 

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer
