### PR TITLE
Improved error message when enum conversion fails.

### DIFF
--- a/source/Nuke.Common/Utilities/ReflectionUtility.Conversion.cs
+++ b/source/Nuke.Common/Utilities/ReflectionUtility.Conversion.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
+using System;
 using System.ComponentModel;
 using JetBrains.Annotations;
 
@@ -30,7 +31,14 @@ namespace Nuke.Common.Utilities
             }
             catch
             {
-                Assert.Fail($"Value '{value}' could not be converted to '{GetDisplayShortName(destinationType)}'");
+                var errorMessage = $"Value '{value}' could not be converted to '{GetDisplayShortName(destinationType)}'.";
+
+                // Check if we have an enum type, if so list the possible values in the error message.
+                var enumType = Nullable.GetUnderlyingType(destinationType) ?? destinationType;
+                if (enumType.IsEnum)
+                    errorMessage += $" Accepted values are: {string.Join(", ", Enum.GetNames(enumType))}";
+
+                Assert.Fail(errorMessage);
                 // ReSharper disable once HeuristicUnreachableCode
                 return null;
             }


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Added list of valid values to exception message when enum value conversion fails. 

Example: 
`Value 'verbosd' could not be converted to 'Verbosity?'. Accepted values are: Verbose, Normal, Minimal, Quiet`


<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
