### PR TITLE
Add support to detect GitHub actions debug logging

### DIFF
--- a/source/Nuke.Common/CI/GitHubActions/GitHubActions.cs
+++ b/source/Nuke.Common/CI/GitHubActions/GitHubActions.cs
@@ -121,6 +121,9 @@ public partial class GitHubActions : Host, IBuildServer
 
     public AbsolutePath StepSummaryFile => EnvironmentInfo.GetVariable("GITHUB_STEP_SUMMARY");
 
+    /// <summary>This is set only if debug logging is enabled, and always has the value of 1. It can be useful as an indicator to enable additional debugging or verbose logging in your own job steps.</summary>
+    public bool IsDebugLoggingEnabled => EnvironmentInfo.HasVariable("RUNNER_DEBUG");
+
     public void Group(string group)
     {
         WriteCommand("group", group);


### PR DESCRIPTION
Encapsulates detection whether GHA debug logging is enabled or not.
When enabled (via various mechanisms documented below) the environment variable `RUNNER_DEBUG` is set to `1`.

https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
