### PR TITLE
Fix #1181 UnityTasks.Unity throws exception on macOS

### DIFF
--- a/source/Nuke.Common/Tools/Unity/UnityTasks.cs
+++ b/source/Nuke.Common/Tools/Unity/UnityTasks.cs
@@ -79,7 +79,7 @@ public partial class UnityTasks
 
         var editorVersion = ReadUnityEditorVersion(unitySettings.ProjectPath);
         var hubToolPath = GetToolPathViaHubVersion(editorVersion);
-        if (hubToolPath.Exists())
+        if (hubToolPath.FileExists())
         {
             unitySettings.HubVersion = editorVersion;
             return;


### PR DESCRIPTION
This fixes #1181.

When executing the Unity tool on macOS, an exception was thrown because the FilePathExtension was not able to determine if `hubToolPath` was a file or directory. The check is now explicit and does not rely on the naming of the variable.

I considered adding tests for this issue, but found that it would require sweeping changes to decouple the platform and system logic. A more simplified test would be one that would only detect the issue when actually running on macOS and not on Windows, but I don't yet know if the Nuke project has anything set up for platform testing to make such tests feasible.

For now, the change is simple enough to warrant that we go without a test, I believe.

<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->



<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
