### PR TITLE
Use json file directly in bootstrap

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -22,6 +22,8 @@ $DotNetChannel = "STS"
 
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
 $env:DOTNET_NOLOGO = 1
+$env:DOTNET_ROLL_FORWARD = "Major"
+$env:NUKE_TELEMETRY_OPTOUT = 1
 
 ###########################################################################
 # EXECUTION

--- a/source/Nuke.GlobalTool/templates/build.sh
+++ b/source/Nuke.GlobalTool/templates/build.sh
@@ -3,7 +3,7 @@
 bash --version 2>&1 | head -n 1
 
 set -eo pipefail
-SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 ###########################################################################
 # CONFIGURATION
@@ -23,10 +23,6 @@ export DOTNET_NOLOGO=1
 # EXECUTION
 ###########################################################################
 
-function FirstJsonValue {
-    perl -nle 'print $1 if m{"'"$1"'": "([^"]+)",?}' <<< "${@:2}"
-}
-
 # If dotnet CLI is installed globally and it matches requested version, use for execution
 if [ -x "$(command -v dotnet)" ] && dotnet --version &>/dev/null; then
     export DOTNET_EXE="$(command -v dotnet)"
@@ -37,20 +33,14 @@ else
     curl -Lsfo "$DOTNET_INSTALL_FILE" "$DOTNET_INSTALL_URL"
     chmod +x "$DOTNET_INSTALL_FILE"
 
-    # If global.json exists, load expected version
-    if [[ -f "$DOTNET_GLOBAL_FILE" ]]; then
-        DOTNET_VERSION=$(FirstJsonValue "version" "$(cat "$DOTNET_GLOBAL_FILE")")
-        if [[ "$DOTNET_VERSION" == ""  ]]; then
-            unset DOTNET_VERSION
-        fi
-    fi
-
     # Install by channel or version
     DOTNET_DIRECTORY="$TEMP_DIRECTORY/dotnet-unix"
-    if [[ -z ${DOTNET_VERSION+x} ]]; then
-        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --channel "$DOTNET_CHANNEL" --no-path
-    else
+    if [[ -n ${DOTNET_VERSION+x} ]]; then
         "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "$DOTNET_VERSION" --no-path
+    elif [[ -f $DOTNET_GLOBAL_FILE ]]; then
+        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --jsonfile "$DOTNET_GLOBAL_FILE" --no-path
+    else
+        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --channel "$DOTNET_CHANNEL" --no-path
     fi
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
     export PATH="$DOTNET_DIRECTORY:$PATH"


### PR DESCRIPTION
This PR fixes #1336.

This PR also introduces a breaking change. When the consumer has a `global.json` file, but it does not have an `sdk` property with `version` set then the current behavior is to fall back to using the `STS` channel. In that case, this will cause the `dotnet-install` script to fail. Is this okay for a breaking change? Is this something that was considered when designing the current dotnet version resolution?

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer
