### PR TITLE
Fix LatestMavenVersionAttribute

### DIFF
--- a/source/Nuke.Common/Attributes/LatestMavenVersionAttribute.cs
+++ b/source/Nuke.Common/Attributes/LatestMavenVersionAttribute.cs
@@ -29,7 +29,7 @@ namespace Nuke.Common.Tooling
         public override object GetValue(MemberInfo member, object instance)
         {
             var endpoint = _repository.TrimStart("https").TrimStart("http").TrimStart("://").TrimEnd("/");
-            var uri = $"https://{endpoint}/m2/{_groupId.Replace(".", "/")}/{_artifactId ?? _groupId}/maven-metadata.xml";
+            var uri = $"https://{endpoint}/{_groupId.Replace(".", "/")}/{_artifactId ?? _groupId}/maven-metadata.xml";
             var content = HttpTasks.HttpDownloadString(uri);
             return XmlTasks.XmlPeekFromString(content, ".//version").Last();
         }

--- a/source/Nuke.Common/Attributes/LatestMavenVersionAttribute.cs
+++ b/source/Nuke.Common/Attributes/LatestMavenVersionAttribute.cs
@@ -31,7 +31,7 @@ namespace Nuke.Common.Tooling
             var endpoint = _repository.TrimStart("https").TrimStart("http").TrimStart("://").TrimEnd("/");
             var uri = $"https://{endpoint}/{_groupId.Replace(".", "/")}/{_artifactId ?? _groupId}/maven-metadata.xml";
             var content = HttpTasks.HttpDownloadString(uri);
-            return XmlTasks.XmlPeekFromString(content, ".//version").Last();
+            return XmlTasks.XmlPeekFromString(content, ".//latest").Single();
         }
     }
 }


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Removed the hardcoded `m2` route part from the LatestMavenVersion attribute url construction.
The api prefix can be supplied by as part of the repository argument (this fixes #1103 which also contains more detailed information)

Other than that, while fixing the issue above, I noticed that the actual version returned across maven repositories wasn't consistent either as the versions listed in `maven-metadata.xml` are apparently not ordered the same way across repository implementations, mainly an issue in case build information suffixes are being used in the version number (Eg: 1.0.0-rc.1 vs 1.0.0). This was fixed by reading the `<latest>` attribute instead of getting the version from the last `<version>` attribute.



<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
