### PR TITLE
Fixed invalid check for current LogLevel in ProcessException message.

### DIFF
--- a/source/Nuke.Common/Logger.cs
+++ b/source/Nuke.Common/Logger.cs
@@ -14,8 +14,6 @@ namespace Nuke.Common
     [DebuggerStepThrough]
     public static class Logger
     {
-        public static LogLevel LogLevel = LogLevel.Normal;
-
         [Obsolete("Use Serilog.Log.Write instead")]
         public static void Log(LogLevel level, string text = null)
         {

--- a/source/Nuke.Common/Tooling/ProcessException.cs
+++ b/source/Nuke.Common/Tooling/ProcessException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2021 Maintainers of NUKE.
+// Copyright 2021 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
-using Nuke.Common.Execution;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
 
@@ -31,7 +30,7 @@ namespace Nuke.Common.Tooling
                 messageBuilder.AppendLine("Error output:");
                 errorOutput.ForEach(x => messageBuilder.Append(indentation).AppendLine(x.Text));
             }
-            else if (Logging.Level <= LogLevel.Trace)
+            else if (Logger.LogLevel <= LogLevel.Trace)
             {
                 messageBuilder.AppendLine("Standard output:");
                 process.Output.ForEach(x => messageBuilder.Append(indentation).AppendLine(x.Text));

--- a/source/Nuke.Common/Tooling/ProcessException.cs
+++ b/source/Nuke.Common/Tooling/ProcessException.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
+using Nuke.Common.Execution;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
 
@@ -30,7 +31,7 @@ namespace Nuke.Common.Tooling
                 messageBuilder.AppendLine("Error output:");
                 errorOutput.ForEach(x => messageBuilder.Append(indentation).AppendLine(x.Text));
             }
-            else if (Logger.LogLevel <= LogLevel.Trace)
+            else if (Logging.Level <= LogLevel.Trace)
             {
                 messageBuilder.AppendLine("Standard output:");
                 process.Output.ForEach(x => messageBuilder.Append(indentation).AppendLine(x.Text));

--- a/source/Nuke.Common/Tooling/ProcessException.cs
+++ b/source/Nuke.Common/Tooling/ProcessException.cs
@@ -1,4 +1,4 @@
-// Copyright 2021 Maintainers of NUKE.
+﻿// Copyright 2021 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
+using Nuke.Common.Execution;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
 
@@ -30,7 +31,7 @@ namespace Nuke.Common.Tooling
                 messageBuilder.AppendLine("Error output:");
                 errorOutput.ForEach(x => messageBuilder.Append(indentation).AppendLine(x.Text));
             }
-            else if (Logger.LogLevel <= LogLevel.Trace)
+            else if (Logging.Level <= LogLevel.Trace)
             {
                 messageBuilder.AppendLine("Standard output:");
                 process.Output.ForEach(x => messageBuilder.Append(indentation).AppendLine(x.Text));

--- a/source/Nuke.Common/Tooling/ProcessTasks.cs
+++ b/source/Nuke.Common/Tooling/ProcessTasks.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
-using Nuke.Common.Execution;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
 using Serilog;
@@ -244,7 +243,7 @@ namespace Nuke.Common.Tooling
 
         public static void CheckPathEnvironmentVariable()
         {
-            if (Logging.Level >= LogLevel.Normal)
+            if (Logger.LogLevel >= LogLevel.Normal)
                 return;
 
             EnvironmentInfo.Variables

--- a/source/Nuke.Common/Tooling/ProcessTasks.cs
+++ b/source/Nuke.Common/Tooling/ProcessTasks.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
+using Nuke.Common.Execution;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
 using Serilog;
@@ -243,7 +244,7 @@ namespace Nuke.Common.Tooling
 
         public static void CheckPathEnvironmentVariable()
         {
-            if (Logger.LogLevel >= LogLevel.Normal)
+            if (Logging.Level >= LogLevel.Normal)
                 return;
 
             EnvironmentInfo.Variables


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

`Logger` was deprecated some time ago, and it seems that the `Logger.LogLevel` property is always `LogLevel.Normal` now.  
This broke the formatting of exception messages for `ProcessException` so that they no longer included the tool output if verbosity was set to Verbose (or Trace). The correct place to check current log level seems to be `Logging.Level`. Updated the message formatting in `ProcessException` to fix this.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
