### PR TITLE
Fix appveyor configuration generation

### DIFF
--- a/source/Nuke.Common/CI/AppVeyor/Configuration/AppVeyorConfiguration.cs
+++ b/source/Nuke.Common/CI/AppVeyor/Configuration/AppVeyorConfiguration.cs
@@ -134,7 +134,17 @@ public class AppVeyorConfiguration : ConfigurationEntity
             writer.WriteLine();
             using (writer.WriteBlock("artifacts:"))
             {
-                Artifacts.ForEach(x => writer.WriteLine($"- path: {x}"));
+                Artifacts.ForEach(x =>
+                {
+                    // If a path starts with a wildcard, we need to wrap it in single quotes
+                    // https://www.appveyor.com/docs/packaging-artifacts/
+                    if (x.Length > 0 && x[0] == '*')
+                    {
+                        x = $"'{x}'";
+                    }
+
+                    writer.WriteLine($"- path: {x}");
+                });
             }
         }
 

--- a/source/Nuke.Common/CI/AppVeyor/Configuration/AppVeyorConfiguration.cs
+++ b/source/Nuke.Common/CI/AppVeyor/Configuration/AppVeyorConfiguration.cs
@@ -136,11 +136,9 @@ public class AppVeyorConfiguration : ConfigurationEntity
             {
                 Artifacts.ForEach(x =>
                 {
-                    // If a path starts with a wildcard, we need to wrap it in single quotes
-                    // https://www.appveyor.com/docs/packaging-artifacts/
                     if (x.Length > 0 && x[0] == '*')
                     {
-                        x = $"'{x}'";
+                        x = x.SingleQuoteIfNeeded();
                     }
 
                     writer.WriteLine($"- path: {x}");

--- a/source/Nuke.Common/CI/AppVeyor/Configuration/AppVeyorConfiguration.cs
+++ b/source/Nuke.Common/CI/AppVeyor/Configuration/AppVeyorConfiguration.cs
@@ -134,15 +134,7 @@ public class AppVeyorConfiguration : ConfigurationEntity
             writer.WriteLine();
             using (writer.WriteBlock("artifacts:"))
             {
-                Artifacts.ForEach(x =>
-                {
-                    if (x.Length > 0 && x[0] == '*')
-                    {
-                        x = x.SingleQuoteIfNeeded();
-                    }
-
-                    writer.WriteLine($"- path: {x}");
-                });
+                Artifacts.ForEach(x => writer.WriteLine($"- path: {x.SingleQuoteIfNeeded(disallowed: '*')}"));
             }
         }
 


### PR DESCRIPTION
As per the [documentation](https://www.appveyor.com/docs/packaging-artifacts/) 
> IMPORTANT! If the artifact path starts with *, you need to surround the value with single quotes

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
