### PR TITLE
Upgrade Microsoft.Build dependencies to version 17.9.5

### DIFF
--- a/source/Nuke.ProjectModel/Nuke.ProjectModel.csproj
+++ b/source/Nuke.ProjectModel/Nuke.ProjectModel.csproj
@@ -15,10 +15,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Build" Version="17.8.3" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.8.3" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.8.3" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.8.3" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build" Version="17.9.5" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.9.5" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.9.5" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.9.5" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">


### PR DESCRIPTION
Anything above 17.5.0 and below 17.9.5 causes transitive dependency to [Microsoft.VisualStudio.Setup.Configuration.Interop](https://www.nuget.org/packages/Microsoft.VisualStudio.Setup.Configuration.Interop/) which has a [Visual Studio like license](https://visualstudio.microsoft.com/license-terms/vs-setup-sdk/) and thus bad for build servers.

NET 7 and NET 6 target fortunately reference older versions which don't have this dependency.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
