### PR TITLE
feat: add dotnet workload tools

### DIFF
--- a/source/Nuke.Common/Tools/DotNet/DotNet.json
+++ b/source/Nuke.Common/Tools/DotNet/DotNet.json
@@ -1081,6 +1081,82 @@
           }
         ]
       }
+    },
+    {
+      "help": "The <c>dotnet workload install</c> command installs one or more optional workloads. Optional workloads can be installed on top of the .NET SDK to provide support for various application types, such as .NET MAUI and Blazor WebAssembly AOT.",
+      "postfix": "WorkloadInstall",
+      "omitCommonProperties": true,
+      "definiteArgument": "workload install",
+      "settingsClass": {
+        "properties": [
+          {
+            "name": "WorkloadId",
+            "type": "List<string>",
+            "format": "{value}",
+            "help": "The workload ID or multiple IDs to install."
+          },
+          {
+            "name": "ConfigFile",
+            "type": "string",
+            "format": "--configFile {value}",
+            "help": "The NuGet configuration file (nuget.config) to use. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used."
+          },
+          {
+            "name": "DisableParallel",
+            "type": "bool",
+            "format": "--disable-parallel",
+            "help": "Prevents restoring multiple projects in parallel."
+          },
+          {
+            "name": "IgnoreFailedSources",
+            "type": "bool",
+            "format": "--ignore-failed-sources",
+            "help": "Treats package source failures as warnings."
+          },
+          {
+            "name": "IncludePreviews",
+            "type": "bool",
+            "format": "--include-previews",
+            "help": "Allows prerelease workload manifests."
+          },
+          {
+            "name": "Interactive",
+            "type": "bool",
+            "format": "--interactive",
+            "help": "Allows the command to stop and wait for user input or action. For example, to complete authentication."
+          },
+          {
+            "name": "NoCache",
+            "type": "bool",
+            "format": "--no-cache",
+            "help": "Prevents caching of packages and http requests."
+          },
+          {
+            "name": "SkipManifestUpdate",
+            "type": "bool",
+            "format": "--skip-manifest-update",
+            "help": "Skip updating the workload manifests. The workload manifests define what assets and versions need to be installed for each workload."
+          },
+          {
+            "name": "Source",
+            "type": "string",
+            "format": "--source {value}",
+            "help": "Specifies the URI of the NuGet package source to use. This setting overrides all of the sources specified in the nuget.config files. Multiple sources can be provided by specifying this option multiple times."
+          },
+          {
+            "name": "TempDir",
+            "type": "string",
+            "format": "--temp-dir {value}",
+            "help": "Specify the temporary directory used to download and extract NuGet packages (must be secure)."
+          },
+          {
+            "name": "Verbosity",
+            "type": "DotNetVerbosity",
+            "format": "--verbosity {value}",
+            "help": "Sets the verbosity level of the command. Allowed values are <c>q[uiet]</c>, <c>m[inimal]</c>, <c>n[ormal]</c>, <c>d[etailed]</c>, and <c>diag[nostic]</c>."
+          }
+        ]
+      }
     }
   ],
   "commonTaskProperties": [

--- a/source/Nuke.Common/Tools/DotNet/DotNet.json
+++ b/source/Nuke.Common/Tools/DotNet/DotNet.json
@@ -1157,6 +1157,82 @@
           }
         ]
       }
