### PR TITLE
Fix console detection on Windows 10+

### DIFF
--- a/source/Nuke.Build/Logging.cs
+++ b/source/Nuke.Build/Logging.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 using Nuke.Common.CI;
 using Nuke.Common.Execution.Theming;
@@ -25,7 +26,9 @@ public static class Logging
 {
     public static readonly LoggingLevelSwitch LevelSwitch = new();
 
-    internal static bool SupportsAnsiOutput => Environment.GetEnvironmentVariable("TERM") is { } term && term.StartsWithOrdinalIgnoreCase("xterm");
+    internal static bool SupportsAnsiOutput => Environment.GetEnvironmentVariable("TERM") is { } term && term.StartsWithOrdinalIgnoreCase("xterm")
+            || RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Environment.OSVersion.Version.Major >= 10;
+
     internal static IHostTheme DefaultTheme { get; } = SupportsAnsiOutput
         ? AnsiConsoleHostTheme.Default256AnsiColorTheme
         : SystemConsoleHostTheme.DefaultSystemColorTheme;

--- a/source/Nuke.Build/Theming/SystemConsoleHostTheme.cs
+++ b/source/Nuke.Build/Theming/SystemConsoleHostTheme.cs
@@ -15,7 +15,7 @@ public class SystemConsoleHostTheme : SystemConsoleTheme, IHostTheme
         new SystemConsoleThemeStyle { Foreground = ConsoleColor.Green },
         new Dictionary<ConsoleThemeStyle, SystemConsoleThemeStyle>
         {
-            [ConsoleThemeStyle.Text] = new(),
+            [ConsoleThemeStyle.Text] = new() { Foreground = ConsoleColor.Gray },
             [ConsoleThemeStyle.SecondaryText] = new() { Foreground = ConsoleColor.Gray },
             [ConsoleThemeStyle.TertiaryText] = new() { Foreground = ConsoleColor.Gray },
             [ConsoleThemeStyle.Name] = new() { Foreground = ConsoleColor.Blue },
@@ -26,7 +26,7 @@ public class SystemConsoleHostTheme : SystemConsoleTheme, IHostTheme
             [ConsoleThemeStyle.Boolean] = new() { Foreground = ConsoleColor.Magenta },
             [ConsoleThemeStyle.Scalar] = new() { Foreground = ConsoleColor.Magenta },
             [ConsoleThemeStyle.LevelVerbose] = new() { Foreground = ConsoleColor.Gray },
-            [ConsoleThemeStyle.LevelDebug] = new(),
+            [ConsoleThemeStyle.LevelDebug] = new() { Foreground = ConsoleColor.Gray },
             [ConsoleThemeStyle.LevelInformation] = new() { Foreground = ConsoleColor.Cyan },
             [ConsoleThemeStyle.LevelWarning] = new() { Foreground = ConsoleColor.Yellow },
             [ConsoleThemeStyle.LevelError] = new() { Foreground = ConsoleColor.Red },


### PR DESCRIPTION
Detect Windows 10+ as ANSI output capable and fix `SystemConsoleHostTheme` `Debug` level color

fixes #1161

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
