### PR TITLE
Add Directory.Packages.props to CacheKeyFiles glob default

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
@@ -59,7 +59,7 @@ jobs:
           path: |
             .nuke/temp
             ~/.nuget/packages
-          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
       - name: 'Run: Test'
         run: ./build.cmd Test
         env:
@@ -94,7 +94,7 @@ jobs:
           path: |
             .nuke/temp
             ~/.nuget/packages
-          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
       - name: 'Run: Test'
         run: ./build.cmd Test
         env:
@@ -129,7 +129,7 @@ jobs:
           path: |
             .nuke/temp
             ~/.nuget/packages
-          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
       - name: 'Run: Test'
         run: ./build.cmd Test
         env:

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
@@ -54,13 +54,13 @@ stages:
           - task: Cache@2
             displayName: 'Cache: nuke-temp'
             inputs:
-              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuke-temp
               path: .nuke/temp
           - task: Cache@2
             displayName: 'Cache: nuget-packages'
             inputs:
-              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(HOME)/.nuget/packages
           - task: CmdLine@2
@@ -87,13 +87,13 @@ stages:
           - task: Cache@2
             displayName: 'Cache: nuke-temp'
             inputs:
-              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuke-temp
               path: .nuke/temp
           - task: Cache@2
             displayName: 'Cache: nuget-packages'
             inputs:
-              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(HOME)/.nuget/packages
           - task: CmdLine@2
@@ -122,13 +122,13 @@ stages:
           - task: Cache@2
             displayName: 'Cache: nuke-temp'
             inputs:
-              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuke-temp
               path: .nuke/temp
           - task: Cache@2
             displayName: 'Cache: nuget-packages'
             inputs:
-              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(HOME)/.nuget/packages
           - task: CmdLine@2
@@ -155,13 +155,13 @@ stages:
           - task: Cache@2
             displayName: 'Cache: nuke-temp'
             inputs:
-              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuke-temp
               path: .nuke/temp
           - task: Cache@2
             displayName: 'Cache: nuget-packages'
             inputs:
-              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(HOME)/.nuget/packages
           - task: CmdLine@2
@@ -194,13 +194,13 @@ stages:
           - task: Cache@2
             displayName: 'Cache: nuke-temp'
             inputs:
-              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuke-temp
               path: .nuke/temp
           - task: Cache@2
             displayName: 'Cache: nuget-packages'
             inputs:
-              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(USERPROFILE)/.nuget/packages
           - task: CmdLine@2
@@ -227,13 +227,13 @@ stages:
           - task: Cache@2
             displayName: 'Cache: nuke-temp'
             inputs:
-              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuke-temp
               path: .nuke/temp
           - task: Cache@2
             displayName: 'Cache: nuget-packages'
             inputs:
-              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(USERPROFILE)/.nuget/packages
           - task: CmdLine@2
@@ -262,13 +262,13 @@ stages:
           - task: Cache@2
             displayName: 'Cache: nuke-temp'
             inputs:
-              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuke-temp
               path: .nuke/temp
           - task: Cache@2
             displayName: 'Cache: nuget-packages'
             inputs:
-              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(USERPROFILE)/.nuget/packages
           - task: CmdLine@2
@@ -295,13 +295,13 @@ stages:
           - task: Cache@2
             displayName: 'Cache: nuke-temp'
             inputs:
-              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuke-temp | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuke-temp
               path: .nuke/temp
           - task: Cache@2
             displayName: 'Cache: nuget-packages'
             inputs:
-              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj
+              key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(USERPROFILE)/.nuget/packages
           - task: CmdLine@2

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=simple-triggers_attribute=GitHubActionsAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=simple-triggers_attribute=GitHubActionsAttribute.verified.txt
@@ -34,7 +34,7 @@ jobs:
           path: |
             .nuke/temp
             ~/.nuget/packages
-          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
       - name: 'Run: Test'
         run: ./build.cmd Test
         env:
@@ -66,7 +66,7 @@ jobs:
           path: |
             .nuke/temp
             ~/.nuget/packages
-          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
       - name: 'Run: Test'
         run: ./build.cmd Test
         env:
@@ -98,7 +98,7 @@ jobs:
           path: |
             .nuke/temp
             ~/.nuget/packages
-          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
+          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
       - name: 'Run: Test'
         run: ./build.cmd Test
         env:

--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
@@ -111,7 +111,7 @@ public class AzurePipelinesAttribute : ChainedConfigurationAttributeBase
     public string[] PullRequestsPathsInclude { get; set; } = new string[0];
     public string[] PullRequestsPathsExclude { get; set; } = new string[0];
 
-    public string[] CacheKeyFiles { get; set; } = { "**/global.json", "**/*.csproj" };
+    public string[] CacheKeyFiles { get; set; } = { "**/global.json", "**/*.csproj", "**/Directory.Packages.props" };
     public string[] CachePaths { get; set; } = { AzurePipelinesCachePaths.Nuke, AzurePipelinesCachePaths.NuGet };
 
     public string[] ImportVariableGroups { get; set; } = new string[0];

--- a/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
+++ b/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
@@ -67,7 +67,7 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
 
     public string[] CacheIncludePatterns { get; set; } = { ".nuke/temp", "~/.nuget/packages" };
     public string[] CacheExcludePatterns { get; set; } = new string[0];
-    public string[] CacheKeyFiles { get; set; } = { "**/global.json", "**/*.csproj" };
+    public string[] CacheKeyFiles { get; set; } = { "**/global.json", "**/*.csproj", "**/Directory.Packages.props" };
 
     public bool PublishArtifacts { get; set; } = true;
 


### PR DESCRIPTION
Projects using [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/Central-Package-Management) don't have version numbers in csproj files and thus cache key calculation will not create correct result. Proposing to add also `Directory.Packages.props` hashes to be part of cache key by default.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
