### PR TITLE
Add condition support for GitHubActionsArtifactStep

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
@@ -67,16 +67,19 @@ jobs:
           RequiredInput: ${{ github.event.inputs.RequiredInput }}
       - name: 'Publish: src'
         uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
           name: src
           path: src
       - name: 'Publish: test-results'
         uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
           name: test-results
           path: output/test-results
       - name: 'Publish: coverage-report.zip'
         uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
           name: coverage-report.zip
           path: output/coverage-report.zip
@@ -102,16 +105,19 @@ jobs:
           RequiredInput: ${{ github.event.inputs.RequiredInput }}
       - name: 'Publish: src'
         uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
           name: src
           path: src
       - name: 'Publish: test-results'
         uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
           name: test-results
           path: output/test-results
       - name: 'Publish: coverage-report.zip'
         uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
           name: coverage-report.zip
           path: output/coverage-report.zip
@@ -137,16 +143,19 @@ jobs:
           RequiredInput: ${{ github.event.inputs.RequiredInput }}
       - name: 'Publish: src'
         uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
           name: src
           path: src
       - name: 'Publish: test-results'
         uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
           name: test-results
           path: output/test-results
       - name: 'Publish: coverage-report.zip'
         uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
           name: coverage-report.zip
           path: output/coverage-report.zip

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -153,6 +153,7 @@ public class ConfigurationGenerationTest
                     OnPullRequestExcludePaths = new[] { "pull_request_exclude_path/**" },
                     OnWorkflowDispatchOptionalInputs = new[] { "OptionalInput" },
                     OnWorkflowDispatchRequiredInputs = new[] { "RequiredInput" },
+                    PublishCondition = "success() || failure()",
                     Submodules = GitHubActionsSubmodules.Recursive,
                     FetchDepth = 2
                 }

--- a/source/Nuke.Common/CI/GitHubActions/Configuration/GitHubActionsArtifactStep.cs
+++ b/source/Nuke.Common/CI/GitHubActions/Configuration/GitHubActionsArtifactStep.cs
@@ -12,6 +12,7 @@ public class GitHubActionsArtifactStep : GitHubActionsStep
 {
     public string Name { get; set; }
     public string Path { get; set; }
+    public string Condition { get; set; }
 
     public override void Write(CustomFileWriter writer)
     {
@@ -20,6 +21,11 @@ public class GitHubActionsArtifactStep : GitHubActionsStep
 
         using (writer.Indent())
         {
+            if (!Condition.IsNullOrWhiteSpace())
+            {
+                writer.WriteLine($"if: {Condition}");
+            }
+
             writer.WriteLine("with:");
             using (writer.Indent())
             {

--- a/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
+++ b/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2023 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -70,6 +70,7 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
     public string[] CacheKeyFiles { get; set; } = { "**/global.json", "**/*.csproj" };
 
     public bool PublishArtifacts { get; set; } = true;
+    public string PublishCondition { get; set; }
 
     public string[] InvokedTargets { get; set; } = new string[0];
 
@@ -159,7 +160,8 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
                 yield return new GitHubActionsArtifactStep
                              {
                                  Name = artifact.ToString().TrimStart(artifact.Parent.ToString()).TrimStart('/', '\\'),
-                                 Path = Build.RootDirectory.GetUnixRelativePathTo(artifact)
+                                 Path = Build.RootDirectory.GetUnixRelativePathTo(artifact),
+                                 Condition = PublishCondition
                              };
             }
         }


### PR DESCRIPTION
Here I'm suggesting an addition to `GitHubActionsArtifactStep`, supporting the `if` clause which would allow following use case:

* running a NUKE target which will produce a report as file, containing possible failure details
* task will return non-zero exit code for build (exception), signaling there was a problem, build fails
* new `PublishCondition` generates `if`, which allows supplying rule like `success() || failure()` - even if build fails or is success, gather the artifacts (but in this case, don't do it if build was cancelled - could use `always()` if should always publish)
* the earlier behavior was that if build fails, no artifacts are gathered and the report containing problems details is lost

[Background info from stackoverflow](https://stackoverflow.com/a/58859404/111604)

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
