### PR TITLE
Fixing signtool.exe path for new windows kits

### DIFF
--- a/source/Nuke.Common/Tools/SignTool/SignToolSettings.cs
+++ b/source/Nuke.Common/Tools/SignTool/SignToolSettings.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
-using System;
 using System.Linq;
 using JetBrains.Annotations;
 using Nuke.Common.IO;
@@ -20,8 +19,14 @@ partial class SignToolTasks
                 : SpecialFolders.ProgramFiles).NotNull();
 
         var platformIdentifier = EnvironmentInfo.Is64Bit ? "x64" : "x86";
+        const string windowsKitLastVersion = "10";
 
-        return new[]
+        var windowsKitsRootDirectory = programDirectory / "Windows Kits" / windowsKitLastVersion / "bin";
+        var signToolPath = windowsKitsRootDirectory.GlobFiles($"{windowsKitLastVersion}.*/{platformIdentifier}/signtool.exe").LastOrDefault();
+
+        return signToolPath ?? 
+
+        new[]
                {
                    programDirectory / "Windows Kits" / "10" / "bin" / "10.0.15063.0",
                    programDirectory / "Windows Kits" / "10" / "App Certification Kit",


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
I look inside the path of the latest Windows Kit major version (in this case "10") and check in all the minor version folders (for example "10.0.22621.0", "10.0.16299.0"), and get the last one that contains the file "signtool.exe".

if nothing is found, I fallback on the previous code.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
