### PR TITLE
feat(tools): support sonar.token parameter

### DIFF
--- a/source/Nuke.Common/Tools/SonarScanner/SonarScanner.json
+++ b/source/Nuke.Common/Tools/SonarScanner/SonarScanner.json
@@ -67,6 +67,13 @@
             "help": "Specifies the password for the SonarQube username in the <c>sonar.login</c> argument. This argument is not needed if you use authentication token. If this argument is added to the begin step, it must also be added on the end step."
           },
           {
+            "name": "Token",
+            "type": "string",
+            "format": "/d:sonar.token={value}",
+            "secret": true,
+            "help": "Specifies the authentication token used to authenticate with to SonarQube. If this argument is added to the begin step, it must also be added to the end step."
+          },
+          {
             "name": "Verbose",
             "type": "bool",
             "format": "/d:sonar.verbose={value}",
@@ -312,6 +319,13 @@
             "format": "/d:sonar.password={value}",
             "secret": true,
             "help": "Specifies the password for the SonarQube username in the <c>sonar.login</c> argument. This argument is not needed if you use authentication token. If this argument is added to the begin step, it must also be added on the end step."
+          },
+          {
+            "name": "Token",
+            "type": "string",
+            "format": "/d:sonar.token={value}",
+            "secret": true,
+            "help": "Specifies the authentication token used to authenticate with to SonarQube. If this argument is added to the begin step, it must also be added to the end step."
           },
           {
             "name": "ClientCertificatePassword",


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Sonar is deprecating the usage of `sonar.login` parameter and one should use `sonar.token` instead. 

https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner-for-dotnet/#begin

> `/d:sonar.token=<token>` [recommended] Requires version 5.13+. Use sonar.login for earlier versions.

> Specifies the [authentication token](https://docs.sonarsource.com/sonarqube/9.8/user-guide/user-account/generating-and-using-tokens/) used to authenticate with to SonarQube. If this argument is added to the begin step, it must also be added to the end step.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
