### PR TITLE
Expose ExitCode on ProcessException

### DIFF
--- a/source/Nuke.Common/Tooling/ProcessException.cs
+++ b/source/Nuke.Common/Tooling/ProcessException.cs
@@ -54,5 +54,7 @@ namespace Nuke.Common.Tooling
         }
 
         internal IProcess Process { get; }
+
+        public int ExitCode => Process.ExitCode;
     }
 }


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

* Expose the exit code on `ProcessException`.

It would be immensly useful to be able to get the actual exit code instead of parsing the error message.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
