### PR TITLE
Use shellcheck --severity=warning on all shell scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,17 @@
+name: shellcheck
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt update && sudo apt install --assume-yes shellcheck
+
+      - name: Run shellcheck
+        run: find . -name \*.sh  | xargs shellcheck --severity=warning

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,8 @@ fi
 
 # If dotnet CLI is installed globally and it matches requested version, use for execution
 if [ -x "$(command -v dotnet)" ] && dotnet --version &>/dev/null; then
-    export DOTNET_EXE="$(command -v dotnet)"
+    DOTNET_EXE="$(command -v dotnet)"
+    export DOTNET_EXE
 else
     # Download install script
     DOTNET_INSTALL_FILE="$TEMP_DIRECTORY/dotnet-install.sh"

--- a/source/Nuke.GlobalTool/templates/build.sh
+++ b/source/Nuke.GlobalTool/templates/build.sh
@@ -29,7 +29,8 @@ function FirstJsonValue {
 
 # If dotnet CLI is installed globally and it matches requested version, use for execution
 if [ -x "$(command -v dotnet)" ] && dotnet --version &>/dev/null; then
-    export DOTNET_EXE="$(command -v dotnet)"
+    DOTNET_EXE="$(command -v dotnet)"
+    export DOTNET_EXE
 else
     # Download install script
     DOTNET_INSTALL_FILE="$TEMP_DIRECTORY/dotnet-install.sh"


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
When using nuke in a project and applying `shellcheck --severity=warning` (a wonderful shell linting tool), it turned up a minor nit in nuke's `build.sh`.   So, it was suggested by a colleague that I fix this "at the source" 😄 .
<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
