### PR TITLE
Avoid duplicate dotnetcli

### DIFF
--- a/source/Nuke.Tooling.Tests/NuGetPackageResolverTest.cs
+++ b/source/Nuke.Tooling.Tests/NuGetPackageResolverTest.cs
@@ -42,6 +42,20 @@ public class NuGetPackageResolverTest
     }
 
     [Fact]
+    public void TestGetGlobalInstalledPackageWithDuplicateNupkg()
+    {
+        var result = NuGetPackageResolver.GetGlobalInstalledPackage("coverlet.console", version: null, packagesConfigFile: null);
+        // Null is the result as well, but it is inconclusive :(
+        if (result != null)
+        {
+            result.Should().NotBeNull();
+            result.Id.Should().Be("coverlet.console");
+            result.File.Name.Should().EndWith("nupkg");
+            // Do not check version as it is not deterministic
+        }
+    }
+
+    [Fact]
     public void TestGetLocalInstalledPackageViaProjectFile()
     {
         var result = NuGetPackageResolver.GetLocalInstalledPackage("xunit.runner.console", ProjectFile, resolveDependencies: false);

--- a/source/Nuke.Tooling/NuGetPackageResolver.cs
+++ b/source/Nuke.Tooling/NuGetPackageResolver.cs
@@ -214,6 +214,13 @@ public static class NuGetPackageResolver
             .OrderByDescending(x => x.Version)
             .ToList();
 
+        if (candidatePackages.GroupBy(g => g.Version).Any(p => p.Count() > 1))
+            // skip duplicated packages with the packageId as name
+            candidatePackages = candidatePackages
+                .GroupBy(g => g.Version)
+                .SelectMany(g => g.Count() <= 1 ? g : g.Where(p => !p.File.NameWithoutExtension.EqualsOrdinalIgnoreCase(packageId)))
+                .ToList();
+
         return versionRange == null
             ? candidatePackages.FirstOrDefault()
             : candidatePackages.SingleOrDefault(x => x.Version == versionRange.FindBestMatch(candidatePackages.Select(y => y.Version)));


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

fixes issue #1344

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [ ] Is based on my own work
- [x] Is in compliance with my employer

It was originally posted by @cwuethrich at #1345, but has some conflicts. I've cherry-pick his commit (author is preserved). And add a test with the issue that I could reproduce with `coverlet.console`. Which is not required to be installed, so test is inconclusive 😞.