### PR TITLE
chore: update description for verbosity parameter

### DIFF
--- a/source/Nuke.Build.Tests/SchemaUtilityTest.TestGetBuildSchema.verified.txt
+++ b/source/Nuke.Build.Tests/SchemaUtilityTest.TestGetBuildSchema.verified.txt
@@ -101,7 +101,7 @@
         },
         "Verbosity": {
           "type": "string",
-          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "description": "Logging verbosity during build execution. Accepted values are 'Verbose', 'Normal', 'Minimal', 'Quiet'. Default is 'Normal'",
           "enum": [
             "Minimal",
             "Normal",

--- a/source/Nuke.Build/NukeBuild.Statics.cs
+++ b/source/Nuke.Build/NukeBuild.Statics.cs
@@ -72,7 +72,7 @@ public abstract partial class NukeBuild
     /// <summary>
     /// Gets the logging verbosity during build execution. Default is <see cref="Nuke.Common.Verbosity.Normal"/>.
     /// </summary>
-    [Parameter("Logging verbosity during build execution. Default is 'Normal'.")]
+    [Parameter("Logging verbosity during build execution. Accepted values are 'Verbose', 'Normal', 'Minimal', 'Quiet'. Default is 'Normal'.")]
     public static Verbosity Verbosity
     {
         get => (Verbosity) Logging.Level;

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=TeamCityAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=TeamCityAttribute.verified.txt
@@ -80,7 +80,7 @@ project {
         select (
             "env.Verbosity",
             label = "Verbosity",
-            description = "Logging verbosity during build execution. Default is 'Normal'.",
+            description = "Logging verbosity during build execution. Accepted values are 'Verbose', 'Normal', 'Minimal', 'Quiet'. Default is 'Normal'.",
             value = "Normal",
             options = listOf("Minimal" to "Minimal", "Normal" to "Normal", "Quiet" to "Quiet", "Verbose" to "Verbose"),
             display = ParameterDisplay.NORMAL)


### PR DESCRIPTION
Add accepted values to the description of the verbosity parameter.

Each time I want to use the `--verbosity` parameter, I have to search through documentation what are the accepted values. By adding the accepted values to the parameter description, I will save myself(and probably others) a few minutes each time I use verbosity.

<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->



<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer
