### PR TITLE
Replace obsolete BinaryFormatter

### DIFF
--- a/source/Nuke.Build/Execution/TargetExecutionException.cs
+++ b/source/Nuke.Build/Execution/TargetExecutionException.cs
@@ -1,9 +1,8 @@
-// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2023 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
 using System;
-using System.Linq;
 using System.Runtime.Serialization;
 
 namespace Nuke.Common.Execution;
@@ -16,6 +15,9 @@ internal class TargetExecutionException : Exception
     {
     }
 
+#if NET8_0_OR_GREATER
+    [Obsolete(DiagnosticId = "SYSLIB0051")] 
+#endif
     protected TargetExecutionException(
         SerializationInfo info,
         StreamingContext context)

--- a/source/Nuke.Tooling/Nuke.Tooling.csproj
+++ b/source/Nuke.Tooling/Nuke.Tooling.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Json" Version="6.0.8" />
     <PackageReference Include="NuGet.Packaging" Version="5.11.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />
   </ItemGroup>

--- a/source/Nuke.Tooling/ProcessException.cs
+++ b/source/Nuke.Tooling/ProcessException.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2023 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -48,6 +48,9 @@ public class ProcessException : Exception
         ExitCode = process.ExitCode;
     }
 
+#if NET8_0_OR_GREATER
+    [Obsolete(DiagnosticId = "SYSLIB0051")] 
+#endif
     protected ProcessException(
         SerializationInfo info,
         StreamingContext context)

--- a/source/Nuke.Tooling/SettingsEntity.NewInstance.cs
+++ b/source/Nuke.Tooling/SettingsEntity.NewInstance.cs
@@ -2,12 +2,8 @@
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Runtime.Serialization.Formatters.Binary;
 using JetBrains.Annotations;
-#pragma warning disable SYSLIB0011
+using System.Text.Json;
 
 namespace Nuke.Common.Tooling;
 
@@ -17,18 +13,15 @@ public static partial class SettingsEntityExtensions
     public static T NewInstance<T>(this T settingsEntity)
         where T : ISettingsEntity
     {
-        var binaryFormatter = new BinaryFormatter();
+        var json = JsonSerializer.Serialize(settingsEntity);
+        var newInstance = JsonSerializer.Deserialize<T>(json);
 
-        using var memoryStream = new MemoryStream();
-        binaryFormatter.Serialize(memoryStream, settingsEntity);
-        memoryStream.Seek(offset: 0, loc: SeekOrigin.Begin);
-
-        var newInstance = (T) binaryFormatter.Deserialize(memoryStream);
         if (newInstance is ToolSettings toolSettings)
         {
-            toolSettings.ProcessArgumentConfigurator = ((ToolSettings) (object) settingsEntity).ProcessArgumentConfigurator;
-            toolSettings.ProcessLogger = ((ToolSettings) (object) settingsEntity).ProcessLogger;
-            toolSettings.ProcessExitHandler = ((ToolSettings) (object) settingsEntity).ProcessExitHandler;
+            var originalToolSettings = settingsEntity as ToolSettings;
+            toolSettings.ProcessArgumentConfigurator = originalToolSettings.ProcessArgumentConfigurator;
+            toolSettings.ProcessLogger = originalToolSettings.ProcessLogger;
+            toolSettings.ProcessExitHandler = originalToolSettings.ProcessExitHandler;
         }
 
         return newInstance;

--- a/source/Nuke.Tooling/ToolSettings.cs
+++ b/source/Nuke.Tooling/ToolSettings.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2023 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -27,7 +27,7 @@ public abstract class ToolSettings : ISettingsEntity
     public virtual string ProcessToolPath { get; internal set; }
     public virtual string ProcessWorkingDirectory { get; internal set; }
 
-    public IReadOnlyDictionary<string, string> ProcessEnvironmentVariables => ProcessEnvironmentVariablesInternal.AsReadOnly();
+    public IReadOnlyDictionary<string, string> ProcessEnvironmentVariables => DictionaryExtensions.AsReadOnly(ProcessEnvironmentVariablesInternal);
     internal Dictionary<string, string> ProcessEnvironmentVariablesInternal { get; set; }
     public int? ProcessExecutionTimeout { get; internal set; }
     public bool? ProcessLogOutput { get; internal set; }

--- a/source/Nuke.Utilities.Net/HttpResponse.Assert.cs
+++ b/source/Nuke.Utilities.Net/HttpResponse.Assert.cs
@@ -83,6 +83,9 @@ public class HttpResponseException : Exception
     {
     }
 
+#if NET8_0_OR_GREATER
+    [Obsolete(DiagnosticId = "SYSLIB0051")] 
+#endif
     protected HttpResponseException(
         SerializationInfo info,
         StreamingContext context)


### PR DESCRIPTION
Tried to update to net8.0:

- Fixed The call is ambiguous between the following methods or properties `ProcessEnvironmentVariablesInternal.AsReadOnly()`
- Replaced BinaryFormatter with System.Text.Json serialization https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/7.0/binaryformatter-apis-produce-errors
- Followed the guidelines here https://github.com/dotnet/docs/issues/34893 to fix the System.Exception-derived type serialize issues 

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
