### PR TITLE
Unity: Fix RunTests settings class.

### DIFF
--- a/source/Nuke.Common/Tools/Unity/Unity.json
+++ b/source/Nuke.Common/Tools/Unity/Unity.json
@@ -166,7 +166,7 @@
       "customAssertion": true,
       "definiteArgument": "-runTests",
       "settingsClass": {
-        "baseClass": "UnityBaseSettings",
+        "baseClass": "UnityProjectSettings",
         "properties": [
           {
             "name": "TestCategories",


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Fix for incorrect base class in `UnityTasks.UnityRunTests`.
Before: `UnityBaseSettings`
After: `UnityProjectSettings`

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
