### PR TITLE
Force EnableUnsafeBinaryFormatterSerialization using SetSwitch - BinaryFormatter Issue

### DIFF
--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -8,7 +8,7 @@
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+    <!--<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>-->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -8,7 +8,6 @@
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <!--<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>-->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/source/Nuke.Common/Nuke.Common.props
+++ b/source/Nuke.Common/Nuke.Common.props
@@ -5,7 +5,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <MSBuildWarningsAsErrors>$(MSBuildWarningsAsErrors);CS8785</MSBuildWarningsAsErrors>
     <NoWarn>$(NoWarn);SYSLIB0050;SYSLIB0051</NoWarn>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+    <!--<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>-->
   </PropertyGroup>
 
 </Project>

--- a/source/Nuke.Common/Nuke.Common.props
+++ b/source/Nuke.Common/Nuke.Common.props
@@ -5,7 +5,6 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <MSBuildWarningsAsErrors>$(MSBuildWarningsAsErrors);CS8785</MSBuildWarningsAsErrors>
     <NoWarn>$(NoWarn);SYSLIB0050;SYSLIB0051</NoWarn>
-    <!--<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>-->
   </PropertyGroup>
 
 </Project>

--- a/source/Nuke.Tooling.Tests/NewInstanceTest.cs
+++ b/source/Nuke.Tooling.Tests/NewInstanceTest.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2023 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using FluentAssertions;
+using Nuke.Common.Tooling;
+using System;
+using Xunit;
+
+namespace Nuke.Common.Tests;
+
+public class NewInstanceTest
+{
+    [Serializable]
+    public class SimpleEntity : ISettingsEntity
+    {
+        public int Integer { get; set; }
+        public string String { get; set; }
+    }
+
+    [Fact]
+    public void TestSimpleEntity()
+    {
+        var entity = new SimpleEntity { Integer = 1, String = "test" };
+        var newInstance = entity.NewInstance();
+
+        newInstance.Integer.Should().Be(entity.Integer);
+        newInstance.String.Should().Be(entity.String);
+    }
+
+}

--- a/source/Nuke.Tooling.Tests/Nuke.Tooling.Tests.csproj
+++ b/source/Nuke.Tooling.Tests/Nuke.Tooling.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Nuke.Tooling/SettingsEntity.NewInstance.cs
+++ b/source/Nuke.Tooling/SettingsEntity.NewInstance.cs
@@ -2,11 +2,11 @@
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
-using JetBrains.Annotations;
 using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
+using JetBrains.Annotations;
 #pragma warning disable SYSLIB0011
 
 namespace Nuke.Common.Tooling;
@@ -25,12 +25,12 @@ public static partial class SettingsEntityExtensions
         binaryFormatter.Serialize(memoryStream, settingsEntity);
         memoryStream.Seek(offset: 0, loc: SeekOrigin.Begin);
 
-        var newInstance = (T)binaryFormatter.Deserialize(memoryStream);
+        var newInstance = (T) binaryFormatter.Deserialize(memoryStream);
         if (newInstance is ToolSettings toolSettings)
         {
-            toolSettings.ProcessArgumentConfigurator = ((ToolSettings)(object)settingsEntity).ProcessArgumentConfigurator;
-            toolSettings.ProcessLogger = ((ToolSettings)(object)settingsEntity).ProcessLogger;
-            toolSettings.ProcessExitHandler = ((ToolSettings)(object)settingsEntity).ProcessExitHandler;
+            toolSettings.ProcessArgumentConfigurator = ((ToolSettings) (object) settingsEntity).ProcessArgumentConfigurator;
+            toolSettings.ProcessLogger = ((ToolSettings) (object) settingsEntity).ProcessLogger;
+            toolSettings.ProcessExitHandler = ((ToolSettings) (object) settingsEntity).ProcessExitHandler;
         }
 
         return newInstance;

--- a/source/Nuke.Tooling/SettingsEntity.NewInstance.cs
+++ b/source/Nuke.Tooling/SettingsEntity.NewInstance.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2024 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using JetBrains.Annotations;
+
 #pragma warning disable SYSLIB0011
 
 namespace Nuke.Common.Tooling;
