### PR TITLE
Update Azure Pipelines Publish step

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
@@ -70,7 +70,6 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
-            displayName: 'Publish artifact src'
             inputs:
               artifactName: src
               pathToPublish: 'src'
@@ -102,7 +101,6 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
-            displayName: 'Publish artifact src'
             inputs:
               artifactName: src
               pathToPublish: 'src'
@@ -136,7 +134,6 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
-            displayName: 'Publish artifact test-results'
             inputs:
               artifactName: test-results
               pathToPublish: 'output/test-results'
@@ -168,7 +165,6 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
-            displayName: 'Publish artifact coverage-report.zip'
             inputs:
               artifactName: coverage-report.zip
               pathToPublish: 'output/coverage-report.zip'
@@ -206,7 +202,6 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
-            displayName: 'Publish artifact src'
             inputs:
               artifactName: src
               pathToPublish: 'src'
@@ -238,7 +233,6 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
-            displayName: 'Publish artifact src'
             inputs:
               artifactName: src
               pathToPublish: 'src'
@@ -272,7 +266,6 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
-            displayName: 'Publish artifact test-results'
             inputs:
               artifactName: test-results
               pathToPublish: 'output/test-results'
@@ -304,7 +297,6 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
-            displayName: 'Publish artifact coverage-report.zip'
             inputs:
               artifactName: coverage-report.zip
               pathToPublish: 'output/coverage-report.zip'

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
@@ -72,7 +72,7 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs:
               artifactName: src
-              pathtoPublish: 'src'
+              pathToPublish: 'src'
       - job: Compile
         displayName: 'Compile'
         dependsOn: [ Restore ]
@@ -103,7 +103,7 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs:
               artifactName: src
-              pathtoPublish: 'src'
+              pathToPublish: 'src'
       - job: Test
         displayName: 'Test'
         dependsOn: [ Compile ]
@@ -136,7 +136,7 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs:
               artifactName: test-results
-              pathtoPublish: 'output/test-results'
+              pathToPublish: 'output/test-results'
       - job: Coverage
         displayName: 'Coverage'
         dependsOn: [ Test ]
@@ -167,7 +167,7 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs:
               artifactName: coverage-report.zip
-              pathtoPublish: 'output/coverage-report.zip'
+              pathToPublish: 'output/coverage-report.zip'
   - stage: windows_2019
     displayName: 'windows-2019'
     dependsOn: [  ]
@@ -204,7 +204,7 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs:
               artifactName: src
-              pathtoPublish: 'src'
+              pathToPublish: 'src'
       - job: Compile
         displayName: 'Compile'
         dependsOn: [ Restore ]
@@ -235,7 +235,7 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs:
               artifactName: src
-              pathtoPublish: 'src'
+              pathToPublish: 'src'
       - job: Test
         displayName: 'Test'
         dependsOn: [ Compile ]
@@ -268,7 +268,7 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs:
               artifactName: test-results
-              pathtoPublish: 'output/test-results'
+              pathToPublish: 'output/test-results'
       - job: Coverage
         displayName: 'Coverage'
         dependsOn: [ Test ]
@@ -299,4 +299,4 @@ stages:
           - task: PublishBuildArtifacts@1
             inputs:
               artifactName: coverage-report.zip
-              pathtoPublish: 'output/coverage-report.zip'
+              pathToPublish: 'output/coverage-report.zip'

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
@@ -70,6 +70,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
+            displayName: 'Publish artifact src'
             inputs:
               artifactName: src
               pathToPublish: 'src'
@@ -101,6 +102,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
+            displayName: 'Publish artifact src'
             inputs:
               artifactName: src
               pathToPublish: 'src'
@@ -134,6 +136,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
+            displayName: 'Publish artifact test-results'
             inputs:
               artifactName: test-results
               pathToPublish: 'output/test-results'
@@ -165,6 +168,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
+            displayName: 'Publish artifact coverage-report.zip'
             inputs:
               artifactName: coverage-report.zip
               pathToPublish: 'output/coverage-report.zip'
