### PR TITLE
Replace Codecov.Tool with CodecovUploader

### DIFF
--- a/source/Nuke.Common/Tools/Codecov/Codecov.json
+++ b/source/Nuke.Common/Tools/Codecov/Codecov.json
@@ -6,7 +6,7 @@
   "name": "Codecov",
   "officialUrl": "https://about.codecov.io/",
   "help": "Code coverage is a measurement used to express which lines of code were executed by a test suite. We use three primary terms to describe each line executed.<para/><ul><li>hit - indicates that the source code was executed by the test suite.</li><li>partial - indicates that the source code was not fully executed by the test suite; there are remaining branches that were not executed.</li><li>miss - indicates that the source code was not executed by the test suite.</li></ul><para/>Coverage is the ratio of <c>hits / (sum of hit + partial + miss)</c>. A code base that has 5 lines executed by tests out of 12 total lines will receive a coverage ratio of 41% (rounding down).<para/>Phrased simply, code coverage provides a visual measurement of what source code is being executed by a test suite. This information indicates to the software developer where they should write new tests in an effort to achieve higher coverage.<para/>Testing source code helps to prevent bugs and syntax errors by executing each line with a known variable and cross-checking it with an expected output.",
-  "nugetPackageId": "Codecov.Tool",
+  "nugetPackageId": "CodecovUploader",
   "customExecutable": true,
   "tasks": [
     {

--- a/source/Nuke.Common/Tools/Codecov/CodecovTasks.cs
+++ b/source/Nuke.Common/Tools/Codecov/CodecovTasks.cs
@@ -10,17 +10,25 @@ partial class CodecovSettings
 {
     private string GetProcessToolPath()
     {
-        return CodecovTasks.GetToolPath(Framework);
+        return CodecovTasks.GetToolPath();
     }
 }
 
 partial class CodecovTasks
 {
-    internal static string GetToolPath(string framework = null)
+    internal static string GetToolPath()
     {
         return NuGetToolPathResolver.GetPackageExecutable(
-            packageId: "Codecov.Tool",
-            packageExecutable: "codecov.dll",
-            framework: framework);
+            packageId: "CodecovUploader",
+            packageExecutable: GetPackageExecutable());
+    }
+
+    private static string GetPackageExecutable()
+    {
+        if (EnvironmentInfo.IsWin)
+            return "codecov.exe";
+        if (EnvironmentInfo.IsOsx)
+            return "codecov-macos";
+        return "codecov-linux";
     }
 }

--- a/source/Nuke.Common/Tools/Codecov/CodecovTasks.cs
+++ b/source/Nuke.Common/Tools/Codecov/CodecovTasks.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
+using System;
 using Nuke.Common.Tooling;
 
 namespace Nuke.Common.Tools.Codecov;
@@ -25,10 +26,12 @@ partial class CodecovTasks
 
     private static string GetPackageExecutable()
     {
-        if (EnvironmentInfo.IsWin)
-            return "codecov.exe";
-        if (EnvironmentInfo.IsOsx)
-            return "codecov-macos";
-        return "codecov-linux";
+        return EnvironmentInfo.Platform switch
+        {
+            PlatformFamily.Windows => "codecov.exe",
+            PlatformFamily.OSX => "codecov-macos",
+            PlatformFamily.Linux => "codecov-linux",
+            _ => throw new ArgumentOutOfRangeException()
+        };
     }
 }


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

The `Codecov.Tool` package is deprecated and suggests moving to `CodecovUploader`. I had issues continuing to use `Codecov.Tool` since the package is outdated and is dependent on `net5.0` or earlier.

![image](https://github.com/nuke-build/nuke/assets/715687/4b84a566-6928-4806-ad2c-9cae351c7924)

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