+    },
+    {
+      "help": "The <c>dotnet workload restore</c> command analyzes a project or solution to determine which workloads it needs, then installs any workloads that are missing.",
+      "postfix": "WorkloadRestore",
+      "omitCommonProperties": true,
+      "definiteArgument": "workload restore",
+      "settingsClass": {
+        "properties": [
+          {
+            "name": "Project",
+            "type": "string",
+            "format": "{value}",
+            "help": "The project or solution file to install workloads for. If a file is not specified, the command searches the current directory for one."
+          },
+          {
+            "name": "ConfigFile",
+            "type": "string",
+            "format": "--configFile {value}",
+            "help": "The NuGet configuration file (nuget.config) to use. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used."
+          },
+          {
+            "name": "DisableParallel",
+            "type": "bool",
+            "format": "--disable-parallel",
+            "help": "Prevents restoring multiple projects in parallel."
+          },
+          {
+            "name": "IgnoreFailedSources",
+            "type": "bool",
+            "format": "--ignore-failed-sources",
+            "help": "Treats package source failures as warnings."
+          },
+          {
+            "name": "IncludePreviews",
+            "type": "bool",
+            "format": "--include-previews",
+            "help": "Allows prerelease workload manifests."
+          },
+          {
+            "name": "Interactive",
+            "type": "bool",
+            "format": "--interactive",
+            "help": "Allows the command to stop and wait for user input or action. For example, to complete authentication."
+          },
+          {
+            "name": "NoCache",
+            "type": "bool",
+            "format": "--no-cache",
+            "help": "Prevents caching of packages and http requests."
+          },
+          {
+            "name": "SkipManifestUpdate",
+            "type": "bool",
+            "format": "--skip-manifest-update",
+            "help": "Skip updating the workload manifests. The workload manifests define what assets and versions need to be installed for each workload."
+          },
+          {
+            "name": "Source",
+            "type": "string",
+            "format": "--source {value}",
+            "help": "Specifies the URI of the NuGet package source to use. This setting overrides all of the sources specified in the nuget.config files. Multiple sources can be provided by specifying this option multiple times."
+          },
+          {
+            "name": "TempDir",
+            "type": "string",
+            "format": "--temp-dir {value}",
+            "help": "Specify the temporary directory used to download and extract NuGet packages (must be secure)."
+          },
+          {
+            "name": "Verbosity",
+            "type": "DotNetVerbosity",
+            "format": "--verbosity {value}",
+            "help": "Sets the verbosity level of the command. Allowed values are <c>q[uiet]</c>, <c>m[inimal]</c>, <c>n[ormal]</c>, <c>d[etailed]</c>, and <c>diag[nostic]</c>."
+          }
+        ]
+      }
     }
   ],
   "commonTaskProperties": [

--- a/source/Nuke.Common/Tools/DotNet/DotNet.json
+++ b/source/Nuke.Common/Tools/DotNet/DotNet.json
@@ -1159,6 +1159,22 @@
       }
     },
     {
+      "help": "The <c>dotnet workload uninstall</c> command uninstalls one or more workloads.",
+      "postfix": "WorkloadUninstall",
+      "omitCommonProperties": true,
+      "definiteArgument": "workload uninstall",
+      "settingsClass": {
+        "properties": [
+          {
+            "name": "WorkloadId",
+            "type": "List<string>",
+            "format": "{value}",
+            "help": "The workload ID or multiple IDs to install."
+          }
+        ]
+      }
+    },
+    {
       "help": "The <c>dotnet workload restore</c> command analyzes a project or solution to determine which workloads it needs, then installs any workloads that are missing.",
       "postfix": "WorkloadRestore",
       "omitCommonProperties": true,

--- a/source/Nuke.Common/Tools/DotNet/DotNet.json
+++ b/source/Nuke.Common/Tools/DotNet/DotNet.json
@@ -1233,6 +1233,82 @@
           }
         ]
       }
+    },
+    {
+      "help": "The <c>dotnet workload update</c> command updates all installed workloads to the newest available versions. It queries Nuget.org for updated workload manifests. It then updates local manifests, downloads new versions of the installed workloads, and removes all old versions of each workload.",
+      "postfix": "WorkloadUpdate",
+      "omitCommonProperties": true,
+      "definiteArgument": "workload update",
+      "settingsClass": {
+        "properties": [
+          {
+            "name": "AdvertisingManifestsOnly",
+            "type": "bool",
+            "format": "--advertising-manifests-only",
+            "help": "Downloads advertising manifests but doesn't update any workloads."
+          },
+          {
+            "name": "ConfigFile",
+            "type": "string",
+            "format": "--configFile {value}",
+            "help": "The NuGet configuration file (nuget.config) to use. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used."
+          },
+          {
+            "name": "DisableParallel",
+            "type": "bool",
+            "format": "--disable-parallel",
+            "help": "Prevents restoring multiple projects in parallel."
+          },
+          {
+            "name": "FromPreviousSdk",
+            "type": "bool",
+            "format": "--from-previous-sdk",
+            "help": "Include workloads installed with previous SDK versions in the update."
+          },
+          {
+            "name": "IgnoreFailedSources",
+            "type": "bool",
+            "format": "--ignore-failed-sources",
+            "help": "Treats package source failures as warnings."
+          },
+          {
+            "name": "IncludePreviews",
+            "type": "bool",
+            "format": "--include-previews",
+            "help": "Allows prerelease workload manifests."
+          },
+          {
+            "name": "Interactive",
+            "type": "bool",
+            "format": "--interactive",
+            "help": "Allows the command to stop and wait for user input or action. For example, to complete authentication."
+          },
+          {
+            "name": "NoCache",
+            "type": "bool",
+            "format": "--no-cache",
+            "help": "Prevents caching of packages and http requests."
+          },
+          {
+            "name": "Source",
+            "type": "string",
+            "format": "--source {value}",
+            "help": "Specifies the URI of the NuGet package source to use. This setting overrides all of the sources specified in the nuget.config files. Multiple sources can be provided by specifying this option multiple times."
+          },
+          {
+            "name": "TempDir",
+            "type": "string",
+            "format": "--temp-dir {value}",
+            "help": "Specify the temporary directory used to download and extract NuGet packages (must be secure)."
+          },
+          {
+            "name": "Verbosity",
+            "type": "DotNetVerbosity",
+            "format": "--verbosity {value}",
+            "help": "Sets the verbosity level of the command. Allowed values are <c>q[uiet]</c>, <c>m[inimal]</c>, <c>n[ormal]</c>, <c>d[etailed]</c>, and <c>diag[nostic]</c>."
+          }
+        ]
+      }
     }
   ],
   "commonTaskProperties": [

--- a/source/Nuke.Common/Tools/DotNet/DotNet.json
+++ b/source/Nuke.Common/Tools/DotNet/DotNet.json
@@ -1309,6 +1309,70 @@
           }
         ]
       }
