### PR TITLE
Add support for GitHub Actions job timeout and concurrency configuration

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
@@ -48,6 +48,10 @@ jobs:
   macos-latest:
     name: macos-latest
     runs-on: macos-latest
+    timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
         with:
@@ -87,6 +91,10 @@ jobs:
   ubuntu-latest:
     name: ubuntu-latest
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
         with:
@@ -126,6 +134,10 @@ jobs:
   windows-latest:
     name: windows-latest
     runs-on: windows-latest
+    timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
         with:

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -156,7 +156,9 @@ public class ConfigurationGenerationTest
                     PublishCondition = "success() || failure()",
                     Submodules = GitHubActionsSubmodules.Recursive,
                     Lfs = true,
-                    FetchDepth = 2
+                    FetchDepth = 2,
+                    TimeoutMinutes = 30,
+                    JobConcurrencyCancelInProgress = true
                 }
             );
 

--- a/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
+++ b/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
@@ -73,6 +73,11 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
     public bool PublishArtifacts { get; set; } = true;
     public string PublishCondition { get; set; }
 
+    public int TimeoutMinutes { get; set; }
+
+    public string JobConcurrencyGroup { get; set; }
+    public bool JobConcurrencyCancelInProgress { get; set; }
+
     public string[] InvokedTargets { get; set; } = new string[0];
 
     public GitHubActionsSubmodules Submodules
@@ -124,7 +129,10 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
                {
                    Name = image.GetValue().Replace(".", "_"),
                    Steps = GetSteps(image, relevantTargets).ToArray(),
-                   Image = image
+                   Image = image,
+                   TimeoutMinutes = TimeoutMinutes,
+                   ConcurrencyGroup = JobConcurrencyGroup,
+                   ConcurrencyCancelInProgress = JobConcurrencyCancelInProgress
                };
     }
 


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

This PR adds support for two useful configuration sections in GitHub Actions YAML configuration. This helps in commercial setting where build minutes count (are paid for).  Tested changes against GitHub and YAML is valid and concurrency cancellation works as expected.

## jobs.<job_id>.timeout-minutes

* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes
* default is 360 minutes which is quite high, especially if your job could get stuck

## jobs.<job_id>.concurrency

* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idconcurrency
* named this property with `Job` prefix because this could also be defined on workflow level
* if `true` without a name, generating name that is crafted for general PR use (pushes to PR cancel old job runs for that PR)

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
