### PR TITLE
NuGetToolPathResolver should use TargetFramework of the running appli…

### DIFF
--- a/source/Nuke.Tooling.Tests/NuGetPackageResolverTest.cs
+++ b/source/Nuke.Tooling.Tests/NuGetPackageResolverTest.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2023 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -41,32 +41,40 @@ public class NuGetPackageResolverTest
         result.Version.OriginalVersion.Should().Be(XunitConsolePackageVersion);
     }
 
-    [Fact]
-    public void TestGetLocalInstalledPackageViaProjectFile()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("net6.0")]
+    public void TestGetLocalInstalledPackageViaProjectFile(string framework)
     {
-        var result = NuGetPackageResolver.GetLocalInstalledPackage("xunit.runner.console", ProjectFile, resolveDependencies: false);
+        var result = NuGetPackageResolver.GetLocalInstalledPackage("xunit.runner.console", ProjectFile, framework: framework, resolveDependencies: false);
         result.Should().NotBeNull();
         result.Version.OriginalVersion.Should().Be(XunitConsolePackageVersion);
     }
 
-    [Fact]
-    public void TestGetLocalInstalledPackageViaAssetsFile()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("net6.0")]
+    public void TestGetLocalInstalledPackageViaAssetsFile(string framework)
     {
-        var result = NuGetPackageResolver.GetLocalInstalledPackage("xunit.runner.console", AssetsFile, resolveDependencies: false);
+        var result = NuGetPackageResolver.GetLocalInstalledPackage("xunit.runner.console", AssetsFile, framework: framework, resolveDependencies: false);
         result.Version.OriginalVersion.Should().Be(XunitConsolePackageVersion);
     }
 
-    [Fact]
-    public void TestGetLocalInstalledPackagesViaProjectFile()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("net6.0")]
+    public void TestGetLocalInstalledPackagesViaProjectFile(string framework)
     {
-        var result = NuGetPackageResolver.GetLocalInstalledPackages(ProjectFile, resolveDependencies: false);
+        var result = NuGetPackageResolver.GetLocalInstalledPackages(ProjectFile, framework: framework, resolveDependencies: false);
         result.Should().Contain(x => x.Id == "xunit.runner.console");
     }
 
-    [Fact]
-    public void TestGetLocalInstalledPackagesViaAssetsFile()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("net6.0")]
+    public void TestGetLocalInstalledPackagesViaAssetsFile(string framework)
     {
-        var result = NuGetPackageResolver.GetLocalInstalledPackages(AssetsFile, resolveDependencies: false);
+        var result = NuGetPackageResolver.GetLocalInstalledPackages(AssetsFile, framework: framework, resolveDependencies: false);
         result.Should().Contain(x => x.Id == "xunit.runner.console");
     }
 }

--- a/source/Nuke.Tooling/NuGetPackageResolver.cs
+++ b/source/Nuke.Tooling/NuGetPackageResolver.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2023 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -41,7 +41,7 @@ public static class NuGetPackageResolver
     // TODO: add HasLocalInstalledPackage() ?
     public static IEnumerable<InstalledPackage> GetLocalInstalledPackages(
         AbsolutePath packagesConfigFile,
-        string framework,
+        string framework = null,
         bool resolveDependencies = true,
         Func<(string PackageId, string Version), bool> preFilter = null)
     {
@@ -54,8 +54,7 @@ public static class NuGetPackageResolver
         AbsolutePath packagesConfigFile,
         string framework = null,
         bool resolveDependencies = true)
-    {
-        framework = "net8.0";
+    {                                                                                                                                                              
         var assetsContent = packagesConfigFile.ReadAllText();
         var assetsObject = JObject.Parse(assetsContent);
 
@@ -95,7 +94,7 @@ public static class NuGetPackageResolver
         bool resolveDependencies = true,
         Func<(string PackageId, string Version), bool> preFilter = null)
     {
-        return GetLocalInstalledPackagesFromAssetsFileWithoutLoading(packagesConfigFile, resolveDependencies: resolveDependencies)
+        return GetLocalInstalledPackagesFromAssetsFileWithoutLoading(packagesConfigFile, framework, resolveDependencies: resolveDependencies)
             .Where(x => preFilter == null || preFilter.Invoke(x))
             .Select(x => GetGlobalInstalledPackage(x.PackageId, x.Version, packagesConfigFile))
             .WhereNotNull();

--- a/source/Nuke.Tooling/NuGetToolPathResolver.cs
+++ b/source/Nuke.Tooling/NuGetToolPathResolver.cs
@@ -26,10 +26,15 @@ public static class NuGetToolPathResolver
     {
         Assert.True(packageId != null && packageExecutable != null);
 
-        var packageDirectory = GetPackageDirectory(packageId.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries), version);
+        if (framework == null)
+        {
+            framework = $".net{EnvironmentInfo.Framework.Version}";
+        }
+
+        var packageDirectory = GetPackageDirectory(packageId.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries), framework, version);
         var packageExecutables = packageExecutable.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
 #if !NETSTANDARD2_0
-            var enumerationOptions = new EnumerationOptions { RecurseSubdirectories = true, MatchCasing = MatchCasing.CaseInsensitive };
+        var enumerationOptions = new EnumerationOptions { RecurseSubdirectories = true, MatchCasing = MatchCasing.CaseInsensitive };
 #endif
         var packageExecutablePaths = packageExecutables
 #if !NETSTANDARD2_0
@@ -78,7 +83,7 @@ public static class NuGetToolPathResolver
         return GetPackageExecutable(frameworks[sortedFrameworks.First()]);
     }
 
-    private static string GetPackageDirectory(string[] packageIds, [CanBeNull] string version)
+    private static string GetPackageDirectory(string[] packageIds, [CanBeNull] string framework, [CanBeNull] string version)
     {
         try
         {
@@ -90,10 +95,10 @@ public static class NuGetToolPathResolver
                             ? Path.Combine(EmbeddedPackagesDirectory, x)
                             : null,
                         () => NuGetAssetsConfigFile != null
-                            ? NuGetPackageResolver.GetLocalInstalledPackage(x, NuGetAssetsConfigFile, version)?.Directory
+                            ? NuGetPackageResolver.GetLocalInstalledPackage(x, NuGetAssetsConfigFile, framework: framework, version: version)?.Directory
                             : null,
                         () => NuGetPackagesConfigFile != null
-                            ? NuGetPackageResolver.GetLocalInstalledPackage(x, NuGetPackagesConfigFile, version)?.Directory
+                            ? NuGetPackageResolver.GetLocalInstalledPackage(x, NuGetPackagesConfigFile, framework: framework, version: version)?.Directory
                             : null,
                         () => PaketPackagesConfigFile != null
                             ? PaketPackageResolver.GetLocalInstalledPackageDirectory(x, PaketPackagesConfigFile)


### PR DESCRIPTION
…cation to determine what version of dotnet tools are used

<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->



<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [ ] Follows the contribution guidelines
- [ ] Is based on my own work
- [ ] Is in compliance with my employer
