### PR TITLE
fix: do not recurse into symlinked directories

### DIFF
--- a/source/Nuke.Common/IO/FileSystemTasks.cs
+++ b/source/Nuke.Common/IO/FileSystemTasks.cs
@@ -112,8 +112,12 @@ namespace Nuke.Common.IO
             if (!Directory.Exists(directory))
                 return;
 
-            Directory.GetFiles(directory).ForEach(DeleteFileInternal);
-            Directory.GetDirectories(directory).ForEach(DeleteDirectoryInternal);
+            // Check if directory is not a symlink
+            if (!File.GetAttributes(directory).HasFlag(FileAttributes.ReparsePoint))
+            {
+                Directory.GetFiles(directory).ForEach(DeleteFileInternal);
+                Directory.GetDirectories(directory).ForEach(DeleteDirectoryInternal);
+            }
 
             Log.Verbose("Deleting directory {Directory}...", directory);
             Directory.Delete(directory, recursive: false);


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Fixes #1037 

I couldn't come up with a unit test, because .net 5 does not have APIs to create symlinks (they are introduced in .net 7). I've tested the code manually and it appears to work.

The change stops the recursion of FileSystemTasks.DeleteDirectory at folders that have the ReparsePoint FileAttribute. Recursing into these folders does not match the expected behavior and is often dangerous (see #1037).

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
