### PR TITLE
Fix package source name

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,6 +4,6 @@
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
   <packageSources>
-    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Default global `nuget.config` uses `nuget.org` as key.

In my case this global `nuget.config` has private source, and special `packageSourceMapping` to use my private source for some packages. And use `nuget.org` as default one for everything else:

```xml
  <packageSourceMapping>
    <packageSource key="nuget.org">
      <package pattern="*" />
    </packageSource>
    <packageSource key="werwolf.by">
      <package pattern="werwolfby.*" />
    </packageSource>
  </packageSourceMapping>
```

Because `nuget.config` specified `api.nuget.org` as default, my global one doesn't allow me to restore packages in `nuke` project. This fix returns everything how it should be.

There is the question if `nuke` requires `nuget.config` at all?

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
