### PR TITLE
Change type of `JobId` from `int` to `string` at coveralls.net tool

### DIFF
--- a/source/Nuke.Common/Tools/CoverallsNet/CoverallsNet.json
+++ b/source/Nuke.Common/Tools/CoverallsNet/CoverallsNet.json
@@ -112,7 +112,7 @@
           },
           {
             "name": "JobId",
-            "type": "int",
+            "type": "string",
             "format": "--jobId {value}",
             "help": "The job Id to provide to coveralls.io. Default is <c>0</c>."
           },


### PR DESCRIPTION
Fixes #1116 
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->



<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
