### PR TITLE
Redact process Output

### DIFF
--- a/source/Nuke.Tooling/ProcessTasks.cs
+++ b/source/Nuke.Tooling/ProcessTasks.cs
@@ -211,9 +211,8 @@ public static class ProcessTasks
             if (e.Data == null)
                 return;
 
-            output.Add(new Output { Text = e.Data, Type = OutputType.Std });
-
             var filteredOutput = outputFilter(e.Data);
+            output.Add(new Output { Text = filteredOutput, Type = OutputType.Std });
             logger?.Invoke(OutputType.Std, filteredOutput);
         };
         process.ErrorDataReceived += (_, e) =>
@@ -221,9 +220,8 @@ public static class ProcessTasks
             if (e.Data == null)
                 return;
 
-            output.Add(new Output { Text = e.Data, Type = OutputType.Err });
-
             var filteredOutput = outputFilter(e.Data);
+            output.Add(new Output { Text = filteredOutput, Type = OutputType.Err });
             logger?.Invoke(OutputType.Err, filteredOutput);
         };
 


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

I took the easiest approach and I'm redacting the output as they're recorded. This way any consumer of the `IProcess.Output` property will get the redacted output without any change required.

If this is not desirable an alternative is to add a `FilteredOutput` property but this would require the consumers to make a choice between filtered and non-filtered output. If the consumer has provided secrets or an output filter, I think the expectation is for the output to be filtered.

Fixes #1179 

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
