### PR TITLE
update NuGet.Packaging reference from 6.7.0 to 6.9.1

### DIFF
--- a/source/Nuke.MSBuildTasks/Nuke.MSBuildTasks.csproj
+++ b/source/Nuke.MSBuildTasks/Nuke.MSBuildTasks.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Packaging" Version="6.7.0" />
+    <PackageReference Include="NuGet.Packaging" Version="6.9.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Nuke.Tooling/Nuke.Tooling.csproj
+++ b/source/Nuke.Tooling/Nuke.Tooling.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NuGet.Packaging" Version="6.7.0" />
+    <PackageReference Include="NuGet.Packaging" Version="6.9.1" />
     <PackageReference Include="Serilog" Version="3.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
In the current develop branch, running Nuke generates the following compiler warning:  warning NU1904: Package 'NuGet.Packaging' 6.7.0 has a known critical severity vulnerability, https://github.com/advisories/GHSA-68w7-72jg-6qpp [TargetFramework=net6.0]

This pull request updates the NuGet.Packaging references from version 6.7.0 to 6.9.1.


The contributions guidelines say to "Discuss non-trivial changes in an issue."  This seems like a trivial change, so I have not opened an issue for it.



<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [ x] Follows the contribution guidelines
- [ x] Is based on my own work
- [ x] Is in compliance with my employer
