### PR TITLE
Fix dotCover tool path lookup under Linux

### DIFF
--- a/source/Nuke.Common/Tools/DotCover/DotCoverTasks.cs
+++ b/source/Nuke.Common/Tools/DotCover/DotCoverTasks.cs
@@ -12,6 +12,6 @@ partial class DotCoverTasks
     {
         return NuGetToolPathResolver.GetPackageExecutable(
             "JetBrains.dotCover.DotNetCliTool|JetBrains.dotCover.CommandLineTools",
-            EnvironmentInfo.IsWin ? "dotCover.exe" : "dotCover.sh|dotCover.exe");
+            EnvironmentInfo.IsWin ? "dotCover.exe" : "dotCover.sh|dotCover.dll");
     }
 }


### PR DESCRIPTION
Locate .NET core executable instead of .NET framework executable which does not run under Linux.

Fixes https://github.com/nuke-build/nuke/issues/1346

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
