### PR TITLE
Added Docker CliSettings context and host, along with extensions

### DIFF
--- a/source/Nuke.Common/Tools/Docker/CliSettings.cs
+++ b/source/Nuke.Common/Tools/Docker/CliSettings.cs
@@ -14,6 +14,4 @@ public partial class CliSettings
     {
         return ConfigureProcessArguments(new Arguments());
     }
-
-    public override Action<OutputType, string> ProcessLogger => base.ProcessLogger ?? throw new NotSupportedException();
 }

--- a/source/Nuke.Common/Tools/Docker/Docker.json
+++ b/source/Nuke.Common/Tools/Docker/Docker.json
@@ -10032,6 +10032,8 @@
     },
     {
       "name": "CliSettings",
+      "extensionMethods": true,
+      "baseClass": "ISettingsEntity",
       "properties": [
         {
           "name": "LogLevel",
@@ -10046,10 +10048,22 @@
           "help": "Location of client config files (default ~/.docker)."
         },
         {
+          "name": "Context",
+          "type": "string",
+          "format": "--context {value}",
+          "help": "Name of the context to use to connect to the daemon."
+        },
+        {
           "name": "Debug",
           "type": "bool",
           "format": "--debug",
           "help": "Enable debug mode."
+        },
+        {
+          "name": "Hosts",
+          "type": "List<string>",
+          "format": "--host {value}",
+          "help": "Daemon socket to connect to."
         },
         {
           "name": "TLS",

--- a/source/Nuke.Common/Tools/Docker/DockerTargetDefinitionExtensions.cs
+++ b/source/Nuke.Common/Tools/Docker/DockerTargetDefinitionExtensions.cs
@@ -118,7 +118,17 @@ public static class DockerTargetDefinitionExtensions
                                  $"--{ParameterService.GetParameterDashedName(Constants.SkippedTargetsParameterName)}"
                              }.Concat(settings.Args))
                     .DisableProcessLogInvocation()
-                    .SetProcessLogger((_, message) => Log.Write(LogEventReader.ReadFromString(message))));
+                    .SetProcessLogger((_, message) =>
+                    {
+                        try
+                        {
+                            Log.Write(LogEventReader.ReadFromString(message));
+                        }
+                        catch
+                        {
+                            Log.Debug(message);
+                        }
+                    }));
             }
             finally
             {

--- a/source/Nuke.Tooling.Generator/Generators/DataClassGenerator.cs
+++ b/source/Nuke.Tooling.Generator/Generators/DataClassGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2023 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -200,12 +200,14 @@ public static class DataClassGenerator
         if (hasArguments)
             argumentAdditions[argumentAdditions.Count - 1] += ";";
 
+        var isSettingsEntity = string.Equals(writer.DataClass.BaseClass, "ISettingsEntity");
+
         return writer
-            .WriteLine("protected override Arguments ConfigureProcessArguments(Arguments arguments)")
+            .WriteLine(isSettingsEntity ? "protected Arguments ConfigureProcessArguments(Arguments arguments)" : "protected override Arguments ConfigureProcessArguments(Arguments arguments)")
             .WriteBlock(w => w
                 .WriteLine("arguments")
                 .ForEachWriteLine(argumentAdditions)
-                .WriteLine("return base.ConfigureProcessArguments(arguments);"));
+                .WriteLine(isSettingsEntity ? "return arguments;" : "return base.ConfigureProcessArguments(arguments);"));
     }
 
     private static string GetArgumentAddition(Property property)


### PR DESCRIPTION
Changes
- Added Docker host parameter list (CliSettings for all commands)
- Added Docker context parameter (CliSettings for all commands)
- Set CliSettings extensionMethods to true so it can be configured. Otherwise there is no way to set cli settings values ...

Removing the ProcessLogger from CliSettings could have done the trick, to avoid NewInstance throwing while copying the logger. However it seems the exception there was on purpose, to prevent people from using the logger in the common type. So I modified a little bit the tool code generation to support not deriving from ToolSettings, which removes the extra ProcessLogger and makes NewInstance not try to copy anything. I think it makes everything cleaner, not sure what you had in mind at the beginning ...

It was partially tested in our solution, I was able to remove all hacks to set CliSettings properties. I was not able to do a full build though as our CI is currently broken ...

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer