### PR TITLE
Remove empty lines from changelog before parsing

### DIFF
--- a/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
+++ b/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using JetBrains.Annotations;
 using NuGet.Versioning;
@@ -46,7 +47,7 @@ namespace Nuke.Common.ChangeLog
         [Pure]
         public static IReadOnlyList<ReleaseNotes> ReadReleaseNotes(string changelogFile)
         {
-            var lines = TextTasks.ReadAllLines(changelogFile).ToList();
+            var lines = File.ReadAllLines(changelogFile).Where(x => !x.IsNullOrWhiteSpace()).ToList();
             var releaseSections = GetReleaseSections(lines).ToList();
 
             Assert.True(releaseSections.Any(), "Changelog should have at least one release note section");


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Remove empty lines from the already read changelog lines before parsing it further in `ReadReleaseNotes`, similar to the already existing code in `ExtractChangelogSectionNotes`.

`ReadReleaseNotes` now accepts an `AbsolutePath` instead of a `string` as input, but it should make no difference to the public interface as `AbsolutePath` has an implicit conversion operator for `string`.

Closes #1094 

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
