### PR TITLE
Add option for enabling git LFS file downloads in GitHub Actions

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
@@ -52,6 +52,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          lfs: true
           fetch-depth: 2
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
@@ -87,6 +88,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          lfs: true
           fetch-depth: 2
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
@@ -122,6 +124,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          lfs: true
           fetch-depth: 2
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -154,6 +154,7 @@ public class ConfigurationGenerationTest
                     OnWorkflowDispatchOptionalInputs = new[] { "OptionalInput" },
                     OnWorkflowDispatchRequiredInputs = new[] { "RequiredInput" },
                     Submodules = GitHubActionsSubmodules.Recursive,
+                    Lfs = true,
                     FetchDepth = 2
                 }
             );

--- a/source/Nuke.Common/CI/GitHubActions/Configuration/GitHubActionsCheckoutStep.cs
+++ b/source/Nuke.Common/CI/GitHubActions/Configuration/GitHubActionsCheckoutStep.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2023 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -13,13 +13,14 @@ namespace Nuke.Common.CI.GitHubActions.Configuration;
 public class GitHubActionsCheckoutStep : GitHubActionsStep
 {
     public GitHubActionsSubmodules? Submodules { get; set; }
+    public bool? Lfs { get; set; }
     public uint? FetchDepth { get; set; }
 
     public override void Write(CustomFileWriter writer)
     {
         writer.WriteLine("- uses: actions/checkout@v3");
 
-        if (Submodules.HasValue || FetchDepth.HasValue)
+        if (Submodules.HasValue || Lfs.HasValue || FetchDepth.HasValue)
         {
             using (writer.Indent())
             {
@@ -28,6 +29,8 @@ public class GitHubActionsCheckoutStep : GitHubActionsStep
                 {
                     if (Submodules.HasValue)
                         writer.WriteLine($"submodules: {Submodules.ToString().ToLowerInvariant()}");
+                    if(Lfs.HasValue)
+                        writer.WriteLine($"lfs: {Lfs.ToString().ToLowerInvariant()}");
                     if (FetchDepth.HasValue)
                         writer.WriteLine($"fetch-depth: {FetchDepth}");
                 }

--- a/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
+++ b/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2023 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -26,6 +26,7 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
     private readonly string _name;
     private readonly GitHubActionsImage[] _images;
     private GitHubActionsSubmodules? _submodules;
+    private bool? _lfs;
     private uint? _fetchDepth;
 
     public GitHubActionsAttribute(
@@ -79,6 +80,12 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
         get => throw new NotSupportedException();
     }
 
+    public bool Lfs
+    {
+        set => _lfs = value;
+        get => throw new NotSupportedException();
+    }
+
     public uint FetchDepth
     {
         set => _fetchDepth = value;
@@ -125,6 +132,7 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
         yield return new GitHubActionsCheckoutStep
                      {
                          Submodules = _submodules,
+                         Lfs = _lfs,
                          FetchDepth = _fetchDepth
                      };
 


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Adds option for enabling LFS file downloads in the generated GitHub actions checkout step.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
