### PR TITLE
Add macos-14 to GitHub Actions images

### DIFF
--- a/source/Nuke.Common/CI/GitHubActions/GitHubActionsImage.cs
+++ b/source/Nuke.Common/CI/GitHubActions/GitHubActionsImage.cs
@@ -20,6 +20,7 @@ public enum GitHubActionsImage
     [EnumValue("ubuntu-22.04")] Ubuntu2204,
     [EnumValue("ubuntu-20.04")] Ubuntu2004,
     [EnumValue("ubuntu-18.04")] Ubuntu1804,
+    [EnumValue("macos-14")] MacOs14,
     [EnumValue("macos-12")] MacOs12,
     [EnumValue("macos-11")] MacOs11,
     [EnumValue("macos-10.15")] MacOs1015,


### PR DESCRIPTION
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

And [it's fast](https://github.com/sebastienros/jint/pull/1769#issuecomment-1918470696).

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
