### PR TITLE
Fix Unity detection code

### DIFF
--- a/source/Nuke.Common/Tools/Unity/UnityTasks.cs
+++ b/source/Nuke.Common/Tools/Unity/UnityTasks.cs
@@ -78,15 +78,15 @@ public partial class UnityTasks
             return;
 
         var editorVersion = ReadUnityEditorVersion(unitySettings.ProjectPath);
-        var hubToolPath = GetToolPathViaHubVersion(editorVersion);
-        if (hubToolPath.Exists())
+        var hubToolExe = GetToolPathViaHubVersion(editorVersion);
+        if (hubToolExe.Exists())
         {
             unitySettings.HubVersion = editorVersion;
             return;
         }
 
-        var manualInstallationToolPath = GetToolPathViaManualInstallation();
-        Assert.FileExists(manualInstallationToolPath, $"Required Unity Hub installation for version '{editorVersion}' was not found");
+        var manualInstallationToolExe = GetToolPathViaManualInstallation();
+        Assert.FileExists(manualInstallationToolExe, $"Required Unity Hub installation for version '{editorVersion}' was not found");
     }
 
     private static string ReadUnityEditorVersion(AbsolutePath projectPath)


### PR DESCRIPTION

<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

I have fixed `DetectUnityVersion` which was failing due to incorrectly named variable.
`AbsolutePath.Exists` requires some special naming to work.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
