### PR TITLE
Fix `ExitCode` cannot be accessed because the underlying process has been detached

### DIFF
--- a/source/Nuke.Tooling/ProcessException.cs
+++ b/source/Nuke.Tooling/ProcessException.cs
@@ -45,6 +45,7 @@ namespace Nuke.Common.Tooling
             : base(FormatMessage(process))
         {
             Process = process;
+            ExitCode = process.ExitCode;
         }
 
         protected ProcessException(
@@ -56,6 +57,6 @@ namespace Nuke.Common.Tooling
 
         internal IProcess Process { get; }
 
-        public int ExitCode => Process.ExitCode;
+        public int ExitCode { get; }
     }
 }


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

When catching `ProcessException`, `ExitCode` cannot be accessed because the underlying process seems to be detached. Fix this by saving `ExitCode` on `ProcessException` creation.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
