### PR TITLE
Fix TeamsTasks.SendTeamsMessageAsync

### DIFF
--- a/source/Nuke.Common/Tools/Teams/TeamsTasks.cs
+++ b/source/Nuke.Common/Tools/Teams/TeamsTasks.cs
@@ -24,12 +24,11 @@ public static class TeamsTasks
     public static async Task SendTeamsMessageAsync(Configure<TeamsMessage> configurator, string webhook)
     {
         var message = configurator(new TeamsMessage());
-        var messageJson = JsonConvert.SerializeObject(message);
 
         using var client = new HttpClient();
 
         var response = await client.CreateRequest(HttpMethod.Post, webhook)
-            .WithJsonContent(messageJson)
+            .WithJsonContent(message)
             .GetResponseAsync();
 
         var responseText = await response.GetBodyAsync();


### PR DESCRIPTION
<!-- Please describe what you did below this line -->

`SendTeamsMessageAsync` had a bug where Teams messages couldn't be sent. The reason was that internally, the message object was first serialized to JSON as `messageJson`, and then passed to `WithJsonContent(messageJson)`, which internally did another serialization.  
This resulted in double serialization, and in API errors when trying to send messages via Teams.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer
