### PR TITLE
Fix finalize changelog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,23 +23,22 @@ Therefore, **everything that benefits a larger audience is prioritized** over di
 
 ## Baseline Contributions
 
-There are a number of minimal to zero efforts you can make to show your support for the project:
+There are several minimal to zero efforts you can make to show your support for the project:
 
 - Give the [GitHub project](https://github.com/nuke-build/nuke/stargazers) a star (and tell your team)
 - Follow [@nukebuildnet](https://twitter.com/nukebuildnet) and [@nuke@dotnet.social](https://dotnet.social/@nuke)
-- Upvote, share, and comment our content (see [#mentions](https://app.slack.com/client/T9QUKHC4A/CDJD8CGQ5) on Slack)
+- Upvote, share, and comment on our content (see [#mentions](https://app.slack.com/client/T9QUKHC4A/CDJD8CGQ5) on Slack)
 - Talk about NUKE on social media and let others know where it can help (tag us!)
 
 The above points are considered somewhat of the norm in exchange for using the project free of charge.
 
 ## Sustainability Contributions
 
-There are plenty of ways to show your commitment to the project and strengthen its longevity. These are typically tied to contributing time or money, but also allow for prioritizing your individual issues in return:
+There are plenty of ways to show your commitment to the project and strengthen its longevity. These are typically tied to contributing time or money, but also allow for prioritizing your own issues in return:
 
 - [Convince your company to sponsor](https://humanwhocodes.com/blog/2021/05/talk-to-your-company-sponsoring-open-source/)
 - Sponsor personally (e.g., when the project improves your work performance reviews)
-- Fix or investigate issues that are marked as [`good first issue`](https://github.com/nuke-build/nuke/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
-- Take ownership for a tool wrapper or CI/CD service (.NET CLI, GitHub Actions, ...)
+- Take ownership of a tool wrapper or CI/CD service (.NET CLI, GitHub Actions, ...)
 - Write a blog post or give a meetup talk (let us know!)
 - Help others in GitHub issues/discussions or on Slack and Discord
 
@@ -61,7 +60,7 @@ Evaluate whether your topic is going to be a valid issue:
 
 ### When creating an issue
 
-Choose one of the [issue templates](https://github.com/nuke-build/nuke/issues/new/choose) and fill it out as good as possible. This includes, but is not limited to:
+Choose one of the [issue templates](https://github.com/nuke-build/nuke/issues/new/choose) and fill it out as well as possible. This includes, but is not limited to:
 
 - State the issue as short as possible (more likely there's time to comprehend it)
 - Use [markdown](https://docs.github.com/en/get-started/writing-on-github) for code, logs, and other special text fragments

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ As a community, we want to help each other, provide constructive feedback, and m
 
 ## Consumer Expectations
 
-NUKE is a personal project that was made open-source to let the whole community benefit from it **free of charge** but also ["as is"](https://github.com/nuke-build/nuke/blob/develop/LICENSE). Like a lot of open-source projects, it is primarily maintained and developed by a [single person](https://github.com/matkoch). Some of the **most time-consuming tasks** around the project are:
+NUKE is a personal project that was made open-source to let the whole community benefit from it **free of charge** but also ["as is"](https://github.com/nuke-build/nuke/blob/develop/LICENSE). Like many open-source projects, it is primarily maintained and developed by a [single person](https://github.com/matkoch). Some of the **most time-consuming tasks** around the project are:
 
 - Development of the NuGet package itself (C#, .NET, MSBuild)
 - Collecting CLI metadata (.NET ClI, MSBuild, Docker, +30 others)
@@ -14,12 +14,12 @@ NUKE is a personal project that was made open-source to let the whole community 
 - Hosting (Azure, Cloudflare, Algolia, Fathom)
 - Documentation, presentation slides, and blog posts
 - Helping in GitHub issues/discussions, Slack, and Discord
-- Talking at conferences and meetups including travel
+- Talking at conferences and meetups, including travel
 - Promotion on Twitter and Mastodon
 
-This list should give you an impression of what it took to make NUKE what it is today and what it continuously takes to move it forward. Obviously though, there's only a limited amount of time a single person can dedicate besides their personal life and real job [without burning out](https://www.jeffgeerling.com/blog/2022/burden-open-source-maintainer).
+This list should give you an impression of what it took to make NUKE what it is today and what it continuously takes to move it forward. Obviously, though, there's only a limited amount of time a single person can dedicate besides their personal life and real job [without burning out](https://www.jeffgeerling.com/blog/2022/burden-open-source-maintainer).
 
-Therefore, **everything that benefits a larger audience is prioritized** over digging into issues that only affect a single or few individuals. Please don't take offense when your issue or pull-request is not getting the attention you were hoping for. It is simply a time management decision.
+Therefore, **everything that benefits a larger audience is prioritized** over digging into issues that only affect a single or few individuals. Please don't take offense when your issue or pull request is not getting the attention you were hoping for. It is simply a time management decision.
 
 ## Baseline Contributions
 
@@ -27,18 +27,18 @@ There are several minimal to zero efforts you can make to show your support for 
 
 - Give the [GitHub project](https://github.com/nuke-build/nuke/stargazers) a star (and tell your team)
 - Follow [@nukebuildnet](https://twitter.com/nukebuildnet) and [@nuke@dotnet.social](https://dotnet.social/@nuke)
-- Upvote, share, and comment on our content (see [#mentions](https://app.slack.com/client/T9QUKHC4A/CDJD8CGQ5) on Slack)
+- Upvote, share and comment on our content (see [#mentions](https://app.slack.com/client/T9QUKHC4A/CDJD8CGQ5) on Slack)
 - Talk about NUKE on social media and let others know where it can help (tag us!)
 
 The above points are considered somewhat of the norm in exchange for using the project free of charge.
 
 ## Sustainability Contributions
 
-There are plenty of ways to show your commitment to the project and strengthen its longevity. These are typically tied to contributing time or money, but also allow for prioritizing your own issues in return:
+There are plenty of ways to show your commitment to the project and strengthen its longevity. These are typically tied to contributing time or money but also allow for prioritizing your own issues in return:
 
 - [Convince your company to sponsor](https://humanwhocodes.com/blog/2021/05/talk-to-your-company-sponsoring-open-source/)
 - Sponsor personally (e.g., when the project improves your work performance reviews)
-- Take ownership of a tool wrapper or CI/CD service (.NET CLI, GitHub Actions, ...)
+- Take ownership of a tool wrapper or CI/CD service (.NET CLI, GitHub Actions, etc.)
 - Write a blog post or give a meetup talk (let us know!)
 - Help others in GitHub issues/discussions or on Slack and Discord
 
@@ -53,9 +53,9 @@ Evaluate whether your topic is going to be a valid issue:
 - Have you read and searched the [documentation](https://nuke.build/docs/introduction/)?
 - Have you checked the [FAQ](https://nuke.build/faq/)?
 - Is your issue more of a question? Ask on [GitHub discussions](https://github.com/nuke-build/nuke/discussions), [Slack](https://nuke.build/slack), or [Discord](https://nuke.build/discord)!
-- Have you checked existing/closed issues? Maybe your version is behind?
-- Did you verify it's not an external tool issue? Invoke the command manually!
-- Don't file issues for tool wrappers. Send a pull-request instead!
+- Have you checked existing/closed issues? Is your version behind?
+- Have you verified it's not an external tool issue? Invoke the command manually!
+- Don't file issues for tool wrappers. Send a pull request instead!
 - Refrain from debating the governance or state of the project out of your own interests (see [consumer expectations](#consumer-expectations) & [sustainability contributions](#sustainability-contributions))
 
 ### When creating an issue
@@ -73,12 +73,12 @@ Choose one of the [issue templates](https://github.com/nuke-build/nuke/issues/ne
 
 Once the `triage` label is removed from your issue, you will know how it is seen from the project's perspective:
 
-- Issues labelled as `area:cicd` or `area:tools` usually can be fixed in user code
+- Issues labeled as `area:cicd` or `area:tools` usually can be fixed in user code
   - [Custom arguments](https://nuke.build/docs/common/cli-tools/#custom-arguments) can be wrapped in local extension methods
   - Additional steps in CI/CD configuration generation can be added through inheritance
-- If your issue is labelled as `good first issue`, consider sending a pull-request
+- If your issue is labeled as `good first issue`, consider sending a pull-request
 
-Depending on the priority, available time, and your personal commitment to the project, the issue will be addressed sooner or later. In (hopefully) rare cases, it might also be closed due to missing resources.
+The issue will be addressed sooner or later depending on the priority, available time, and your commitment to the project. In rare cases, it might also be closed due to missing resources.
 
 ## Pull-Requests
 
@@ -95,9 +95,9 @@ In your own interest of getting a pull-request merged (timely):
 
 - Aim for qualitative and readable code
 - Follow the coding style of the existing codebase
-- Make sure the project builds and all tests pass
+- Make sure the project builds, and all tests pass
 - Don't copy/paste chunks of code, even when it's meant as a draft
-- Drafting APIs is okay, as long as you're ready to finish it later
+- Drafting APIs is okay as long as you're ready to finish it later
 - Add tests when meaningful, particularly when there is a related test class already
 
 ### When creating a pull-request
@@ -117,7 +117,8 @@ For tool wrappers (e.g. [.NET CLI](https://github.com/nuke-build/nuke/blob/devel
   - `<para/>` in between paragraphs (as opposed to `<p>...</p>`)
 - Don't explicitly define `secret: false` (it's the default)
 - Don't provide `default: xxx` (it's obsolete)
-- Don't generate the code; it will be done manually once per release
+- Test your changes by calling the `GenerateTools` target
+- Don't commit generated code; it will be done manually once per release
 
 ### After creating a pull-request
 

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_finalize_variant_1.md
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_finalize_variant_1.md
@@ -1,0 +1,34 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+- Added something
+
+## [6.2.1] / 2022-08-19
+- Fixed something
+
+## [6.2.0] / 2022-08-19
+- Added something
+
+## [0.4.0] / 2018-05-02
+- Deprecated something
+
+## [0.3.1] / 2018-03-26
+- Deprecated something
+
+## [0.2.10] / 2018-03-05
+- Fixed something
+
+## [0.2.0] / 2018-02-26
+- Deprecated something
+
+[Unreleased]: https://github.com/nuke-build/nuke/compare/6.2.1...HEAD
+[6.2.1]: https://github.com/nuke-build/nuke/compare/6.2.0...6.2.1
+[6.2.0]: https://github.com/nuke-build/nuke/compare/0.4.0...6.2.0
+[0.4.0]: https://github.com/nuke-build/nuke/compare/0.3.1...0.4.0
+[0.3.1]: https://github.com/nuke-build/nuke/compare/0.2.10...0.3.1
+[0.2.10]: https://github.com/nuke-build/nuke/compare/0.2.0...0.2.10
+[0.2.0]: https://github.com/nuke-build/nuke/tree/0.2.0

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_finalize_variant_1.verified.txt
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_1.0.0_finalize_variant_1.verified.txt
@@ -1,0 +1,37 @@
+﻿# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [6.3.0] / 2022-12-12
+- Added something
+
+## [6.2.1] / 2022-08-19
+- Fixed something
+
+## [6.2.0] / 2022-08-19
+- Added something
+
+## [0.4.0] / 2018-05-02
+- Deprecated something
+
+## [0.3.1] / 2018-03-26
+- Deprecated something
+
+## [0.2.10] / 2018-03-05
+- Fixed something
+
+## [0.2.0] / 2018-02-26
+- Deprecated something
+
+[Unreleased]: https://github.com/nuke-build/nuke/compare/6.3.0...HEAD
+[6.3.0]: https://github.com/nuke-build/nuke/compare/6.2.1...6.3.0
+[6.2.1]: https://github.com/nuke-build/nuke/compare/6.2.0...6.2.1
+[6.2.0]: https://github.com/nuke-build/nuke/compare/0.4.0...6.2.0
+[0.4.0]: https://github.com/nuke-build/nuke/compare/0.3.1...0.4.0
+[0.3.1]: https://github.com/nuke-build/nuke/compare/0.2.10...0.3.1
+[0.2.10]: https://github.com/nuke-build/nuke/compare/0.2.0...0.2.10
+[0.2.0]: https://github.com/nuke-build/nuke/tree/0.2.0

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_finalize_variant_1.md
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_finalize_variant_1.md
@@ -1,0 +1,34 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [vNext]
+- Added something
+
+## [6.2.1] / 2022-08-19
+- Fixed something
+
+## [6.2.0] / 2022-08-19
+- Added something
+
+## [0.4.0] / 2018-05-02
+- Deprecated something
+
+## [0.3.1] / 2018-03-26
+- Deprecated something
+
+## [0.2.10] / 2018-03-05
+- Fixed something
+
+## [0.2.0] / 2018-02-26
+- Deprecated something
+
+[vNext]: https://github.com/nuke-build/nuke/compare/6.2.1...HEAD
+[6.2.1]: https://github.com/nuke-build/nuke/compare/6.2.0...6.2.1
+[6.2.0]: https://github.com/nuke-build/nuke/compare/0.4.0...6.2.0
+[0.4.0]: https://github.com/nuke-build/nuke/compare/0.3.1...0.4.0
+[0.3.1]: https://github.com/nuke-build/nuke/compare/0.2.10...0.3.1
+[0.2.10]: https://github.com/nuke-build/nuke/compare/0.2.0...0.2.10
+[0.2.0]: https://github.com/nuke-build/nuke/tree/0.2.0

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_finalize_variant_1.verified.txt
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_finalize_variant_1.verified.txt
@@ -1,0 +1,37 @@
+﻿# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [vNext]
+
+## [6.3.0] / 2022-12-12
+- Added something
+
+## [6.2.1] / 2022-08-19
+- Fixed something
+
+## [6.2.0] / 2022-08-19
+- Added something
+
+## [0.4.0] / 2018-05-02
+- Deprecated something
+
+## [0.3.1] / 2018-03-26
+- Deprecated something
+
+## [0.2.10] / 2018-03-05
+- Fixed something
+
+## [0.2.0] / 2018-02-26
+- Deprecated something
+
+[vNext]: https://github.com/nuke-build/nuke/compare/6.3.0...HEAD
+[6.3.0]: https://github.com/nuke-build/nuke/compare/6.2.1...6.3.0
+[6.2.1]: https://github.com/nuke-build/nuke/compare/6.2.0...6.2.1
+[6.2.0]: https://github.com/nuke-build/nuke/compare/0.4.0...6.2.0
+[0.4.0]: https://github.com/nuke-build/nuke/compare/0.3.1...0.4.0
+[0.3.1]: https://github.com/nuke-build/nuke/compare/0.2.10...0.3.1
+[0.2.10]: https://github.com/nuke-build/nuke/compare/0.2.0...0.2.10
+[0.2.0]: https://github.com/nuke-build/nuke/tree/0.2.0

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_variant_3.md
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_variant_3.md
@@ -1,0 +1,34 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [vNext]
+- Added something
+
+## [6.2.1] / 2022-08-19
+- Fixed something
+
+## [6.2.0] / 2022-08-19
+- Added something
+
+## [0.4.0] / 2018-05-02
+- Deprecated something
+
+## [0.3.1] / 2018-03-26
+- Deprecated something
+
+## [0.2.10] / 2018-03-05
+- Fixed something
+
+## [0.2.0] / 2018-02-26
+- Deprecated something
+
+[vNext]: https://github.com/nuke-build/nuke/compare/6.2.1...HEAD
+[6.2.1]: https://github.com/nuke-build/nuke/compare/6.2.0...6.2.1
+[6.2.0]: https://github.com/nuke-build/nuke/compare/6.1.2...6.2.0
+[0.4.0]: https://github.com/nuke-build/nuke/compare/0.3.1...0.4.0
+[0.3.1]: https://github.com/nuke-build/nuke/compare/0.2.10...0.3.1
+[0.2.10]: https://github.com/nuke-build/nuke/compare/0.2.0...0.2.10
+[0.2.0]: https://github.com/nuke-build/nuke/tree/0.2.0

--- a/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_variant_3.verified.txt
+++ b/source/Nuke.Common.Tests/ChangelogReferenceFiles/changelog_reference_NUKE_variant_3.verified.txt
@@ -1,0 +1,78 @@
+[
+  {
+    IsEmpty: false,
+    Unreleased: true,
+    Notes: [
+      - Added something,
+      
+    ],
+    StartIndex: 6,
+    EndIndex: 8
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 6.2.1,
+    Notes: [
+      - Fixed something,
+      
+    ],
+    StartIndex: 9,
+    EndIndex: 11
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 6.2.0,
+    Notes: [
+      - Added something,
+      
+    ],
+    StartIndex: 12,
+    EndIndex: 14
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 0.4.0,
+    Notes: [
+      - Deprecated something,
+      
+    ],
+    StartIndex: 15,
+    EndIndex: 17
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 0.3.1,
+    Notes: [
+      - Deprecated something,
+      
+    ],
+    StartIndex: 18,
+    EndIndex: 20
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 0.2.10,
+    Notes: [
+      - Fixed something,
+      
+    ],
+    StartIndex: 21,
+    EndIndex: 23
+  },
+  {
+    IsEmpty: false,
+    Unreleased: false,
+    Version: 0.2.0,
+    Notes: [
+      - Deprecated something,
+      
+    ],
+    StartIndex: 24,
+    EndIndex: 26
+  }
+]

--- a/source/Nuke.Common.Tests/ChangelogTasksTest.cs
+++ b/source/Nuke.Common.Tests/ChangelogTasksTest.cs
@@ -139,11 +139,15 @@ public class ChangelogTasksTest
 
         var copy = Path.Combine(Path.GetTempPath(), "CHANGELOG.md");
         File.Copy(file, copy, overwrite: true);
-        
-        ChangelogTasks.FinalizeChangelog(copy, "6.3.0", new GitRepository(GitProtocol.Https, "github.com", "nuke-build/nuke", "", RootDirectory, "", "", new []{""}, "", ""));
+
+        ChangelogTasks.FinalizeChangelogInternal(
+            copy,
+            "6.3.0",
+            new GitRepository(GitProtocol.Https, "github.com", "nuke-build/nuke", "", RootDirectory, "", "", new[] { "" }, "", ""),
+            new DateTime(year: 2022, month: 12, day: 12));
 
         var contentAfterFinalizing = File.ReadAllText(copy);
-        
+
         return Verifier.Verify(contentAfterFinalizing).UseDirectory(PathToChangelogReferenceFiles).UseFileName(file.NameWithoutExtension);
     }
 

--- a/source/Nuke.Common.Tests/ChangelogTasksTest.cs
+++ b/source/Nuke.Common.Tests/ChangelogTasksTest.cs
@@ -4,11 +4,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using JetBrains.Annotations;
 using Nuke.Common.ChangeLog;
+using Nuke.Common.Git;
 using Nuke.Common.IO;
 using VerifyXunit;
 using Xunit;
@@ -127,14 +129,31 @@ public class ChangelogTasksTest
 
         act.Should().Throw<Exception>().WithMessage("Changelog should have at least one release note section");
     }
+    
+    [Theory]
+    [InlineData("changelog_reference_NUKE_finalize_variant_1.md")]
+    [InlineData("changelog_reference_1.0.0_finalize_variant_1.md")]
+    public Task FinalizeChangelog_NUKEChangelogFile_ChangelogIsCorrectlyFinalized(string fileName)
+    {
+        var file = PathToChangelogReferenceFiles / fileName;
+
+        var copy = Path.Combine(Path.GetTempPath(), "CHANGELOG.md");
+        File.Copy(file, copy, overwrite: true);
+        
+        ChangelogTasks.FinalizeChangelog(copy, "6.3.0", new GitRepository(GitProtocol.Https, "github.com", "nuke-build/nuke", "", RootDirectory, "", "", new []{""}, "", ""));
+
+        var contentAfterFinalizing = File.ReadAllText(copy);
+        
+        return Verifier.Verify(contentAfterFinalizing).UseDirectory(PathToChangelogReferenceFiles).UseFileName(file.NameWithoutExtension);
+    }
 
     [UsedImplicitly]
     public static IEnumerable<object[]> AllChangelogReference_1_0_0_Files
     {
-        get => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_1.0.0*.md").Select(x => new object[] { x });
+        get => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_1.0.0_variant*.md").Select(x => new object[] { x });
     }
 
     [UsedImplicitly]
     public static IEnumerable<object[]> AllChangelogReference_NUKE_Files
-        => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_NUKE*.md").Select(x => new object[] { x });
+        => PathToChangelogReferenceFiles.GlobFiles("changelog_reference_NUKE_variant*.md").Select(x => new object[] { x });
 }

--- a/source/Nuke.Common.Tests/ChangelogTasksTest.cs
+++ b/source/Nuke.Common.Tests/ChangelogTasksTest.cs
@@ -27,11 +27,51 @@ public class ChangelogTasksTest
     [Theory]
     [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
     [MemberData(nameof(AllChangelogReference_NUKE_Files))]
+    public void ReadReleaseNotes_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
+    {
+        Action act = () => ChangelogTasks.ReadReleaseNotes(file);
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+    [MemberData(nameof(AllChangelogReference_NUKE_Files))]
+    public void ReadReleaseNotes_ChangelogReferenceFile_ReturnsAnyReleaseNotes(AbsolutePath file)
+    {
+        var releaseNotes = ChangelogTasks.ReadReleaseNotes(file);
+
+        releaseNotes.Should().NotBeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+    [MemberData(nameof(AllChangelogReference_NUKE_Files))]
+    public void ReadChangelog_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
+    {
+        Action act = () => ChangelogTasks.ReadChangelog(file);
+
+        act.Should().NotThrow();
+    }
+
+    [Theory]
+    [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+    [MemberData(nameof(AllChangelogReference_NUKE_Files))]
     public void ExtractChangelogSectionNotes_ChangelogReferenceFile_ThrowsNoExceptions(AbsolutePath file)
     {
         Action act = () => ChangelogTasks.ExtractChangelogSectionNotes(file);
 
         act.Should().NotThrow();
+    }
+
+    [Theory]
+    [MemberData(nameof(AllChangelogReference_1_0_0_Files))]
+    [MemberData(nameof(AllChangelogReference_NUKE_Files))]
+    public Task ReadReleaseNotes_ChangelogReferenceFile_HasParsedCorrectly(AbsolutePath file)
+    {
+        var releaseNotes = ChangelogTasks.ReadReleaseNotes(file);
+
+        return Verifier.Verify(releaseNotes).UseDirectory(PathToChangelogReferenceFiles).UseFileName(file.NameWithoutExtension);
     }
 
     [Fact]

--- a/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
+++ b/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
@@ -130,6 +130,11 @@ public static class ChangelogTasks
     /// <seealso cref="FinalizeChangelog(ChangeLog,NuGetVersion,GitRepository)"/>
     public static void FinalizeChangelog(AbsolutePath changelogFile, string tag, [CanBeNull] GitRepository repository = null)
     {
+        FinalizeChangelogInternal(changelogFile, tag, repository);
+    }
+
+    internal static void FinalizeChangelogInternal(AbsolutePath changelogFile, string tag, [CanBeNull] GitRepository repository = null, DateTime? dateTime = null)
+    {
         Log.Information("Finalizing {File} for {Tag} ...", PathConstruction.GetRelativePath(NukeBuild.RootDirectory, changelogFile), tag);
 
         var content = changelogFile.ReadAllLines().ToList();
@@ -143,8 +148,10 @@ public static class ChangelogTasks
         Assert.True(secondSection == null || NuGetVersion.Parse(tag).CompareTo(NuGetVersion.Parse(secondSection.Caption)) > 0,
             $"Tag '{tag}' is not greater compared to last tag '{secondSection?.Caption}'");
 
+        var now = dateTime ?? DateTime.Now;
+        
         content.Insert(firstSection.StartIndex + 1, string.Empty);
-        content.Insert(firstSection.StartIndex + 2, $"## [{tag}] / {DateTime.Now:yyyy-MM-dd}");
+        content.Insert(firstSection.StartIndex + 2, $"## [{tag}] / {now:yyyy-MM-dd}");
 
         UpdateVersionSummary(tag, content, repository);
 

--- a/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
+++ b/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
@@ -184,6 +184,9 @@ public static class ChangelogTasks
     {
         static bool IsReleaseHead(string str)
             => str.StartsWith("## ");
+        
+        static bool IsVersionSummary(string str)
+            => str.StartsWith("[");
 
         static string GetCaption(string str)
             => str
@@ -206,7 +209,7 @@ public static class ChangelogTasks
             }
 
             var caption = GetCaption(line);
-            var nextReleaseHeadIndex = content.FindIndex(index + 1, IsReleaseHead);
+            var nextReleaseHeadIndex = content.FindIndex(index + 1, s => IsReleaseHead(s) || IsVersionSummary(s));
 
             var releaseData =
                 new ReleaseSection
@@ -235,7 +238,6 @@ public static class ChangelogTasks
 
             content.RemoveRange(lastSection.EndIndex + 1, content.Count - lastSection.EndIndex - 1);
 
-            content.Add(string.Empty);
             content.Add($"[{firstSection.Caption}]: {repository.GetGitHubCompareTagToHeadUrl(tag)}");
             for (var i = 1; i + 1 < sections.Count; i++)
                 content.Add($"[{sections[i].Caption}]: {repository.GetGitHubCompareTagsUrl(sections[i].Caption, sections[i + 1].Caption)}");

--- a/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
+++ b/source/Nuke.Common/ChangeLog/ChangeLogTasks.cs
@@ -178,12 +178,6 @@ public static class ChangelogTasks
         static bool IsReleaseHead(string str)
             => str.StartsWith("## ");
 
-        static bool IsReleaseContent(string str)
-            => str.StartsWith("###")
-               || str.Trim().StartsWith("-")
-               || str.Trim().StartsWith("*")
-               || str.Trim().StartsWith("+");
-
         static string GetCaption(string str)
             => str
                 .TrimStart('#', ' ', '[')
@@ -205,7 +199,7 @@ public static class ChangelogTasks
             }
 
             var caption = GetCaption(line);
-            var nextReleaseHeadIndex = content.FindIndex(index + 1,  x => IsReleaseHead(x) || !IsReleaseContent(x));
+            var nextReleaseHeadIndex = content.FindIndex(index + 1, IsReleaseHead);
 
             var releaseData =
                 new ReleaseSection

--- a/source/Nuke.Utilities/Text/String.Emptiness.cs
+++ b/source/Nuke.Utilities/Text/String.Emptiness.cs
@@ -19,12 +19,32 @@ public static partial class StringExtensions
     }
 
     /// <summary>
-    /// Indicates whether a specified string is null, empty, or consists only of white-space characters.
+    /// Indicates whether a specified string is null, empty, or only white-space.
     /// </summary>
     [Pure]
     [ContractAnnotation("null => halt")]
     public static bool IsNullOrWhiteSpace(this string str)
     {
         return string.IsNullOrWhiteSpace(str);
+    }
+
+    /// <summary>
+    /// Returns <value>null</value> if the specified string is empty.
+    /// </summary>
+    [Pure]
+    [ContractAnnotation("null => null")]
+    public static string ToNullIfEmpty(this string str)
+    {
+        return str.IsNullOrEmpty() ? null : str;
+    }
+
+    /// <summary>
+    /// Returns <value>null</value> if the specified string is empty or only white-space.
+    /// </summary>
+    [Pure]
+    [ContractAnnotation("null => null")]
+    public static string ToNullIfWhiteSpace(this string str)
+    {
+        return str.IsNullOrWhiteSpace() ? null : str;
     }
 }

--- a/source/Nuke.Utilities/Text/String.Split.cs
+++ b/source/Nuke.Utilities/Text/String.Split.cs
@@ -64,9 +64,18 @@ public static partial class StringExtensions
     /// Splits a given string by new-lines with empty entries preserved.
     /// </summary>
     [Pure]
-    public static string[] SplitLineBreaks(this string str)
+    public static string[] SplitLineBreaks(this string str, StringSplitOptions options = StringSplitOptions.None)
     {
-        return str.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+        return str.Split(new[] { "\r\n", "\n" }, options);
+    }
+
+    /// <summary>
+    /// Splits a given string by paragraphs (double new-line) with empty entries preserved.
+    /// </summary>
+    [Pure]
+    public static string[] SplitParagraphs(this string str, StringSplitOptions options = StringSplitOptions.None)
+    {
+        return str.Split(new[] { "\r\n\r\n", "\n\n" }, options);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

This PR fixes the wrong behavior when calling `FinalizeChangelog()` where the version summary would be repeated, as seen [here](https://github.com/nuke-build/nuke/commit/ea86450b4db1568563b15122f0250495fd55776e).
A unit test has been added to confirm the behavior.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
