### PR TITLE
fix: remove equal sign from passed parameters to MSpec Console Runner

### DIFF
--- a/source/Nuke.Common/Tools/MSpec/MSpec.json
+++ b/source/Nuke.Common/Tools/MSpec/MSpec.json
@@ -23,34 +23,34 @@
           {
             "name": "Filters",
             "type": "List<string>",
-            "format": "-f={value}",
+            "format": "-filters {value}",
             "separator": ",",
             "help": "Filter file specifying contexts to execute (full type name, one per line). Takes precedence over tags."
           },
           {
             "name": "Includes",
             "type": "List<string>",
-            "format": "-i {value}",
+            "format": "-include {value}",
             "separator": ",",
             "help": "Executes all specifications in contexts with these comma delimited tags. Ex. <c>-i 'foo, bar, foo_bar'</c>."
           },
           {
             "name": "Excludes",
             "type": "List<string>",
-            "format": "-x {value}",
+            "format": "-exclude {value}",
             "separator": ",",
             "help": "Exclude specifications in contexts with these comma delimited tags. Ex. <c>-x 'foo, bar, foo_bar'</c>."
           },
           {
             "name": "HtmlOutput",
             "type": "string",
-            "format": "--html={value}",
+            "format": "--html {value}",
             "help": "Outputs the HTML report to path, one-per-assembly w/ index.html (if directory, otherwise all are in one file). Ex. <c>--html=output/reports/</c>"
           },
           {
             "name": "XmlOutput",
             "type": "string",
-            "format": "--xml={value}",
+            "format": "--xml {value}",
             "help": "Outputs the XML report to the file referenced by the path. Ex. <c>--xml=output/reports/MSpecResults.xml</c>"
           },
           {

--- a/source/Nuke.Common/Tools/MSpec/MSpec.json
+++ b/source/Nuke.Common/Tools/MSpec/MSpec.json
@@ -30,14 +30,14 @@
           {
             "name": "Includes",
             "type": "List<string>",
-            "format": "-i={value}",
+            "format": "-i {value}",
             "separator": ",",
             "help": "Executes all specifications in contexts with these comma delimited tags. Ex. <c>-i 'foo, bar, foo_bar'</c>."
           },
           {
             "name": "Excludes",
             "type": "List<string>",
-            "format": "-x={value}",
+            "format": "-x {value}",
             "separator": ",",
             "help": "Exclude specifications in contexts with these comma delimited tags. Ex. <c>-x 'foo, bar, foo_bar'</c>."
           },


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

To get Machine.Specifications work with `includes` and `excludes`, I removed the equal signs for the command line parameters.

Closes #1190 

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
