### PR TITLE
WIP on-prem agent Azure pipeline pool logic

### DIFF
--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesImage.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesImage.cs
@@ -1,4 +1,4 @@
-// Copyright 2021 Maintainers of NUKE.
+﻿// Copyright 2021 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -26,6 +26,7 @@ namespace Nuke.Common.CI.AzurePipelines
         [EnumValue("macOS-latest")] MacOsLatest,
         [EnumValue("macOS-11")] MacOs11,
         [EnumValue("macOS-10.15")] MacOs1015,
-        [EnumValue("macOS-10.14")] MacOs1014
+        [EnumValue("macOS-10.14")] MacOs1014,
+        [EnumValue("OnPrem")] OnPrem
     }
 }

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesCacheStep.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesCacheStep.cs
@@ -15,13 +15,14 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
     public class AzurePipelinesCacheStep : AzurePipelinesStep
     {
         public AzurePipelinesImage Image { get; set; }
+        public string OnPremPoolName { get; set; }
         public string[] KeyFiles { get; set; }
         public string Path { get; set; }
 
-        private string AdjustedPath =>
+        private string AdjustedPath => Image.Equals(default(AzurePipelinesImage)) ?
             Image.GetValue().StartsWithAnyOrdinalIgnoreCase("ubuntu", "macos")
                 ? Path.Replace("~", "$(HOME)")
-                : Path.Replace("~", "$(USERPROFILE)");
+                : Path.Replace("~", "$(USERPROFILE)") : OnPremPoolName;
 
         private string Identifier => Path
             .Replace(".", "/")

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesStage.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesStage.cs
@@ -1,4 +1,4 @@
-// Copyright 2021 Maintainers of NUKE.
+﻿// Copyright 2021 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -16,6 +16,7 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
     {
         public string Name { get; set; }
         public string DisplayName { get; set; }
+        public string PoolName { get; set; }
         public AzurePipelinesImage? Image { get; set; }
         public AzurePipelinesStage[] Dependencies { get; set; }
         public AzurePipelinesJob[] Jobs { get; set; }
@@ -33,6 +34,11 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
                     {
                         writer.WriteLine($"vmImage: {Image.Value.GetValue().SingleQuote()}");
                     }
+                }
+
+                if (PoolName != string.Empty)
+                {
+                    writer.WriteLine($"pool: {PoolName.SingleQuote()}");
                 }
 
                 using (writer.WriteBlock("jobs:"))


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
This PR addresses #1019, I added a new AzurePipelineImage of OnPrem and a string array property `OnPremPools`.

The code in AzurePipelinesAttribute is a bit of copy and paste of GetStage, GetJob and GetSteps to allow the pool name to be passed as a string rather than passing the AzurePipelineImage and the nested ternary in AzurePipelinesCacheStep AdjustedPath needs improving, but it is currently working as I hoped.

Input like
``` 
[AzurePipelines(
    suffix: null,
    AzurePipelinesImage.OnPrem,
    OnPremPools = new[] { "my-onprem-pool" },
```
give me the output I want
```
stages:
  - stage: my_onprem_pool
    displayName: 'my-onprem-pool'
    dependsOn: [  ]
    pool: 'my-onprem-pool'
```

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [ x ] Follows the contribution guidelines
- [ x ] Is based on my own work
- [ x ] Is in compliance with my employer
