### PR TITLE
Add GitHubActionsAttribute.CheckoutTokenSecret

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
@@ -58,6 +58,7 @@ jobs:
           submodules: recursive
           lfs: true
           fetch-depth: 2
+          token: ${{ secrets.GH_FULL_TOKEN }}
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:
@@ -101,6 +102,7 @@ jobs:
           submodules: recursive
           lfs: true
           fetch-depth: 2
+          token: ${{ secrets.GH_FULL_TOKEN }}
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:
@@ -144,6 +146,7 @@ jobs:
           submodules: recursive
           lfs: true
           fetch-depth: 2
+          token: ${{ secrets.GH_FULL_TOKEN }}
       - name: 'Cache: .nuke/temp, ~/.nuget/packages'
         uses: actions/cache@v3
         with:

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -155,6 +155,7 @@ public class ConfigurationGenerationTest
                     OnWorkflowDispatchRequiredInputs = new[] { "RequiredInput" },
                     PublishCondition = "success() || failure()",
                     Submodules = GitHubActionsSubmodules.Recursive,
+                    CheckoutTokenSecret = "GhFullToken",
                     Lfs = true,
                     FetchDepth = 2,
                     TimeoutMinutes = 30,

--- a/source/Nuke.Common/CI/GitHubActions/Configuration/GitHubActionsCheckoutStep.cs
+++ b/source/Nuke.Common/CI/GitHubActions/Configuration/GitHubActionsCheckoutStep.cs
@@ -15,6 +15,7 @@ public class GitHubActionsCheckoutStep : GitHubActionsStep
     public GitHubActionsSubmodules? Submodules { get; set; }
     public bool? Lfs { get; set; }
     public uint? FetchDepth { get; set; }
+    public string Token { get; set; }
 
     public override void Write(CustomFileWriter writer)
     {
@@ -33,6 +34,8 @@ public class GitHubActionsCheckoutStep : GitHubActionsStep
                         writer.WriteLine($"lfs: {Lfs.ToString().ToLowerInvariant()}");
                     if (FetchDepth.HasValue)
                         writer.WriteLine($"fetch-depth: {FetchDepth}");
+                    if (!string.IsNullOrEmpty(Token))
+                        writer.WriteLine($"token: {Token}");
                 }
             }
         }


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

I've added an option to specify GitHub token at the checkout stage when generating GitHub Actions yaml file. This enables checking out submodules which are private GitHub repositories. In order to discourage setting this token in plain text, it's only possible to set it through a secret.

More info here: https://github.com/orgs/community/discussions/25516#discussioncomment-3248190

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
