### PR TITLE
Add missing options to NUnitLabelType for --labels CLI argument.

### DIFF
--- a/source/Nuke.Common/Tools/NUnit/NUnit.json
+++ b/source/Nuke.Common/Tools/NUnit/NUnit.json
@@ -188,7 +188,7 @@
             "name": "Labels",
             "type": "NUnitLabelType",
             "format": "--labels={value}",
-            "help": "Specify whether to write test case names to the output. Values: <c>Off</c>, <c>On</c>, <c>All</c>"
+            "help": "Specify whether to write test case names to the output. Values: <c>Off</c>, <c>On</c>, <c>All</c>, <c>OnOutputOnly</c>, <c>Before</c>, <c>After</c>, <c>BeforeAndAfter</c>"
           },
           {
             "name": "Trace",
@@ -270,7 +270,11 @@
       "values": [
         "Off",
         "On",
-        "All"
+        "All",
+        "OnOutputOnly",
+        "Before",
+        "After",
+        "BeforeAndAfter"
       ]
     },
     {


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Added several missing options for the NUnit console runner `--labels` argument. "On" and "All" are deprecated but still work.

https://github.com/nunit/nunit-console/blob/95fb00fd0f5b721699ad01e118dc3eb3e8a53e5e/src/NUnitConsole/nunit3-console/ConsoleOptions.cs#L298C34-L298C34

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer
