### PR TITLE
Fix docker stack deploy command

### DIFF
--- a/source/Nuke.Common/Tools/Docker/Docker.json
+++ b/source/Nuke.Common/Tools/Docker/Docker.json
@@ -2526,7 +2526,7 @@
       "postfix": "StackDeploy",
       "definiteArgument": "stack deploy",
       "settingsClass": {
-        "baseClass": "DockerStackSettings",
+        "baseClass": "DockerSettings",
         "properties": [
           {
             "name": "BundleFile",


### PR DESCRIPTION
Fix [issue](https://github.com/nuke-build/nuke/issues/1168)

Didn't generate code, because it will be generated manually as described [here](https://github.com/nuke-build/nuke/blob/develop/CONTRIBUTING.md#when-creating-a-pull-request)

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
