### PR TITLE
Fix ReleaseSection end index when changelog contains empty lines

### DIFF
--- a/source/Nuke.Common.Tests/SettingsTest.cs
+++ b/source/Nuke.Common.Tests/SettingsTest.cs
@@ -30,18 +30,22 @@ namespace Nuke.Common.Tests
         [Fact]
         public void TestCommon()
         {
+            var logEntry = default((OutputType Type, string String));
             var settings = new DotNetRunSettings()
                 .SetProcessToolPath("/path/to/dotnet")
                 .SetProcessEnvironmentVariable("key", "value")
                 .SetProcessExecutionTimeout(TimeSpan.FromMilliseconds(1_000))
                 .SetProcessArgumentConfigurator(_ => _
                     .Add("/switch"))
+                .SetProcessCustomLogger((type, str) => logEntry = (type, str))
                 .EnableProcessLogInvocation();
+            settings.ProcessCustomLogger.Invoke(OutputType.Err, "text");
 
             settings.ProcessToolPath.Should().Be("/path/to/dotnet");
             settings.ProcessEnvironmentVariables.Should().ContainSingle(x => x.Key == "key" && x.Value == "value");
             settings.ProcessExecutionTimeout.Should().Be(1_000);
             settings.ProcessArgumentConfigurator.Invoke(new Arguments()).RenderForOutput().Should().Be("/switch");
+            logEntry.Should().Be((OutputType.Err, "text"));
         }
 
         [Fact]

--- a/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
+++ b/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using JetBrains.Annotations;
 using NuGet.Versioning;
@@ -46,7 +47,7 @@ namespace Nuke.Common.ChangeLog
         [Pure]
         public static IReadOnlyList<ReleaseNotes> ReadReleaseNotes(string changelogFile)
         {
-            var lines = TextTasks.ReadAllLines(changelogFile).ToList();
+            var lines = File.ReadAllLines(changelogFile).Where(x => !x.IsNullOrWhiteSpace()).ToList();
             var releaseSections = GetReleaseSections(lines).ToList();
 
             Assert.True(releaseSections.Any(), "Changelog should have at least one release note section");

--- a/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
+++ b/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
@@ -207,15 +207,15 @@ namespace Nuke.Common.ChangeLog
                 }
 
                 var caption = GetCaption(line);
-                var nextNonReleaseContentIndex = content.FindIndex(index + 1, x => IsReleaseHead(x) || !IsReleaseContent(x));
+                var nextReleaseHeadIndex = content.FindIndex(index + 1, IsReleaseHead);
 
                 var releaseData =
                     new ReleaseSection
                     {
                         Caption = caption,
                         StartIndex = index,
-                        EndIndex = nextNonReleaseContentIndex != -1
-                            ? nextNonReleaseContentIndex - 1
+                        EndIndex = nextReleaseHeadIndex >= 0
+                            ? nextReleaseHeadIndex - 1
                             : content.Count - 1
                     };
 

--- a/source/Nuke.Tooling/SettingsEntity.NewInstance.cs
+++ b/source/Nuke.Tooling/SettingsEntity.NewInstance.cs
@@ -25,7 +25,10 @@ namespace Nuke.Common.Tooling
 
             var newInstance = (T) binaryFormatter.Deserialize(memoryStream);
             if (newInstance is ToolSettings toolSettings)
+            {
                 toolSettings.ProcessArgumentConfigurator = ((ToolSettings) (object) settingsEntity).ProcessArgumentConfigurator;
+                toolSettings.ProcessCustomLogger = ((ToolSettings) (object) settingsEntity).ProcessCustomLogger;
+            }
 
             return newInstance;
         }

--- a/source/Nuke.Tooling/ToolSettings.cs
+++ b/source/Nuke.Tooling/ToolSettings.cs
@@ -33,6 +33,7 @@ namespace Nuke.Common.Tooling
         public bool? ProcessLogOutput { get; internal set; }
         public bool? ProcessLogInvocation { get; internal set; }
 
+        [field: NonSerialized]
         public virtual Action<OutputType, string> ProcessCustomLogger { get; internal set; }
 
         [NonSerialized]


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

When calculating the end index for the current release section in a changelog, only take the next release header into account.
This will guarantee that list items that span multiple lines don't get cut off.

Closes #1099 

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
