### PR TITLE
Use string.Replace to redact secrets

### DIFF
--- a/source/Nuke.Tooling/ProcessTasks.cs
+++ b/source/Nuke.Tooling/ProcessTasks.cs
@@ -79,7 +79,7 @@ public static class ProcessTasks
             static Func<string, string> GetOutputFilterForArgumentStringHandler(ref ArgumentStringHandler arguments)
             {
                 var redactedValues = arguments.SecretValues;
-                return x => redactedValues.Aggregate(x, (arguments, value) => arguments.ReplaceRegex(value, _ => Arguments.Redacted));
+                return x => redactedValues.Aggregate(x, (arguments, value) => arguments.Replace(value, Arguments.Redacted));
             }
 
             return StartProcess(


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

I'm now using `string.Replace` to redact secrets instead of `ReplaceRegex`. Secrets can potentially contain regular expression metacharacters which leads to unpredictable behaviour.

Fixes #1169.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
