### PR TITLE
Fixed IsGitHubRepository throws NullReferenceException for repository…

### DIFF
--- a/source/Nuke.Common/Tools/GitHub/GitHubTasks.cs
+++ b/source/Nuke.Common/Tools/GitHub/GitHubTasks.cs
@@ -125,7 +125,7 @@ public static class GitHubTasks
 
     public static bool IsGitHubRepository(this GitRepository repository)
     {
-        return repository != null && repository.Endpoint.EqualsOrdinalIgnoreCase("github.com");
+        return repository?.Endpoint?.EqualsOrdinalIgnoreCase("github.com") ?? false;
     }
 
     public static string GetGitHubOwner(this GitRepository repository)


### PR DESCRIPTION
… without remotes.

Fixes #1102. 

<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

A `Repository` without remotes returns a `null` `EndPoint`; also consider this when returning `false`.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
