### PR TITLE
Update deprecated option for NUnit

### DIFF
--- a/source/Nuke.Common/Tools/NUnit/NUnit.json
+++ b/source/Nuke.Common/Tools/NUnit/NUnit.json
@@ -42,9 +42,9 @@
           {
             "name": "Parameters",
             "type": "Dictionary<string, string>",
-            "format": "--params={value}",
+            "format": "--testparam={value}",
             "itemFormat": "{key}={value}",
-            "help": "A test parameter specified in the form NAME=VALUE. Multiple parameters may be specified, separated by semicolons or by repeating the <c>--params</c> option multiple times."
+            "help": "A test parameter specified in the form NAME=VALUE for consumption by tests. Multiple parameters must be specified separated using a <c>--testparam</c> option for each."
           },
           {
             "name": "Configuration",


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Updated deprecated option `--params` to `--testparam` for `NUnit`.

See also https://docs.nunit.org/articles/nunit/running-tests/Console-Command-Line.html#options

![image](https://github.com/nuke-build/nuke/assets/20745992/dc8d087f-4026-42c1-8d63-a409e07ef8e4)



<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
