### PR TITLE
Add reminder to clear clipboard after secret was added

### DIFF
--- a/source/Nuke.GlobalTool/Program.Secrets.cs
+++ b/source/Nuke.GlobalTool/Program.Secrets.cs
@@ -78,6 +78,9 @@ namespace Nuke.GlobalTool
                     if (choice == DeletePasswordAndExit)
                         DeletePasswordFromCredentialStore(credentialStoreName);
 
+                    if (addedSecrets.Any())
+                        Host.Information("Remember to clear your clipboard!");
+
                     return 0;
                 }
             }


### PR DESCRIPTION
This adds a reminder to clear the clipboard after secret was added.

Fixes #960 

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