@@ -202,6 +206,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
+            displayName: 'Publish artifact src'
             inputs:
               artifactName: src
               pathToPublish: 'src'
@@ -233,6 +238,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
+            displayName: 'Publish artifact src'
             inputs:
               artifactName: src
               pathToPublish: 'src'
@@ -266,6 +272,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
+            displayName: 'Publish artifact test-results'
             inputs:
               artifactName: test-results
               pathToPublish: 'output/test-results'
@@ -297,6 +304,7 @@ stages:
               SYSTEM_ACCESSTOKEN: $(System.AccessToken)
               ApiKey: $(ApiKey)
           - task: PublishBuildArtifacts@1
+            displayName: 'Publish artifact coverage-report.zip'
             inputs:
               artifactName: coverage-report.zip
               pathToPublish: 'output/coverage-report.zip'

--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
@@ -286,9 +286,11 @@ namespace Nuke.Common.CI.AzurePipelines
 
             foreach (var publishedArtifact in publishedArtifacts)
             {
+                var artifactName = publishedArtifact.Split('/').Last();
                 yield return new AzurePipelinesPublishStep
                              {
-                                 ArtifactName = publishedArtifact.Split('/').Last(),
+                                 DisplayName = $"Publish artifact {artifactName}",
+                                 ArtifactName = artifactName,
                                  PathToPublish = publishedArtifact
                              };
             }

--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
@@ -289,7 +289,6 @@ namespace Nuke.Common.CI.AzurePipelines
                 var artifactName = publishedArtifact.Split('/').Last();
                 yield return new AzurePipelinesPublishStep
                              {
-                                 DisplayName = $"Publish artifact {artifactName}",
                                  ArtifactName = artifactName,
                                  PathToPublish = publishedArtifact
                              };

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesPublishStep.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesPublishStep.cs
@@ -12,6 +12,7 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
     [PublicAPI]
     public class AzurePipelinesPublishStep : AzurePipelinesStep
     {
+        public string DisplayName { get; set; }
         public string ArtifactName { get; set; }
         public string PathToPublish { get; set; }
 
@@ -19,6 +20,9 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
         {
             using (writer.WriteBlock("- task: PublishBuildArtifacts@1"))
             {
+                if (!string.IsNullOrWhiteSpace(DisplayName))
+                    writer.WriteLine($"displayName: {DisplayName.SingleQuote()}");
+
                 using (writer.WriteBlock("inputs:"))
                 {
                     writer.WriteLine($"artifactName: {ArtifactName}");

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesPublishStep.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesPublishStep.cs
@@ -12,7 +12,6 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
     [PublicAPI]
     public class AzurePipelinesPublishStep : AzurePipelinesStep
     {
-        public string DisplayName { get; set; }
         public string ArtifactName { get; set; }
         public string PathToPublish { get; set; }
 
@@ -20,9 +19,6 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
         {
             using (writer.WriteBlock("- task: PublishBuildArtifacts@1"))
             {
-                if (!string.IsNullOrWhiteSpace(DisplayName))
-                    writer.WriteLine($"displayName: {DisplayName.SingleQuote()}");
-
                 using (writer.WriteBlock("inputs:"))
                 {
                     writer.WriteLine($"artifactName: {ArtifactName}");

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesPublishStep.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesPublishStep.cs
@@ -22,7 +22,7 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
                 using (writer.WriteBlock("inputs:"))
                 {
                     writer.WriteLine($"artifactName: {ArtifactName}");
-                    writer.WriteLine($"pathtoPublish: {PathToPublish.SingleQuote()}");
+                    writer.WriteLine($"pathToPublish: {PathToPublish.SingleQuote()}");
                 }
             }
         }


### PR DESCRIPTION
I'm currently working on implementing support for Azure DevOps **Server**.
While I was doing that, I found small issue which also apply to DevOps **Services**:
1. `pathtoPublish` is a small typo, `pathToPublish` is correct
2. If you have multiple targets creating artifacts, the generated `PublishBuildArtifacts@1` always have the same display name. So, I've introduced new `DisplayName` property which is build from artifacts name.

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer
