### PR TITLE
feat(azure-pipelines): add isOutput and isReadOnly to SetVariable

### DIFF
--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelines.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelines.cs
@@ -205,14 +205,16 @@ public partial class AzurePipelines : Host, IBuildServer
                 .AddPairWhenValueNotNull("code", code));
     }
 
-    public void SetVariable(string name, string value, bool? isSecret = null)
+    public void SetVariable(string name, string value, bool? isSecret = null, bool? isOutput = null, bool? isReadOnly = null)
     {
         WriteCommand(
             "task.setvariable",
             value,
             dictionaryConfigurator: x => x
                 .AddPair("variable", name)
-                .AddPairWhenValueNotNull("issecret", isSecret));
+                .AddPairWhenValueNotNull("issecret", isSecret)
+                .AddPairWhenValueNotNull("isoutput", isOutput)
+                .AddPairWhenValueNotNull("isreadonly", isReadOnly));
     }
 
     private string GetText(AzurePipelinesIssueType type)


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Added the possibility to set output and read-only variables for Azure Pipelines according to the [docs](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=bash#set-variable-properties)


<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
