### PR TITLE
Add separate GH Actions root level concurrency group

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=detailed-triggers_attribute=GitHubActionsAttribute.verified.txt
@@ -44,13 +44,17 @@ on:
   schedule:
     - cron: '* 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   macos-latest:
     name: macos-latest
     runs-on: macos-latest
     timeout-minutes: 30
     concurrency:
-      group: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}
+      group: custom-job-group
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -93,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
-      group: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}
+      group: custom-job-group
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -136,7 +140,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     concurrency:
-      group: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}
+      group: custom-job-group
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -158,7 +158,9 @@ public class ConfigurationGenerationTest
                     Lfs = true,
                     FetchDepth = 2,
                     TimeoutMinutes = 30,
-                    JobConcurrencyCancelInProgress = true
+                    ConcurrencyCancelInProgress = true,
+                    JobConcurrencyCancelInProgress = true,
+                    JobConcurrencyGroup = "custom-job-group"
                 }
             );
 

--- a/source/Nuke.Common/CI/GitHubActions/Configuration/GitHubActionsConfiguration.cs
+++ b/source/Nuke.Common/CI/GitHubActions/Configuration/GitHubActionsConfiguration.cs
@@ -18,6 +18,8 @@ public class GitHubActionsConfiguration : ConfigurationEntity
     public GitHubActionsTrigger[] ShortTriggers { get; set; }
     public GitHubActionsDetailedTrigger[] DetailedTriggers { get; set; }
     public (GitHubActionsPermissions Type, string Permission)[] Permissions { get; set; }
+    public string ConcurrencyGroup { get; set; }
+    public bool ConcurrencyCancelInProgress { get; set; }
     public GitHubActionsJob[] Jobs { get; set; }
 
     public override void Write(CustomFileWriter writer)
@@ -43,6 +45,28 @@ public class GitHubActionsConfiguration : ConfigurationEntity
             using (writer.Indent())
             {
                 Permissions.ForEach(x => writer.WriteLine($"{x.Type.GetValue()}: {x.Permission}"));
+            }
+        }
+
+        if (!ConcurrencyGroup.IsNullOrWhiteSpace() || ConcurrencyCancelInProgress)
+        {
+            writer.WriteLine();
+            writer.WriteLine("concurrency:");
+            using (writer.Indent())
+            {
+                var group = ConcurrencyGroup;
+                if (group.IsNullOrWhiteSpace())
+                {
+                    // create a default value that only cancels in-progress runs of the same workflow
+                    // we don't fall back to github.ref which would disable multiple runs in main/master which is usually what is wanted
+                    group = "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}";
+                }
+
+                writer.WriteLine($"group: {group}");
+                if (ConcurrencyCancelInProgress)
+                {
+                    writer.WriteLine("cancel-in-progress: true");
+                }
             }
         }
 

--- a/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
+++ b/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
@@ -75,6 +75,9 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
 
     public int TimeoutMinutes { get; set; }
 
+    public string ConcurrencyGroup { get; set; }
+    public bool ConcurrencyCancelInProgress { get; set; }
+
     public string JobConcurrencyGroup { get; set; }
     public bool JobConcurrencyCancelInProgress { get; set; }
 
@@ -112,6 +115,8 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
                                 DetailedTriggers = GetTriggers().ToArray(),
                                 Permissions = WritePermissions.Select(x => (x, "write"))
                                     .Concat(ReadPermissions.Select(x => (x, "read"))).ToArray(),
+                                ConcurrencyGroup = ConcurrencyGroup,
+                                ConcurrencyCancelInProgress = ConcurrencyCancelInProgress,
                                 Jobs = _images.Select(x => GetJobs(x, relevantTargets)).ToArray()
                             };
 


### PR DESCRIPTION
Different image jobs can be cancelling each others when having same job group definition (it's valid to have it on job level too though). Adding a separate concurrency group to root level will cancel the entire workflow including it's jobs instead of jobs fighting against each other will make the default multi-image setup easier.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
