### PR TITLE
fix case issues for verbosity when calling dotnet format

### DIFF
--- a/source/Nuke.Common/Tools/DotNet/DotNet.Generated.cs
+++ b/source/Nuke.Common/Tools/DotNet/DotNet.Generated.cs
@@ -23121,11 +23121,11 @@ public static partial class DotNetToolUpdateSettingsExtensions
 [TypeConverter(typeof(TypeConverter<DotNetVerbosity>))]
 public partial class DotNetVerbosity : Enumeration
 {
-    public static DotNetVerbosity Quiet = (DotNetVerbosity) "Quiet";
-    public static DotNetVerbosity Minimal = (DotNetVerbosity) "Minimal";
-    public static DotNetVerbosity Normal = (DotNetVerbosity) "Normal";
-    public static DotNetVerbosity Detailed = (DotNetVerbosity) "Detailed";
-    public static DotNetVerbosity Diagnostic = (DotNetVerbosity) "Diagnostic";
+    public static DotNetVerbosity quiet = (DotNetVerbosity) "quiet";
+    public static DotNetVerbosity minimal = (DotNetVerbosity) "minimal";
+    public static DotNetVerbosity normal = (DotNetVerbosity) "normal";
+    public static DotNetVerbosity detailed = (DotNetVerbosity) "detailed";
+    public static DotNetVerbosity diagnostic = (DotNetVerbosity) "diagnostic";
     public static implicit operator DotNetVerbosity(string value)
     {
         return new DotNetVerbosity { Value = value };

--- a/source/Nuke.Common/Tools/DotNet/DotNet.json
+++ b/source/Nuke.Common/Tools/DotNet/DotNet.json
@@ -1313,11 +1313,11 @@
     {
       "name": "DotNetVerbosity",
       "values": [
-        "Quiet",
-        "Minimal",
-        "Normal",
-        "Detailed",
-        "Diagnostic"
+        "quiet",
+        "minimal",
+        "normal",
+        "detailed",
+        "diagnostic"
       ]
     },
     {

--- a/source/Nuke.Common/Tools/DotNet/DotNetTasks.cs
+++ b/source/Nuke.Common/Tools/DotNet/DotNetTasks.cs
@@ -16,10 +16,10 @@ public class DotNetVerbosityMappingAttribute : VerbosityMappingAttribute
     public DotNetVerbosityMappingAttribute()
         : base(typeof(DotNetVerbosity))
     {
-        Quiet = nameof(DotNetVerbosity.Quiet);
-        Minimal = nameof(DotNetVerbosity.Minimal);
-        Normal = nameof(DotNetVerbosity.Minimal);
-        Verbose = nameof(DotNetVerbosity.Detailed);
+        Quiet = nameof(DotNetVerbosity.quiet);
+        Minimal = nameof(DotNetVerbosity.minimal);
+        Normal = nameof(DotNetVerbosity.minimal);
+        Verbose = nameof(DotNetVerbosity.detailed);
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

This is proposed fix for https://github.com/dotnet/format/issues/1797

Seems that all other dotnet commands happily accept lower case values for verbosity, maybe it should be the case here as well? At least until dotnet format team decides what to do about the issue.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
