### PR TITLE
Update azure pipelines download step

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
@@ -158,6 +158,14 @@ stages:
               key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(HOME)/.nuget/packages
+          - task: DownloadBuildArtifacts@0
+            inputs:
+              buildType: 'current'
+              downloadType: 'specific'
+              itemPattern: |
+                output/test-results/*.trx
+                output/test-results/*.xml
+              downloadPath: '$(Build.Repository.LocalPath)'
           - task: CmdLine@2
             inputs:
               script: './build.cmd Coverage --skip'
@@ -290,6 +298,14 @@ stages:
               key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(USERPROFILE)/.nuget/packages
+          - task: DownloadBuildArtifacts@0
+            inputs:
+              buildType: 'current'
+              downloadType: 'specific'
+              itemPattern: |
+                output/test-results/*.trx
+                output/test-results/*.xml
+              downloadPath: '$(Build.Repository.LocalPath)'
           - task: CmdLine@2
             inputs:
               script: './build.cmd Coverage --skip'

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesDownloadStep.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesDownloadStep.cs
@@ -12,8 +12,7 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
     [PublicAPI]
     public class AzurePipelinesDownloadStep : AzurePipelinesStep
     {
-        public string ArtifactName { get; set; }
-        public string DownloadPath { get; set; }
+        public string[] ItemPatterns { get; set; }
 
         public override void Write(CustomFileWriter writer)
         {
@@ -22,8 +21,16 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration
                 // writer.WriteLine("displayName: Download Artifacts");
                 using (writer.WriteBlock("inputs:"))
                 {
-                    writer.WriteLine($"artifactName: {ArtifactName}");
-                    writer.WriteLine($"downloadPath: {DownloadPath.SingleQuote()}");
+                    writer.WriteLine("buildType: 'current'");
+                    writer.WriteLine("downloadType: 'specific'");
+                    using (writer.WriteBlock("itemPattern: |"))
+                    {
+                        foreach (var itemPattern in ItemPatterns)
+                        {
+                            writer.WriteLine(itemPattern);
+                        }
+                    }
+                    writer.WriteLine("downloadPath: '$(Build.Repository.LocalPath)'");
                 }
             }
         }


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
I have tried to complete the implementation around the `AzurePipelinesDownloadStep` so that artifacts can be consumed from other jobs/targets. Now generates a `DownloadBuildArtifacts@0s` task that looks something like:
```
- task: DownloadBuildArtifacts@0
  inputs:
    buildType: 'current'
    downloadType: 'specific'
    itemPattern: |
      artifacts/*.zip
    downloadPath: '$(Build.Repository.LocalPath)'
```

~~As an aside I did seem to run into an issue when trying to use the updated package in anger. When running the build I got the following error:~~
```
Error output:
   Unhandled exception. System.TypeInitializationException: The type initializer for 'Nuke.Common.NukeBuild' threw an exception.
    ---> System.Exception: Resolving argument 'Host' failed.
   Value 'AzurePipelines' could not be converted to 'Host'
   Arguments were:
     [0] = --generate-configuration
     [1] = AzurePipelines
     [2] = --host
     [3] = AzurePipelines
      at Nuke.Common.Assert.Fail(String message, Exception exception) in C:\Dev\github\nuke\source\Nuke.Utilities\Assert.cs:line 28
      at Nuke.Common.ArgumentParser.ConvertArgument(String argumentName, String[] values, Type destinationType, Nullable`1 separator) in C:\Dev\github\nuke\source\Nuke.Utilities\ArgumentParser.cs:line 140
      at Nuke.Common.ArgumentParser.GetNamedArgument(String argumentName, Type destinationType, Nullable`1 separator) in C:\Dev\github\nuke\source\Nuke.Utilities\ArgumentParser.cs:line 81
      at Nuke.Common.ParameterService.GetCommandLineArgument(String argumentName, Type destinationType, Nullable`1 separator) in C:\Dev\github\nuke\source\Nuke.Build\Execution\ParameterService.cs:line 172
      at Nuke.Common.ParameterService.<GetParameter>g__TryFromCommandLineArguments|18_0(<>c__DisplayClass18_0& ) in C:\Dev\github\nuke\source\Nuke.Build\Execution\ParameterService.cs:line 143
      at Nuke.Common.ParameterService.GetParameter(String parameterName, Type destinationType, Nullable`1 separator) in C:\Dev\github\nuke\source\Nuke.Build\Execution\ParameterService.cs:line 162
      at Nuke.Common.ParameterService.GetFromMemberInfo(MemberInfo member, Type destinationType, Func`4 provider) in C:\Dev\github\nuke\source\Nuke.Build\Execution\ParameterService.cs:line 136
      at Nuke.Common.ParameterService.GetParameter[T](MemberInfo member, Type destinationType) in C:\Dev\github\nuke\source\Nuke.Build\Execution\ParameterService.Statics.cs:line 41
      at Nuke.Common.ParameterService.GetParameter[T](Expression`1 expression) in C:\Dev\github\nuke\source\Nuke.Build\Execution\ParameterService.Statics.cs:line 29
      at Nuke.Common.NukeBuild..cctor() in C:\Dev\github\nuke\source\Nuke.Build\NukeBuild.Statics.cs:line 33
      --- End of inner exception stack trace ---
      at Nuke.Common.NukeBuild.Execute[T](Expression`1[] defaultTargetExpressions) in C:\Dev\github\nuke\source\Nuke.Build\NukeBuild.cs:line 78
      at Build.Main() in C:\Dev\Racti.SampleWebApp\build\Build.cs:line 204
```
~~I tracked it down to an issue with the `Host.AvailableTypes` property which didn't seem to be returning any types. Can only assume the issue was perhaps introduced when the project was updated to target `.net6.0`. Not sure if the fix I have put in is the best, but seems to work.~~

Edit: Have removed the changes for the above fix. Not sure if it is really an issue or just me. Seems better to just stick with the original intent of this PR.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
