### PR TITLE
Update AzurePipelinesImage enum

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
@@ -36,11 +36,11 @@ trigger:
       - excluded_path
 
 stages:
-  - stage: ubuntu_18_04
-    displayName: 'ubuntu-18.04'
+  - stage: ubuntu_22_04
+    displayName: 'ubuntu-22.04'
     dependsOn: [  ]
     pool:
-      vmImage: 'ubuntu-18.04'
+      vmImage: 'ubuntu-22.04'
     jobs:
       - job: Restore
         displayName: 'Restore'

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -76,7 +76,7 @@ public class ConfigurationGenerationTest
             (
                 null,
                 new TestAzurePipelinesAttribute(
-                    AzurePipelinesImage.Ubuntu1804,
+                    AzurePipelinesImage.Ubuntu2204,
                     AzurePipelinesImage.Windows2019)
                 {
                     NonEntryTargets = new[] { nameof(Clean) },

--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesImage.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesImage.cs
@@ -15,16 +15,14 @@ namespace Nuke.Common.CI.AzurePipelines;
 [PublicAPI]
 public enum AzurePipelinesImage
 {
-    [EnumValue("windows-latest")] WindowsLatest,
     [EnumValue("windows-2022")] Windows2022,
     [EnumValue("windows-2019")] Windows2019,
-    [EnumValue("vs2017-win2016")] Vs2017Win2016,
-    [EnumValue("ubuntu-latest")] UbuntuLatest,
+    [EnumValue("ubuntu-22.04")] Ubuntu2204,
     [EnumValue("ubuntu-20.04")] Ubuntu2004,
-    [EnumValue("ubuntu-18.04")] Ubuntu1804,
-    [EnumValue("ubuntu-16.04")] Ubuntu1604,
-    [EnumValue("macOS-latest")] MacOsLatest,
+    [EnumValue("macOS-13")] MacOs13,
+    [EnumValue("macOS-12")] MacOs12,
     [EnumValue("macOS-11")] MacOs11,
-    [EnumValue("macOS-10.15")] MacOs1015,
-    [EnumValue("macOS-10.14")] MacOs1014
+    [EnumValue("windows-latest")] WindowsLatest,
+    [EnumValue("ubuntu-latest")] UbuntuLatest,
+    [EnumValue("macOS-latest")] MacOsLatest
 }


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Updated the AzurePipelinesImage enum used for YAML generation.
Removed deprecated images and added macOS 13, matching what is stated on the [MS Learn page](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software).

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
