### PR TITLE
Add relative working directory to NerdbankGitVersioning attribute

### DIFF
--- a/azure-pipelines.qodana.yml
+++ b/azure-pipelines.qodana.yml
@@ -1,0 +1,15 @@
+pool:
+  vmImage: 'ubuntu-latest'
+
+jobs:
+  - job: QodanaScan
+    displayName: 'Qodana Scan'
+    steps:
+      - task: Cache@2  # Not required, but Qodana will open projects with cache faster.
+        inputs:
+          key: '"$(Build.Repository.Name)" | "$(Build.SourceBranchName)" | "$(Build.SourceVersion)"'
+          path: '$(Agent.TempDirectory)/qodana/cache'
+          restoreKeys: |
+            "$(Build.Repository.Name)" | "$(Build.SourceBranchName)"
+            "$(Build.Repository.Name)"
+      - task: QodanaScan@2023

--- a/source/Nuke.Common.Tests/ChangelogTasksTest.cs
+++ b/source/Nuke.Common.Tests/ChangelogTasksTest.cs
@@ -13,127 +13,128 @@ using Nuke.Common.IO;
 using VerifyXunit;
 using Xunit;
 
-namespace Nuke.Common.Tests
+// ReSharper disable ReturnValueOfPureMethodIsNotUsed
+
+namespace Nuke.Common.Tests;
+
+[UsesVerify]
+public class ChangelogTasksTest
 {
-    [UsesVerify]
-    public class ChangelogTasksTest
+    private static AbsolutePath RootDirectory => Constants.TryGetRootDirectoryFrom(EnvironmentInfo.WorkingDirectory).NotNull();
+
+    private static AbsolutePath PathToChangelogReferenceFiles => RootDirectory / "source" / "Nuke.Common.Tests" / "ChangelogReferenceFiles";
+
+    [Theory]
+    [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+    [MemberData(nameof(AllChangelogReference_NUKE_Files))]
+    public void ReadReleaseNotes_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
     {
-        private static AbsolutePath RootDirectory => Constants.TryGetRootDirectoryFrom(EnvironmentInfo.WorkingDirectory).NotNull();
+        Action act = () => ChangelogTasks.ReadReleaseNotes(file);
 
-        private static AbsolutePath PathToChangelogReferenceFiles => RootDirectory / "source" / "Nuke.Common.Tests" / "ChangelogReferenceFiles";
-
-        [Theory]
-        [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
-        [MemberData(nameof(AllChangelogReference_NUKE_Files))]
-        public void ReadReleaseNotes_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
-        {
-            Action act = () => ChangelogTasks.ReadReleaseNotes(file);
-
-            act.Should().NotThrow();
-        }
-
-        [Theory]
-        [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
-        [MemberData(nameof(AllChangelogReference_NUKE_Files))]
-        public void ReadReleaseNotes_ChangelogReferenceFile_ReturnsAnyReleaseNotes(AbsolutePath file)
-        {
-            var releaseNotes = ChangelogTasks.ReadReleaseNotes(file);
-
-            releaseNotes.Should().NotBeEmpty();
-        }
-
-        [Theory]
-        [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
-        [MemberData(nameof(AllChangelogReference_NUKE_Files))]
-        public void ReadChangelog_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
-        {
-            Action act = () => ChangelogTasks.ReadChangelog(file);
-
-            act.Should().NotThrow();
-        }
-
-        [Theory]
-        [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
-        [MemberData(nameof(AllChangelogReference_NUKE_Files))]
-        public void ExtractChangelogSectionNotes_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
-        {
-            Action act = () => ChangelogTasks.ExtractChangelogSectionNotes(file);
-
-            act.Should().NotThrow();
-        }
-
-        [Theory]
-        [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
-        [MemberData(nameof(AllChangelogReference_NUKE_Files))]
-        public Task ReadReleaseNotes_ChangelogReferenceFile_HasParsedCorrectly(AbsolutePath file)
-        {
-            var releaseNotes = ChangelogTasks.ReadReleaseNotes(file);
-
-            return Verifier.Verify(releaseNotes).UseDirectory(PathToChangelogReferenceFiles).UseFileName(file.NameWithoutExtension);
-        }
-
-        [Fact]
-        public void GetReleaseSections_ChangelogReferenceFileWithoutReleaseHead_ReturnsEmpty()
-        {
-            var file = PathToChangelogReferenceFiles / "changelog_reference_invalid_variant_1.md";
-            var lines = file.ReadAllLines().ToList();
-
-            ChangelogTasks.GetReleaseSections(lines).Should().BeEmpty();
-        }
-
-        [Theory]
-        [InlineData("changelog_reference_1.0.0_variant_5.md", "0.2.3")]
-        public Task ExtractChangelogSectionNotes_WithTag_ReturnsSectionThatMatchesProvidedTag(string fileName, string tag)
-        {
-            var changeLogFilePath = PathToChangelogReferenceFiles / fileName;
-            var sectionNotes = ChangelogTasks.ExtractChangelogSectionNotes(changeLogFilePath, tag);
-
-            return Verifier.Verify(sectionNotes).UseDirectory(PathToChangelogReferenceFiles)
-                .UseFileName($"{changeLogFilePath.NameWithoutExtension}_section_{tag}");
-        }
-
-        [Theory]
-        [InlineData("changelog_reference_1.0.0_variant_5.md", "0.0.0")]
-        [InlineData("changelog_reference_1.0.0_variant_5.md", "9.9.9")]
-        public void ExtractChangelogSection_WithNonExistingTag_ThrowsInformativeException(string fileName, string tag)
-        {
-            var file = PathToChangelogReferenceFiles / fileName;
-
-            Action act = () => ChangelogTasks.ExtractChangelogSectionNotes(file, tag);
-
-            act.Should().Throw<Exception>().WithMessage($"Could not find release section for '{tag}'.");
-        }
-
-        [Theory]
-        [InlineData("changelog_reference_invalid_variant_2.md")]
-        public void ReadChangelog_ChangelogFileThatHasMultipleUnreleasedSection_ThrowsInformativeException(string fileName)
-        {
-            var file = PathToChangelogReferenceFiles / fileName;
-
-            Action act = () => ChangelogTasks.ReadChangelog(file);
-
-            act.Should().Throw<Exception>().WithMessage("Changelog should have only one draft section");
-        }
-
-        [Theory]
-        [InlineData("changelog_reference_invalid_variant_1.md")]
-        public void ReadChangelog_EmptyChangelogFile_ThrowsInformativeException(string fileName)
-        {
-            var file = PathToChangelogReferenceFiles / fileName;
-
-            Action act = () => ChangelogTasks.ReadChangelog(file);
-
-            act.Should().Throw<Exception>().WithMessage("Changelog should have at least one release note section");
-        }
-
-        [UsedImplicitly]
-        public static IEnumerable<object[]> AllChangelogReference_1_0_0_Files
-        {
-            get => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_1.0.0*.md").Select(x => new object[] { x });
-        }
-
-        [UsedImplicitly]
-        public static IEnumerable<object[]> AllChangelogReference_NUKE_Files
-            => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_NUKE*.md").Select(x => new object[] { x });
+        act.Should().NotThrow();
     }
+
+    [Theory]
+    [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+    [MemberData(nameof(AllChangelogReference_NUKE_Files))]
+    public void ReadReleaseNotes_ChangelogReferenceFile_ReturnsAnyReleaseNotes(AbsolutePath file)
+    {
+        var releaseNotes = ChangelogTasks.ReadReleaseNotes(file);
+
+        releaseNotes.Should().NotBeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+    [MemberData(nameof(AllChangelogReference_NUKE_Files))]
+    public void ReadChangelog_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
+    {
+        Action act = () => ChangelogTasks.ReadChangelog(file);
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+    [MemberData(nameof(AllChangelogReference_NUKE_Files))]
+    public void ExtractChangelogSectionNotes_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
+    {
+        Action act = () => ChangelogTasks.ExtractChangelogSectionNotes(file);
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+    [MemberData(nameof(AllChangelogReference_NUKE_Files))]
+    public Task ReadReleaseNotes_ChangelogReferenceFile_HasParsedCorrectly(AbsolutePath file)
+    {
+        var releaseNotes = ChangelogTasks.ReadReleaseNotes(file);
+
+        return Verifier.Verify(releaseNotes).UseDirectory(PathToChangelogReferenceFiles).UseFileName(file.NameWithoutExtension);
+    }
+
+    [Fact]
+    public void GetReleaseSections_ChangelogReferenceFileWithoutReleaseHead_ReturnsEmpty()
+    {
+        var file = PathToChangelogReferenceFiles / "changelog_reference_invalid_variant_1.md";
+        var lines = file.ReadAllLines().ToList();
+
+        ChangelogTasks.GetReleaseSections(lines).Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("changelog_reference_1.0.0_variant_5.md", "0.2.3")]
+    public Task ExtractChangelogSectionNotes_WithTag_ReturnsSectionThatMatchesProvidedTag(string fileName, string tag)
+    {
+        var changeLogFilePath = PathToChangelogReferenceFiles / fileName;
+        var sectionNotes = ChangelogTasks.ExtractChangelogSectionNotes(changeLogFilePath, tag);
+
+        return Verifier.Verify(sectionNotes).UseDirectory(PathToChangelogReferenceFiles)
+            .UseFileName($"{changeLogFilePath.NameWithoutExtension}_section_{tag}");
+    }
+
+    [Theory]
+    [InlineData("changelog_reference_1.0.0_variant_5.md", "0.0.0")]
+    [InlineData("changelog_reference_1.0.0_variant_5.md", "9.9.9")]
+    public void ExtractChangelogSection_WithNonExistingTag_ThrowsInformativeException(string fileName, string tag)
+    {
+        var file = PathToChangelogReferenceFiles / fileName;
+
+        Action act = () => ChangelogTasks.ExtractChangelogSectionNotes(file, tag);
+
+        act.Should().Throw<Exception>().WithMessage($"Could not find release section for '{tag}'.");
+    }
+
+    [Theory]
+    [InlineData("changelog_reference_invalid_variant_2.md")]
+    public void ReadChangelog_ChangelogFileThatHasMultipleUnreleasedSection_ThrowsInformativeException(string fileName)
+    {
+        var file = PathToChangelogReferenceFiles / fileName;
+
+        Action act = () => ChangelogTasks.ReadChangelog(file);
+
+        act.Should().Throw<Exception>().WithMessage("Changelog should have only one draft section");
+    }
+
+    [Theory]
+    [InlineData("changelog_reference_invalid_variant_1.md")]
+    public void ReadChangelog_EmptyChangelogFile_ThrowsInformativeException(string fileName)
+    {
+        var file = PathToChangelogReferenceFiles / fileName;
+
+        Action act = () => ChangelogTasks.ReadChangelog(file);
+
+        act.Should().Throw<Exception>().WithMessage("Changelog should have at least one release note section");
+    }
+
+    [UsedImplicitly]
+    public static IEnumerable<object[]> AllChangelogReference_1_0_0_Files
+    {
+        get => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_1.0.0*.md").Select(x => new object[] { x });
+    }
+
+    [UsedImplicitly]
+    public static IEnumerable<object[]> AllChangelogReference_NUKE_Files
+        => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_NUKE*.md").Select(x => new object[] { x });
 }

--- a/source/Nuke.Common/Tools/MSpec/MSpec.json
+++ b/source/Nuke.Common/Tools/MSpec/MSpec.json
@@ -23,34 +23,34 @@
           {
             "name": "Filters",
             "type": "List<string>",
-            "format": "-f={value}",
+            "format": "-filters {value}",
             "separator": ",",
             "help": "Filter file specifying contexts to execute (full type name, one per line). Takes precedence over tags."
           },
           {
             "name": "Includes",
             "type": "List<string>",
-            "format": "-i={value}",
+            "format": "-include {value}",
             "separator": ",",
             "help": "Executes all specifications in contexts with these comma delimited tags. Ex. <c>-i 'foo, bar, foo_bar'</c>."
           },
           {
             "name": "Excludes",
             "type": "List<string>",
-            "format": "-x={value}",
+            "format": "-exclude {value}",
             "separator": ",",
             "help": "Exclude specifications in contexts with these comma delimited tags. Ex. <c>-x 'foo, bar, foo_bar'</c>."
           },
           {
             "name": "HtmlOutput",
             "type": "string",
-            "format": "--html={value}",
+            "format": "--html {value}",
             "help": "Outputs the HTML report to path, one-per-assembly w/ index.html (if directory, otherwise all are in one file). Ex. <c>--html=output/reports/</c>"
           },
           {
             "name": "XmlOutput",
             "type": "string",
-            "format": "--xml={value}",
+            "format": "--xml {value}",
             "help": "Outputs the XML report to the file referenced by the path. Ex. <c>--xml=output/reports/MSpecResults.xml</c>"
           },
           {

--- a/source/Nuke.Common/Tools/NerdbankGitVersioning/NerdbankGitVersioningAttribute.cs
+++ b/source/Nuke.Common/Tools/NerdbankGitVersioning/NerdbankGitVersioningAttribute.cs
@@ -22,11 +22,17 @@ public class NerdbankGitVersioningAttribute : ValueInjectionAttributeBase
 {
     public bool UpdateBuildNumber { get; set; }
 
+    /// <summary>
+    /// Relative path inside <see cref="INukeBuild.RootDirectory" />  where configuration file is located.
+    /// </summary>
+    public string WorkingDirectoryRelativePath { get; set; }
+
     public override object GetValue(MemberInfo member, object instance)
     {
         var version = NerdbankGitVersioningTasks.NerdbankGitVersioningGetVersion(s => s
                 .DisableProcessLogOutput()
-                .SetFormat(NerdbankGitVersioningFormat.json))
+                .SetFormat(NerdbankGitVersioningFormat.json)
+                .When(WorkingDirectoryRelativePath != null, x => x.SetProcessWorkingDirectory(Build.RootDirectory / WorkingDirectoryRelativePath)))
             .Result;
 
         if (UpdateBuildNumber)

--- a/source/Nuke.Common/Tools/Teams/TeamsTasks.cs
+++ b/source/Nuke.Common/Tools/Teams/TeamsTasks.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Newtonsoft.Json;
 using Nuke.Common.Tooling;
 using Nuke.Common.Utilities.Net;
 

--- a/source/Nuke.Common/Tools/Teams/TeamsTasks.cs
+++ b/source/Nuke.Common/Tools/Teams/TeamsTasks.cs
@@ -24,12 +24,11 @@ public static class TeamsTasks
     public static async Task SendTeamsMessageAsync(Configure<TeamsMessage> configurator, string webhook)
     {
         var message = configurator(new TeamsMessage());
-        var messageJson = JsonConvert.SerializeObject(message);
 
         using var client = new HttpClient();
 
         var response = await client.CreateRequest(HttpMethod.Post, webhook)
-            .WithJsonContent(messageJson)
+            .WithJsonContent(message)
             .GetResponseAsync();
 
         var responseText = await response.GetBodyAsync();

--- a/source/Nuke.Tooling.Tests/ArgumentStringHandlerTest.cs
+++ b/source/Nuke.Tooling.Tests/ArgumentStringHandlerTest.cs
@@ -7,6 +7,8 @@ using Nuke.Common.IO;
 using Nuke.Common.Tooling;
 using Xunit;
 
+// ReSharper disable StringLiteralAsInterpolationArgument
+
 namespace Nuke.Common.Tests;
 
 public class ArgumentStringHandlerTest
@@ -80,5 +82,5 @@ public class ArgumentStringHandlerTest
         filteredOutput.Should().Be("There is a [REDACTED]!");
     }
 
-    string ArgsToString(ArgumentStringHandler args) => args.ToStringAndClear();
+    private string ArgsToString(ArgumentStringHandler args) => args.ToStringAndClear();
 }

--- a/source/Nuke.Tooling/ProcessTasks.cs
+++ b/source/Nuke.Tooling/ProcessTasks.cs
@@ -211,9 +211,8 @@ public static class ProcessTasks
             if (e.Data == null)
                 return;
 
-            output.Add(new Output { Text = e.Data, Type = OutputType.Std });
-
             var filteredOutput = outputFilter(e.Data);
+            output.Add(new Output { Text = filteredOutput, Type = OutputType.Std });
             logger?.Invoke(OutputType.Std, filteredOutput);
         };
         process.ErrorDataReceived += (_, e) =>
@@ -221,9 +220,8 @@ public static class ProcessTasks
             if (e.Data == null)
                 return;
 
-            output.Add(new Output { Text = e.Data, Type = OutputType.Err });
-
             var filteredOutput = outputFilter(e.Data);
+            output.Add(new Output { Text = filteredOutput, Type = OutputType.Err });
             logger?.Invoke(OutputType.Err, filteredOutput);
         };
 


### PR DESCRIPTION
Adds support for mono repos by allowing usage of different configuration files in subdirectories.
See https://github.com/dotnet/Nerdbank.GitVersioning/blob/main/doc/pathFilters.md for documentation about multiple NBGV configuration files in same repository.

Usage:
```csharp
[NerdbankGitVersioning(WorkingDirectoryRelativePath = @"subdir\different-config\")]
readonly NerdbankGitVersioning Nbgv;
```

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
