### PR TITLE
Fix ExtractChangelogSectionNotes not throwing the intended exception

### DIFF
--- a/source/Nuke.Common.Tests/SettingsTest.cs
+++ b/source/Nuke.Common.Tests/SettingsTest.cs
@@ -30,18 +30,22 @@ namespace Nuke.Common.Tests
         [Fact]
         public void TestCommon()
         {
+            var logEntry = default((OutputType Type, string String));
             var settings = new DotNetRunSettings()
                 .SetProcessToolPath("/path/to/dotnet")
                 .SetProcessEnvironmentVariable("key", "value")
                 .SetProcessExecutionTimeout(TimeSpan.FromMilliseconds(1_000))
                 .SetProcessArgumentConfigurator(_ => _
                     .Add("/switch"))
+                .SetProcessCustomLogger((type, str) => logEntry = (type, str))
                 .EnableProcessLogInvocation();
+            settings.ProcessCustomLogger.Invoke(OutputType.Err, "text");
 
             settings.ProcessToolPath.Should().Be("/path/to/dotnet");
             settings.ProcessEnvironmentVariables.Should().ContainSingle(x => x.Key == "key" && x.Value == "value");
             settings.ProcessExecutionTimeout.Should().Be(1_000);
             settings.ProcessArgumentConfigurator.Invoke(new Arguments()).RenderForOutput().Should().Be("/switch");
+            logEntry.Should().Be((OutputType.Err, "text"));
         }
 
         [Fact]

--- a/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
+++ b/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using JetBrains.Annotations;
 using NuGet.Versioning;
@@ -46,7 +47,7 @@ namespace Nuke.Common.ChangeLog
         [Pure]
         public static IReadOnlyList<ReleaseNotes> ReadReleaseNotes(string changelogFile)
         {
-            var lines = TextTasks.ReadAllLines(changelogFile).ToList();
+            var lines = File.ReadAllLines(changelogFile).Where(x => !x.IsNullOrWhiteSpace()).ToList();
             var releaseSections = GetReleaseSections(lines).ToList();
 
             Assert.True(releaseSections.Any(), "Changelog should have at least one release note section");

--- a/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
+++ b/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
@@ -169,7 +169,7 @@ namespace Nuke.Common.ChangeLog
             var sections = GetReleaseSections(content);
             var section = tag == null
                 ? sections.First(x => x.StartIndex < x.EndIndex)
-                : sections.First(x => x.Caption.EqualsOrdinalIgnoreCase(tag)).NotNull($"Could not find release section for '{tag}'.");
+                : sections.FirstOrDefault(x => x.Caption.EqualsOrdinalIgnoreCase(tag)).NotNull($"Could not find release section for '{tag}'.");
 
             return content
                 .Skip(section.StartIndex + 1)

--- a/source/Nuke.Tooling/SettingsEntity.NewInstance.cs
+++ b/source/Nuke.Tooling/SettingsEntity.NewInstance.cs
@@ -25,7 +25,10 @@ namespace Nuke.Common.Tooling
 
             var newInstance = (T) binaryFormatter.Deserialize(memoryStream);
             if (newInstance is ToolSettings toolSettings)
+            {
                 toolSettings.ProcessArgumentConfigurator = ((ToolSettings) (object) settingsEntity).ProcessArgumentConfigurator;
+                toolSettings.ProcessCustomLogger = ((ToolSettings) (object) settingsEntity).ProcessCustomLogger;
+            }
 
             return newInstance;
         }

--- a/source/Nuke.Tooling/ToolSettings.cs
+++ b/source/Nuke.Tooling/ToolSettings.cs
@@ -33,6 +33,7 @@ namespace Nuke.Common.Tooling
         public bool? ProcessLogOutput { get; internal set; }
         public bool? ProcessLogInvocation { get; internal set; }
 
+        [field: NonSerialized]
         public virtual Action<OutputType, string> ProcessCustomLogger { get; internal set; }
 
         [NonSerialized]


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

The `ExtractChangelogSectionNotes()` method if provided with a tag string that does not exist in the changelog throws an exception with the message `"Sequence contains no matching element"`, instead of the intended exception message `"Could not find release section for '{tag}'."` defined here:
https://github.com/nuke-build/nuke/blob/6506f3081926e89232e1811b77f5c984a7bf17b5/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs#L172

Consider the changelog to look similar to this:
```markdown
# Changelog
## [Unreleased]
### Added
- Some text that spans
  multiple lines
- A text on a single line

## [0.2.3] - 2023-01-02
### Fixed
- Fixed something
```
Calling the method with a non-existing tag (in this case "4.0.4")
```csharp
ChangelogTasks.ExtractChangelogSectionNotes(<pathToChangelogFile>, "4.0.4")
```
would result in an exception with the message `"Sequence contains no matching element"` instead of `"Could not find release section for '4.0.4'."`

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