+    },
+    {
+      "help": "The <c>dotnet workload repair</c>  command reinstalls all installed workloads. Workloads are made up of multiple workload packs and it's possible to get into a state where some installed successfully but others didn't. For example, a dotnet workload install command might not finish installing because of a dropped internet connection.",
+      "postfix": "WorkloadRepair",
+      "omitCommonProperties": true,
+      "definiteArgument": "workload repair",
+      "settingsClass": {
+        "properties": [
+          {
+            "name": "ConfigFile",
+            "type": "string",
+            "format": "--configFile {value}",
+            "help": "The NuGet configuration file (nuget.config) to use. If specified, only the settings from this file will be used. If not specified, the hierarchy of configuration files from the current directory will be used."
+          },
+          {
+            "name": "DisableParallel",
+            "type": "bool",
+            "format": "--disable-parallel",
+            "help": "Prevents restoring multiple projects in parallel."
+          },
+          {
+            "name": "IgnoreFailedSources",
+            "type": "bool",
+            "format": "--ignore-failed-sources",
+            "help": "Treats package source failures as warnings."
+          },
+          {
+            "name": "IncludePreviews",
+            "type": "bool",
+            "format": "--include-previews",
+            "help": "Allows prerelease workload manifests."
+          },
+          {
+            "name": "Interactive",
+            "type": "bool",
+            "format": "--interactive",
+            "help": "Allows the command to stop and wait for user input or action. For example, to complete authentication."
+          },
+          {
+            "name": "NoCache",
+            "type": "bool",
+            "format": "--no-cache",
+            "help": "Prevents caching of packages and http requests."
+          },
+          {
+            "name": "Source",
+            "type": "string",
+            "format": "--source {value}",
+            "help": "Specifies the URI of the NuGet package source to use. This setting overrides all of the sources specified in the nuget.config files. Multiple sources can be provided by specifying this option multiple times."
+          },
+          {
+            "name": "TempDir",
+            "type": "string",
+            "format": "--temp-dir {value}",
+            "help": "Specify the temporary directory used to download and extract NuGet packages (must be secure)."
+          },
+          {
+            "name": "Verbosity",
+            "type": "DotNetVerbosity",
+            "format": "--verbosity {value}",
+            "help": "Sets the verbosity level of the command. Allowed values are <c>q[uiet]</c>, <c>m[inimal]</c>, <c>n[ormal]</c>, <c>d[etailed]</c>, and <c>diag[nostic]</c>."
+          }
+        ]
+      }
     }
   ],
   "commonTaskProperties": [

--- a/source/Nuke.Common/Tools/DotNet/DotNet.json
+++ b/source/Nuke.Common/Tools/DotNet/DotNet.json
@@ -13,7 +13,12 @@
     "https://raw.githubusercontent.com/dotnet/docs/main/docs/core/tools/dotnet-tool-uninstall.md",
     "https://raw.githubusercontent.com/dotnet/docs/main/docs/core/tools/dotnet-tool-update.md",
     "https://raw.githubusercontent.com/dotnet/docs/main/docs/core/tools/dotnet-msbuild.md",
-    "https://raw.githubusercontent.com/dotnet/docs/main/docs/core/tools/dotnet-format.md"
+    "https://raw.githubusercontent.com/dotnet/docs/main/docs/core/tools/dotnet-format.md",
+    "https://raw.githubusercontent.com/dotnet/docs/main/docs/core/tools/dotnet-workload-install.md",
+    "https://raw.githubusercontent.com/dotnet/docs/main/docs/core/tools/dotnet-workload-repair.md",
+    "https://raw.githubusercontent.com/dotnet/docs/main/docs/core/tools/dotnet-workload-restore.md",
+    "https://raw.githubusercontent.com/dotnet/docs/main/docs/core/tools/dotnet-workload-uninstall.md",
+    "https://raw.githubusercontent.com/dotnet/docs/main/docs/core/tools/dotnet-workload-update.md"
   ],
   "name": "DotNet",
   "officialUrl": "https://docs.microsoft.com/en-us/dotnet/core/tools/",


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
I have added the tools 

- `DotNetWorkloadInstall` 
- `DotNetWorkloadRepair` 
- `DotNetWorkloadRestore` 
- `DotNetWorkloadUninstall` 
- `DotNetWorkloadUpdate` 

with the most sensible parameters (excluding -h|--help).

IMHO only the `dotnet workload restore` makes sense, because you cannot develop e.g. a maui app without having this workload installed. But I added it just in case.

Closes #1253 
<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
