### PR TITLE
fix(npm): log npm notice messages as Debug

### DIFF
--- a/source/Nuke.Common/Tools/Npm/NpmTasks.cs
+++ b/source/Nuke.Common/Tools/Npm/NpmTasks.cs
@@ -20,6 +20,8 @@ partial class NpmTasks
             {
                 if (output.StartsWith("npmWARN") || output.StartsWith("npm WARN"))
                     Log.Warning(output);
+                else if(output.StartsWith("npm notice"))
+                    Log.Debug(output);
                 else
                     Log.Error(output);
 


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Fixes #1275. As mentioned in the issue, NPM logs various messages to the standard error. The code treated the special prefixes `npmWARN` and `npm WARN` already as warning. This PR extends the handling to treat `npm notice` prefixed messages as normal Debug logs (like standard output). 

Unfortunately a suitable base for adding a unit test is missing in the codebase, otherwise I would have added some tests. Developing the foundation for testing such log outputs would exceed the scope of this PR.  

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
