### PR TITLE
Add gitcommit and gitref args for octopus create-release CLI

### DIFF
--- a/source/Nuke.Common/Tools/Octopus/Octopus.json
+++ b/source/Nuke.Common/Tools/Octopus/Octopus.json
@@ -145,6 +145,18 @@
             "help": "Default version number of all packages to use for this release."
           },
           {
+            "name": "GitCommit",
+            "type": "string",
+            "format": "--gitCommit={value}",
+            "help": "Git commit to use when creating the release. Use in conjunction with the --gitRef parameter to select any previous commit."
+          },
+          {
+            "name": "GitRef",
+            "type": "string",
+            "format": "--gitRef={value}",
+            "help": "Git reference to use when creating the release."
+          },
+          {
             "name": "Version",
             "type": "string",
             "format": "--version={value}",


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Updated the Octopus CLI json to include the new version-controlled args on create-release (gitRef and gitCommit). [Docs are here](https://octopus.com/docs/octopus-rest-api/octopus-cli/create-release#Creatingreleases-version-controlled).


<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
