### PR TITLE
ChangelogTasks Unit Tests and Fixes

### DIFF
--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_1.md
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_1.md
@@ -1,0 +1,49 @@
+Some text at the top of the changelog file.
+
+# Changelog
+
+This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+
+- Added something
+
+### Fixed
+
+- Fixed something
+
+## [1.4.0] - 2023-01-05
+
+### Added
+
+- First item
+- Second item
+
+### Changed
+
+- Fixed something
+- Fixed something else
+
+## [1.0.0] - 2023-01-03
+
+### Removed
+
+- Removed something
+
+## [0.2.0] - 2023-01-02
+
+### Added
+
+- Some text that spans
+  multiple lines
+- A text on a single line
+
+## [0.1.0] - 2023-01-01
+
+### Added
+
+- Added something
+
+Some text at the end of the changelog file.

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_1.verified.txt
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_1.verified.txt
@@ -1,0 +1,84 @@
+﻿[
+  {
+    IsEmpty: false,
+    Unreleased: true,
+    Notes: [
+      ,
+      ### Added,
+      ,
+      - Added something,
+      ,
+      ### Fixed,
+      ,
+      - Fixed something,
+      
+    ],
+    StartIndex: 6,
+    EndIndex: 15
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 1.4.0,
+    Notes: [
+      ,
+      ### Added,
+      ,
+      - First item,
+      - Second item,
+      ,
+      ### Changed,
+      ,
+      - Fixed something,
+      - Fixed something else,
+      
+    ],
+    StartIndex: 16,
+    EndIndex: 27
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 1.0.0,
+    Notes: [
+      ,
+      ### Removed,
+      ,
+      - Removed something,
+      
+    ],
+    StartIndex: 28,
+    EndIndex: 33
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 0.2.0,
+    Notes: [
+      ,
+      ### Added,
+      ,
+      - Some text that spans,
+        multiple lines,
+      - A text on a single line,
+      
+    ],
+    StartIndex: 34,
+    EndIndex: 41
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 0.1.0,
+    Notes: [
+      ,
+      ### Added,
+      ,
+      - Added something,
+      ,
+      Some text at the end of the changelog file.
+    ],
+    StartIndex: 42,
+    EndIndex: 48
+  }
+]

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_2.md
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_2.md
@@ -1,0 +1,19 @@
+# Changelog
+
+This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+
+- Some text that spans
+  multiple lines
+
+- A text on a single line
+
+
+## [1.0.0] - 2023-01-01
+
+### Fixed
+
+- Fixed something

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_2.verified.txt
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_2.verified.txt
@@ -1,0 +1,32 @@
+﻿[
+  {
+    IsEmpty: false,
+    Unreleased: true,
+    Notes: [
+      ,
+      ### Added,
+      ,
+      - Some text that spans,
+        multiple lines,
+      ,
+      - A text on a single line,
+      ,
+      
+    ],
+    StartIndex: 4,
+    EndIndex: 13
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 1.0.0,
+    Notes: [
+      ,
+      ### Fixed,
+      ,
+      - Fixed something
+    ],
+    StartIndex: 14,
+    EndIndex: 18
+  }
+]

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_3.md
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_3.md
@@ -1,0 +1,53 @@
+Some text at the top of the changelog file.
+
+#    Changelog
+
+This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+
+- Added something
+
+  ### Fixed
+
+-       Fixed something
+
+## [1.4.0] - 2023-01-05
+
+### Added    
+
+
+
+
+- First item
+
+- Second item
+
+###          Changed
+
+- Fixed something
+- Fixed something else
+
+## [1.0.0] - 2023-01-03
+
+### Removed
+
+             - Removed something
+
+## [0.2.0] - 2023-01-02
+
+### Added
+
+- Some text that spans
+  multiple lines
+- A text on a single line
+
+## [0.1.0]   -     2023-01-01    
+
+### Added
+
+- Added something
+
+    Some text at the end of the changelog file.

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_3.verified.txt
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_3.verified.txt
@@ -1,0 +1,88 @@
+﻿[
+  {
+    IsEmpty: false,
+    Unreleased: true,
+    Notes: [
+      ,
+      ### Added,
+      ,
+      - Added something,
+      ,
+        ### Fixed,
+      ,
+      -       Fixed something,
+      
+    ],
+    StartIndex: 6,
+    EndIndex: 15
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 1.4.0,
+    Notes: [
+      ,
+      ### Added    ,
+      ,
+      ,
+      ,
+      ,
+      - First item,
+      ,
+      - Second item,
+      ,
+      ###          Changed,
+      ,
+      - Fixed something,
+      - Fixed something else,
+      
+    ],
+    StartIndex: 16,
+    EndIndex: 31
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 1.0.0,
+    Notes: [
+      ,
+      ### Removed,
+      ,
+                   - Removed something,
+      
+    ],
+    StartIndex: 32,
+    EndIndex: 37
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 0.2.0,
+    Notes: [
+      ,
+      ### Added,
+      ,
+      - Some text that spans,
+        multiple lines,
+      - A text on a single line,
+      
+    ],
+    StartIndex: 38,
+    EndIndex: 45
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 0.1.0,
+    Notes: [
+      ,
+      ### Added,
+      ,
+      - Added something,
+      ,
+          Some text at the end of the changelog file.
+    ],
+    StartIndex: 46,
+    EndIndex: 52
+  }
+]

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_4.md
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_4.md
@@ -1,0 +1,7 @@
+# Changelog
+This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+## [Unreleased]
+### Added
+- Some text that spans
+  multiple lines
+- A text on a single line

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_4.verified.txt
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_4.verified.txt
@@ -1,0 +1,14 @@
+﻿[
+  {
+    IsEmpty: false,
+    Unreleased: true,
+    Notes: [
+      ### Added,
+      - Some text that spans,
+        multiple lines,
+      - A text on a single line
+    ],
+    StartIndex: 2,
+    EndIndex: 6
+  }
+]

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_5.md
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_5.md
@@ -1,0 +1,10 @@
+# Changelog
+This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+## [Unreleased]
+### Added
+- Some text that spans
+  multiple lines
+- A text on a single line
+## [0.2.3] - 2023-01-02
+### Fixed
+- Fixed something

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_5.verified.txt
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_5.verified.txt
@@ -1,0 +1,25 @@
+﻿[
+  {
+    IsEmpty: false,
+    Unreleased: true,
+    Notes: [
+      ### Added,
+      - Some text that spans,
+        multiple lines,
+      - A text on a single line
+    ],
+    StartIndex: 2,
+    EndIndex: 6
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 0.2.3,
+    Notes: [
+      ### Fixed,
+      - Fixed something
+    ],
+    StartIndex: 7,
+    EndIndex: 9
+  }
+]

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_5_section_0.2.3.verified.txt
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_variant_5_section_0.2.3.verified.txt
@@ -1,0 +1,4 @@
+﻿[
+  ### Fixed,
+  - Fixed something
+]

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_variant_1.md
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_variant_1.md
@@ -1,0 +1,22 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [vNext]
+
+## [1.2.3] / 2022-01-02
+- Added something
+- Fixed something
+
+## [1.2.2] / 2022-01-01
+- Fixed something
+
+## [0.2.0] / 2020-03-17
+- Added something
+
+## [0.1.0] / 2019-03-23
+- Added something
+
+Some text at the end of the changelog

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_variant_1.verified.txt
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_variant_1.verified.txt
@@ -1,0 +1,57 @@
+﻿[
+  {
+    IsEmpty: true,
+    Unreleased: true,
+    Notes: [
+      
+    ],
+    StartIndex: 6,
+    EndIndex: 7
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 1.2.3,
+    Notes: [
+      - Added something,
+      - Fixed something,
+      
+    ],
+    StartIndex: 8,
+    EndIndex: 11
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 1.2.2,
+    Notes: [
+      - Fixed something,
+      
+    ],
+    StartIndex: 12,
+    EndIndex: 14
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 0.2.0,
+    Notes: [
+      - Added something,
+      
+    ],
+    StartIndex: 15,
+    EndIndex: 17
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 0.1.0,
+    Notes: [
+      - Added something,
+      ,
+      Some text at the end of the changelog
+    ],
+    StartIndex: 18,
+    EndIndex: 21
+  }
+]

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_variant_2.md
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_variant_2.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [vNext]
+- Changed something
+
+## [1.0.0] / 2022-01-02
+- Some text that spans
+  multiple lines
+- A text on a single line
+
+- Added something
+- Fixed something
+
+## [0.1.0] / 2019-03-23
+- Added something
+
+- Fixed something
+
+Some text at the end of the changelog

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_variant_2.verified.txt
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_variant_2.verified.txt
@@ -1,0 +1,42 @@
+﻿[
+  {
+    IsEmpty: false,
+    Unreleased: true,
+    Notes: [
+      - Changed something,
+      
+    ],
+    StartIndex: 6,
+    EndIndex: 8
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 1.0.0,
+    Notes: [
+      - Some text that spans,
+        multiple lines,
+      - A text on a single line,
+      ,
+      - Added something,
+      - Fixed something,
+      
+    ],
+    StartIndex: 9,
+    EndIndex: 16
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 0.1.0,
+    Notes: [
+      - Added something,
+      ,
+      - Fixed something,
+      ,
+      Some text at the end of the changelog
+    ],
+    StartIndex: 17,
+    EndIndex: 22
+  }
+]

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_invalid_variant_1.md
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_invalid_variant_1.md
@@ -1,0 +1,2 @@
+# Changelog
+A change log that does not comply with the format from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_invalid_variant_2.md
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_invalid_variant_2.md
@@ -1,0 +1,13 @@
+# Changelog
+A change log that does not comply with the format from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+## [Unreleased]
+### Added
+- Some text that spans
+  multiple lines
+- A text on a single line
+## [Unreleased]
+### Added
+- Second unreleased section
+## [0.2.3] - 2023-01-02
+### Fixed
+- Fixed something

