### PR TITLE
Do not check for null TenantId in AzureKeyVaultConfigurationAttribute

### DIFF
--- a/source/Nuke.Common/Tools/AzureKeyVault/AzureKeyVaultConfigurationAttribute.cs
+++ b/source/Nuke.Common/Tools/AzureKeyVault/AzureKeyVaultConfigurationAttribute.cs
@@ -47,7 +47,7 @@ namespace Nuke.Common.Tools.AzureKeyVault
                                 };
 
             if (configuration.BaseUrl == null ||
-                configuration.TenantId == null ||
+                //configuration.TenantId == null || //TenantId is not mandatory
                 configuration.ClientId == null ||
                 configuration.ClientSecret == null)
             {


### PR DESCRIPTION
fixing [1197](https://github.com/nuke-build/nuke/issues/1197)

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