@@ -17,7 +18,7 @@ public static partial class SettingsEntityExtensions
     public static T NewInstance<T>(this T settingsEntity)
         where T : ISettingsEntity
     {
-        AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
+        AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", isEnabled: true);
 
         var binaryFormatter = new BinaryFormatter();
 
@@ -25,12 +26,12 @@ public static partial class SettingsEntityExtensions
         binaryFormatter.Serialize(memoryStream, settingsEntity);
         memoryStream.Seek(offset: 0, loc: SeekOrigin.Begin);
 
-        var newInstance = (T) binaryFormatter.Deserialize(memoryStream);
+        var newInstance = (T)binaryFormatter.Deserialize(memoryStream);
         if (newInstance is ToolSettings toolSettings)
         {
-            toolSettings.ProcessArgumentConfigurator = ((ToolSettings) (object) settingsEntity).ProcessArgumentConfigurator;
-            toolSettings.ProcessLogger = ((ToolSettings) (object) settingsEntity).ProcessLogger;
-            toolSettings.ProcessExitHandler = ((ToolSettings) (object) settingsEntity).ProcessExitHandler;
+            toolSettings.ProcessArgumentConfigurator = ((ToolSettings)(object)settingsEntity).ProcessArgumentConfigurator;
+            toolSettings.ProcessLogger = ((ToolSettings)(object)settingsEntity).ProcessLogger;
+            toolSettings.ProcessExitHandler = ((ToolSettings)(object)settingsEntity).ProcessExitHandler;
         }
 
         return newInstance;

--- a/source/Nuke.Tooling/SettingsEntity.NewInstance.cs
+++ b/source/Nuke.Tooling/SettingsEntity.NewInstance.cs
@@ -2,11 +2,11 @@
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
+using JetBrains.Annotations;
 using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
-using JetBrains.Annotations;
 #pragma warning disable SYSLIB0011
 
 namespace Nuke.Common.Tooling;
@@ -17,18 +17,20 @@ public static partial class SettingsEntityExtensions
     public static T NewInstance<T>(this T settingsEntity)
         where T : ISettingsEntity
     {
+        AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
+
         var binaryFormatter = new BinaryFormatter();
 
         using var memoryStream = new MemoryStream();
         binaryFormatter.Serialize(memoryStream, settingsEntity);
         memoryStream.Seek(offset: 0, loc: SeekOrigin.Begin);
 
-        var newInstance = (T) binaryFormatter.Deserialize(memoryStream);
+        var newInstance = (T)binaryFormatter.Deserialize(memoryStream);
         if (newInstance is ToolSettings toolSettings)
         {
-            toolSettings.ProcessArgumentConfigurator = ((ToolSettings) (object) settingsEntity).ProcessArgumentConfigurator;
-            toolSettings.ProcessLogger = ((ToolSettings) (object) settingsEntity).ProcessLogger;
-            toolSettings.ProcessExitHandler = ((ToolSettings) (object) settingsEntity).ProcessExitHandler;
+            toolSettings.ProcessArgumentConfigurator = ((ToolSettings)(object)settingsEntity).ProcessArgumentConfigurator;
+            toolSettings.ProcessLogger = ((ToolSettings)(object)settingsEntity).ProcessLogger;
+            toolSettings.ProcessExitHandler = ((ToolSettings)(object)settingsEntity).ProcessExitHandler;
         }
 
         return newInstance;


### PR DESCRIPTION
Hello everyone,

This PR forces to `EnableUnsafeBinaryFormatterSerialization` in runtime instead of adding the configuration in the csproj. 

This is done by using the code below before using the `BinaryFormatter`. (Reference: https://github.com/pythonnet/pythonnet/issues/2282)

```c#
AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
```

I add a simple test in the Nuke.Tooling.Tests and changes to NET 8.0 to make sure the `BinaryFormatter` gonna work without any `EnableUnsafeBinaryFormatterSerialization` in the csproj.

This gonna make sure the `BinaryFormatter` gonna works regardless if has or hasn't the configuration in the csproj.

And just to remind that the`BinaryFormatter` gonna be removed in the next .NET Core (.NET 9.0 - https://github.com/dotnet/announcements/issues/293)

---

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