--- a/source/Nuke.Common.Tests/ChangelogTasksTest.cs
+++ b/source/Nuke.Common.Tests/ChangelogTasksTest.cs
@@ -24,6 +24,7 @@ namespace Nuke.Common.Tests
 
         [Theory]
         [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+        [MemberData(nameof(AllChangelogReference_NUKE_Files))]
         public void ReadReleaseNotes_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
         {
             Action act = () => ChangelogTasks.ReadReleaseNotes(file);
@@ -33,6 +34,7 @@ namespace Nuke.Common.Tests
 
         [Theory]
         [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+        [MemberData(nameof(AllChangelogReference_NUKE_Files))]
         public void ReadReleaseNotes_ChangelogReferenceFile_ReturnsAnyReleaseNotes(AbsolutePath file)
         {
             var releaseNotes = ChangelogTasks.ReadReleaseNotes(file);
@@ -42,6 +44,7 @@ namespace Nuke.Common.Tests
 
         [Theory]
         [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+        [MemberData(nameof(AllChangelogReference_NUKE_Files))]
         public void ReadChangelog_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
         {
             Action act = () => ChangelogTasks.ReadChangelog(file);
@@ -51,6 +54,7 @@ namespace Nuke.Common.Tests
 
         [Theory]
         [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+        [MemberData(nameof(AllChangelogReference_NUKE_Files))]
         public void ExtractChangelogSectionNotes_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
         {
             Action act = () => ChangelogTasks.ExtractChangelogSectionNotes(file);
@@ -60,6 +64,7 @@ namespace Nuke.Common.Tests
 
         [Theory]
         [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+        [MemberData(nameof(AllChangelogReference_NUKE_Files))]
         public Task ReadReleaseNotes_ChangelogReferenceFile_HasParsedCorrectly(AbsolutePath file)
         {
             var releaseNotes = ChangelogTasks.ReadReleaseNotes(file);
@@ -125,6 +130,12 @@ namespace Nuke.Common.Tests
         public static IEnumerable<object[]> AllChangelogReference_1_0_0_Files
         {
             get => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_1.0.0*.md").Select(file => new object[] { file });
+        }
+        
+        [UsedImplicitly]
+        public static IEnumerable<object[]> AllChangelogReference_NUKE_Files
+        {
+            get => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_NUKE*.md").Select(file => new object[] { file });
         }
     }
 }

--- a/source/Nuke.Common.Tests/ChangelogTasksTest.cs
+++ b/source/Nuke.Common.Tests/ChangelogTasksTest.cs
@@ -1,0 +1,130 @@
+﻿// Copyright 2023 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using JetBrains.Annotations;
+using Nuke.Common.ChangeLog;
+using Nuke.Common.IO;
+using VerifyXunit;
+using Xunit;
+
+namespace Nuke.Common.Tests
+{
+    [UsesVerify]
+    public class ChangelogTasksTest
+    {
+        private static AbsolutePath RootDirectory => Constants.TryGetRootDirectoryFrom(EnvironmentInfo.WorkingDirectory).NotNull();
+
+        private static AbsolutePath PathToChangelogReferenceFiles => RootDirectory / "source" / "Nuke.Common.Tests" / "ChangelogReferenceFiles";
+
+        [Theory]
+        [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+        public void ReadReleaseNotes_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
+        {
+            Action act = () => ChangelogTasks.ReadReleaseNotes(file);
+
+            act.Should().NotThrow();
+        }
+
+        [Theory]
+        [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+        public void ReadReleaseNotes_ChangelogReferenceFile_ReturnsAnyReleaseNotes(AbsolutePath file)
+        {
+            var releaseNotes = ChangelogTasks.ReadReleaseNotes(file);
+
+            releaseNotes.Should().NotBeEmpty();
+        }
+
+        [Theory]
+        [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+        public void ReadChangelog_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
+        {
+            Action act = () => ChangelogTasks.ReadChangelog(file);
+
+            act.Should().NotThrow();
+        }
+
+        [Theory]
+        [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+        public void ExtractChangelogSectionNotes_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
+        {
+            Action act = () => ChangelogTasks.ExtractChangelogSectionNotes(file);
+
+            act.Should().NotThrow();
+        }
+
+        [Theory]
+        [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+        public Task ReadReleaseNotes_ChangelogReferenceFile_HasParsedCorrectly(AbsolutePath file)
+        {
+            var releaseNotes = ChangelogTasks.ReadReleaseNotes(file);
+
+            return Verifier.Verify(releaseNotes).UseDirectory(PathToChangelogReferenceFiles).UseFileName(file.NameWithoutExtension);
+        }
+
+        [Fact]
+        public void GetReleaseSections_ChangelogReferenceFileWithoutReleaseHead_ReturnsEmpty()
+        {
+            var changeLogFilePath = PathToChangelogReferenceFiles / "changelog_reference_invalid_variant_1.md";
+            var lines = changeLogFilePath.ReadAllLines().ToList();
+
+            ChangelogTasks.GetReleaseSections(lines).Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData("changelog_reference_1.0.0_variant_5.md", "0.2.3")]
+        public Task ExtractChangelogSectionNotes_WithTag_ReturnsSectionThatMatchesProvidedTag(string fileName, string tag)
+        {
+            var changeLogFilePath = PathToChangelogReferenceFiles / fileName;
+            var sectionNotes = ChangelogTasks.ExtractChangelogSectionNotes(changeLogFilePath, tag);
+
+            return Verifier.Verify(sectionNotes).UseDirectory(PathToChangelogReferenceFiles)
+                .UseFileName($"{changeLogFilePath.NameWithoutExtension}_section_{tag}");
+        }
+
+        [Theory]
+        [InlineData("changelog_reference_1.0.0_variant_5.md", "0.0.0")]
+        [InlineData("changelog_reference_1.0.0_variant_5.md", "9.9.9")]
+        public void ExtractChangelogSection_WithNonExistingTag_ThrowsInformativeException(string fileName, string tag)
+        {
+            var changeLogFilePath = PathToChangelogReferenceFiles / fileName;
+
+            Action act = () => ChangelogTasks.ExtractChangelogSectionNotes(changeLogFilePath, tag);
+
+            act.Should().Throw<Exception>().Where(ex => ex.Message == $"Could not find release section for '{tag}'.");
+        }
+
+        [Theory]
+        [InlineData("changelog_reference_invalid_variant_2.md")]
+        public void ReadChangelog_ChangelogFileThatHasMultipleUnreleasedSection_ThrowsInformativeException(string fileName)
+        {
+            var changeLogFilePath = PathToChangelogReferenceFiles / fileName;
+
+            Action act = () => ChangelogTasks.ReadChangelog(changeLogFilePath);
+
+            act.Should().Throw<Exception>().Where(ex => ex.Message == "Changelog should have only one draft section");
+        }
+
+        [Theory]
+        [InlineData("changelog_reference_invalid_variant_1.md")]
+        public void ReadChangelog_EmptyChangelogFile_ThrowsInformativeException(string fileName)
+        {
+            var changeLogFilePath = PathToChangelogReferenceFiles / fileName;
+
+            Action act = () => ChangelogTasks.ReadChangelog(changeLogFilePath);
+
+            act.Should().Throw<Exception>().Where(ex => ex.Message == "Changelog should have at least one release note section");
+        }
+
+        [UsedImplicitly]
+        public static IEnumerable<object[]> AllChangelogReference_1_0_0_Files
+        {
+            get => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_1.0.0*.md").Select(file => new object[] { file });
+        }
+    }
+}

--- a/source/Nuke.Common.Tests/ChangelogTasksTest.cs
+++ b/source/Nuke.Common.Tests/ChangelogTasksTest.cs
@@ -75,8 +75,8 @@ namespace Nuke.Common.Tests
         [Fact]
         public void GetReleaseSections_ChangelogReferenceFileWithoutReleaseHead_ReturnsEmpty()
         {
-            var changeLogFilePath = PathToChangelogReferenceFiles / "changelog_reference_invalid_variant_1.md";
-            var lines = changeLogFilePath.ReadAllLines().ToList();
+            var file = PathToChangelogReferenceFiles / "changelog_reference_invalid_variant_1.md";
+            var lines = file.ReadAllLines().ToList();
 
             ChangelogTasks.GetReleaseSections(lines).Should().BeEmpty();
         }
@@ -97,45 +97,43 @@ namespace Nuke.Common.Tests
         [InlineData("changelog_reference_1.0.0_variant_5.md", "9.9.9")]
         public void ExtractChangelogSection_WithNonExistingTag_ThrowsInformativeException(string fileName, string tag)
         {
-            var changeLogFilePath = PathToChangelogReferenceFiles / fileName;
+            var file = PathToChangelogReferenceFiles / fileName;
 
-            Action act = () => ChangelogTasks.ExtractChangelogSectionNotes(changeLogFilePath, tag);
+            Action act = () => ChangelogTasks.ExtractChangelogSectionNotes(file, tag);
 
-            act.Should().Throw<Exception>().Where(ex => ex.Message == $"Could not find release section for '{tag}'.");
+            act.Should().Throw<Exception>().WithMessage($"Could not find release section for '{tag}'.");
         }
 
         [Theory]
         [InlineData("changelog_reference_invalid_variant_2.md")]
         public void ReadChangelog_ChangelogFileThatHasMultipleUnreleasedSection_ThrowsInformativeException(string fileName)
         {
-            var changeLogFilePath = PathToChangelogReferenceFiles / fileName;
+            var file = PathToChangelogReferenceFiles / fileName;
 
-            Action act = () => ChangelogTasks.ReadChangelog(changeLogFilePath);
+            Action act = () => ChangelogTasks.ReadChangelog(file);
 
-            act.Should().Throw<Exception>().Where(ex => ex.Message == "Changelog should have only one draft section");
+            act.Should().Throw<Exception>().WithMessage("Changelog should have only one draft section");
         }
 
         [Theory]
         [InlineData("changelog_reference_invalid_variant_1.md")]
         public void ReadChangelog_EmptyChangelogFile_ThrowsInformativeException(string fileName)
         {
-            var changeLogFilePath = PathToChangelogReferenceFiles / fileName;
+            var file = PathToChangelogReferenceFiles / fileName;
 
-            Action act = () => ChangelogTasks.ReadChangelog(changeLogFilePath);
+            Action act = () => ChangelogTasks.ReadChangelog(file);
 
-            act.Should().Throw<Exception>().Where(ex => ex.Message == "Changelog should have at least one release note section");
+            act.Should().Throw<Exception>().WithMessage("Changelog should have at least one release note section");
         }
 
         [UsedImplicitly]
         public static IEnumerable<object[]> AllChangelogReference_1_0_0_Files
         {
-            get => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_1.0.0*.md").Select(file => new object[] { file });
+            get => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_1.0.0*.md").Select(x => new object[] { x });
         }
-        
+
         [UsedImplicitly]
         public static IEnumerable<object[]> AllChangelogReference_NUKE_Files
-        {
-            get => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_NUKE*.md").Select(file => new object[] { file });
-        }
+            => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_NUKE*.md").Select(x => new object[] { x });
     }
 }

--- a/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
+++ b/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
@@ -204,15 +204,15 @@ public static class ChangelogTasks
             }
 
             var caption = GetCaption(line);
-            var nextNonReleaseContentIndex = content.FindIndex(index + 1, x => IsReleaseHead(x) || !IsReleaseContent(x));
+            var nextReleaseHeadIndex = content.FindIndex(index + 1, IsReleaseHead);
 
             var releaseData =
                 new ReleaseSection
                 {
                     Caption = caption,
                     StartIndex = index,
-                    EndIndex = nextNonReleaseContentIndex != -1
-                        ? nextNonReleaseContentIndex - 1
+                    EndIndex = nextReleaseHeadIndex >= 0
+                        ? nextReleaseHeadIndex - 1
                         : content.Count - 1
                 };
 

--- a/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
+++ b/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
@@ -173,7 +173,7 @@ public static class ChangelogTasks
             .Take(section.EndIndex - section.StartIndex);
     }
 
-    private static IEnumerable<ReleaseSection> GetReleaseSections(List<string> content)
+    internal static IEnumerable<ReleaseSection> GetReleaseSections(List<string> content)
     {
         static bool IsReleaseHead(string str)
             => str.StartsWith("## ");
@@ -242,7 +242,7 @@ public static class ChangelogTasks
     }
 
     [DebuggerDisplay("{" + nameof(Caption) + "} [{" + nameof(StartIndex) + "}-{" + nameof(EndIndex) + "}]")]
-    private class ReleaseSection
+    internal class ReleaseSection
     {
         public string Caption;
         public int StartIndex;

--- a/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
+++ b/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
@@ -166,7 +166,7 @@ public static class ChangelogTasks
         var sections = GetReleaseSections(content);
         var section = tag == null
             ? sections.First(x => x.StartIndex < x.EndIndex)
-            : sections.First(x => x.Caption.EqualsOrdinalIgnoreCase(tag)).NotNull($"Could not find release section for '{tag}'.");
+            : sections.FirstOrDefault(x => x.Caption.EqualsOrdinalIgnoreCase(tag)).NotNull($"Could not find release section for '{tag}'.");
 
         return content
             .Skip(section.StartIndex + 1)

--- a/source/Nuke.Common/ChangeLog/ReleaseNotes.cs
+++ b/source/Nuke.Common/ChangeLog/ReleaseNotes.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using NuGet.Versioning;
 
@@ -15,7 +16,7 @@ public class ReleaseNotes
     /// <summary>
     /// Gets a value indicating whether this release notes section contains notes.
     /// </summary>
-    public bool IsEmpty => Notes.Count == 0;
+    public bool IsEmpty => Notes.All(string.IsNullOrWhiteSpace);
 
     /// <summary>
     /// Gets a value indicating whether this release notes section is unreleased (vNext).


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

- Adds unit tests for `ChangelogTasks`
- Fixes `ReleaseSection` end index when changelog contains empty lines
- Fixes `ExtractChangelogSectionNotes` not throwing the intended exception
- Fixes `IsEmpty` property on `ReleaseNotes` when `Notes` are empty strings

Closes #1099 

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
