### PR TITLE
Add support for async actions that have return value

### DIFF
--- a/source/Nuke.Build/Execution/TargetDefinition.cs
+++ b/source/Nuke.Build/Execution/TargetDefinition.cs
@@ -72,6 +72,11 @@ internal class TargetDefinition : ITargetDefinition
     {
         return Executes(() => action().GetAwaiter().GetResult());
     }
+    
+    public ITargetDefinition Executes<T>(Func<Task<T>> action)
+    {
+        return Executes(() => action().GetAwaiter().GetResult());
+    }
 
     public ITargetDefinition DependsOn(params Target[] targets)
     {

--- a/source/Nuke.Build/ITargetDefinition.cs
+++ b/source/Nuke.Build/ITargetDefinition.cs
@@ -37,6 +37,11 @@ public interface ITargetDefinition
     ///   Adds a <see cref="Task"/> that will be executed for this target.
     /// </summary>
     ITargetDefinition Executes(Func<Task> action);
+    
+    /// <summary>
+    ///   Adds a <see cref="Task"/> that will be executed for this target.
+    /// </summary>
+    ITargetDefinition Executes<T>(Func<Task<T>> action);
 
     /// <summary>
     ///   Adds a set of dependent targets that will be executed before this target.


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Add support for async actions that have a return value. This currently can be a pitfall if you have reusable code you want to invoke from a Nuke target. If you elide the await in the Target you end up in the `ITargetDefinition Executes<T>(Func<T> action);` overload which does not await the result. Here's some sample code to illustrate this better:

```C#
async Task<string> TaskWithReturnValueAsync()
{
    await someAsyncWork();
    return "done";
}

// This target will not await the Task
Target RunTaskWithReturnValue => _ => _
    .Executes(TaskWithReturnValueAsync);
```


<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
