### PR TITLE
Handle duplicate packages in nuget cache (#1386)

### DIFF
--- a/build/Build.GlobalSolution.cs
+++ b/build/Build.GlobalSolution.cs
@@ -15,7 +15,6 @@ using Nuke.Common.Tools.GitHub;
 using Nuke.Common.Utilities;
 using Nuke.Utilities.Text.Yaml;
 using static Nuke.Common.ControlFlow;
-using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.ProjectModel.SolutionModelTasks;
 using static Nuke.Common.Tools.Git.GitTasks;
 
@@ -67,18 +66,16 @@ partial class Build
 
             if ((RootDirectory / $"{Solution.FileName}.DotSettings").FileExists())
             {
-                CopyFile(
-                    source: RootDirectory / $"{Solution.FileName}.DotSettings",
+                (RootDirectory / $"{Solution.FileName}.DotSettings").Copy(
                     target: RootDirectory / $"{global.FileName}.DotSettings",
-                    FileExistsPolicy.Overwrite);
+                    policy: ExistsPolicy.FileOverwrite);
             }
 
             if ((RootDirectory / $"{Solution.FileName}.DotSettings.user").FileExists())
             {
-                CopyFile(
-                    source: RootDirectory / $"{Solution.FileName}.DotSettings.user",
+                (RootDirectory / $"{Solution.FileName}.DotSettings.user").Copy(
                     target: RootDirectory / $"{global.FileName}.DotSettings.user",
-                    FileExistsPolicy.Overwrite);
+                    policy: ExistsPolicy.FileOverwrite);
             }
         });
 }

--- a/source/Nuke.Common/IO/FileSystemTasks.cs
+++ b/source/Nuke.Common/IO/FileSystemTasks.cs
@@ -188,6 +188,7 @@ public static class FileSystemTasks
         File.Delete(file);
     }
 
+    [Obsolete($"Use {nameof(AbsolutePath)}.{nameof(AbsolutePathExtensions.Copy)}")]
     public static void CopyFile(AbsolutePath source, AbsolutePath target, FileExistsPolicy policy = FileExistsPolicy.Fail, bool createDirectories = true)
     {
         if (!ShouldCopyFile(source, target, policy))
@@ -200,6 +201,7 @@ public static class FileSystemTasks
         File.Copy(source, target, overwrite: true);
     }
 
+    [Obsolete($"Use {nameof(AbsolutePath)}.{nameof(AbsolutePathExtensions.CopyToDirectory)}")]
     public static void CopyFileToDirectory(
         AbsolutePath source,
         AbsolutePath targetDirectory,
@@ -209,6 +211,7 @@ public static class FileSystemTasks
         CopyFile(source, Path.Combine(targetDirectory, Path.GetFileName(source).NotNull()), policy, createDirectories);
     }
 
+    [Obsolete($"Use {nameof(AbsolutePath)}.{nameof(AbsolutePathExtensions.Move)}")]
     public static void MoveFile(AbsolutePath source, AbsolutePath target, FileExistsPolicy policy = FileExistsPolicy.Fail, bool createDirectories = true)
     {
         if (!ShouldCopyFile(source, target, policy))
@@ -224,6 +227,7 @@ public static class FileSystemTasks
         File.Move(source, target);
     }
 
+    [Obsolete($"Use {nameof(AbsolutePath)}.{nameof(AbsolutePathExtensions.MoveToDirectory)}")]
     public static void MoveFileToDirectory(
         AbsolutePath source,
         AbsolutePath targetDirectory,
@@ -233,6 +237,7 @@ public static class FileSystemTasks
         MoveFile(source, Path.Combine(targetDirectory, Path.GetFileName(source).NotNull()), policy, createDirectories);
     }
 
+    [Obsolete($"Use {nameof(AbsolutePath)}.{nameof(AbsolutePathExtensions.Rename)}")]
     public static void RenameFile(AbsolutePath file, string newName, FileExistsPolicy policy = FileExistsPolicy.Fail)
     {
         if (Path.GetFileName(file) == newName)
@@ -241,6 +246,7 @@ public static class FileSystemTasks
         MoveFile(file, Path.Combine(Path.GetDirectoryName(file).NotNull(), newName), policy);
     }
 
+    [Obsolete($"Use {nameof(AbsolutePath)}.{nameof(AbsolutePathExtensions.Move)}")]
     public static void MoveDirectory(
         AbsolutePath source,
         AbsolutePath target,
@@ -264,6 +270,7 @@ public static class FileSystemTasks
         }
     }
 
+    [Obsolete($"Use {nameof(AbsolutePath)}.{nameof(AbsolutePathExtensions.MoveToDirectory)}")]
     public static void MoveDirectoryToDirectory(
         AbsolutePath source,
         AbsolutePath targetDirectory,
@@ -273,6 +280,7 @@ public static class FileSystemTasks
         MoveDirectory(source, Path.Combine(targetDirectory, new DirectoryInfo(source).Name), directoryPolicy, filePolicy);
     }
 
+    [Obsolete($"Use {nameof(AbsolutePath)}.{nameof(AbsolutePathExtensions.Rename)}")]
     public static void RenameDirectory(
         string directory,
         string newName,
@@ -282,6 +290,7 @@ public static class FileSystemTasks
         MoveDirectory(directory, Path.Combine(Path.GetDirectoryName(directory).NotNull(), newName), directoryPolicy, filePolicy);
     }
 
+    [Obsolete($"Use {nameof(AbsolutePath)}.{nameof(AbsolutePathExtensions.Copy)}")]
     public static void CopyDirectoryRecursively(
         AbsolutePath source,
         AbsolutePath target,

--- a/source/Nuke.Common/Tools/ReSharper/ReSharperTasks.cs
+++ b/source/Nuke.Common/Tools/ReSharper/ReSharperTasks.cs
@@ -26,11 +26,9 @@ partial class ReSharperTasks
         var wave = GetWave(toolSettings).NotNull("wave != null");
         var shadowDirectory = GetShadowDirectory(toolSettings, wave);
 
-        FileSystemTasks.CopyDirectoryRecursively(
-            Path.GetDirectoryName(toolSettings.ProcessToolPath).NotNull(),
-            shadowDirectory,
-            DirectoryExistsPolicy.Merge,
-            FileExistsPolicy.OverwriteIfNewer);
+        ((AbsolutePath)toolSettings.ProcessToolPath.NotNull()).Copy(
+            target: shadowDirectory,
+            policy: ExistsPolicy.MergeAndOverwriteIfNewer);
 
         toolSettings.Plugins
             .Select(x => (Plugin: x.Key, Version: x.Value == ReSharperPluginLatest ? null : x.Value))

--- a/source/Nuke.Common/Utilities/TemplateUtility.cs
+++ b/source/Nuke.Common/Utilities/TemplateUtility.cs
@@ -88,20 +88,14 @@ public static class TemplateUtility
             FillTemplateFile(file, tokens);
 
             if (ShouldMove(file))
-                FileSystemTasks.RenameFile(file, file.Name.Replace(tokens), FileExistsPolicy.OverwriteIfNewer);
+                file.Rename(file.Name.Replace(tokens), ExistsPolicy.FileOverwriteIfNewer);
         }
 
         directory.GetDirectories()
             .ForEach(x => FillTemplateDirectoryRecursivelyInternal(x, tokens, excludeDirectory, excludeFile));
 
         if (ShouldMove(directory))
-        {
-            FileSystemTasks.RenameDirectory(
-                directory,
-                directory.Name.Replace(tokens),
-                DirectoryExistsPolicy.Merge,
-                FileExistsPolicy.OverwriteIfNewer);
-        }
+            directory.Rename(directory.Name.Replace(tokens), ExistsPolicy.MergeAndOverwriteIfNewer);
     }
 
     public static void FillTemplateFile(

--- a/source/Nuke.Tooling/NuGetPackageResolver.cs
+++ b/source/Nuke.Tooling/NuGetPackageResolver.cs
@@ -216,7 +216,7 @@ public static class NuGetPackageResolver
 
         return versionRange == null
             ? candidatePackages.FirstOrDefault()
-            : candidatePackages.SingleOrDefault(x => x.Version == versionRange.FindBestMatch(candidatePackages.Select(y => y.Version)));
+            : candidatePackages.FirstOrDefault(x => x.Version == versionRange.FindBestMatch(candidatePackages.Select(y => y.Version)));
     }
 
     [CanBeNull]

--- a/source/Nuke.Utilities.Tests/IO/FileSystemDependentTest.cs
+++ b/source/Nuke.Utilities.Tests/IO/FileSystemDependentTest.cs
@@ -32,7 +32,7 @@ public abstract class FileSystemDependentTest
         ExecutionDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location).NotNull();
         RootDirectory = Constants.TryGetRootDirectoryFrom(EnvironmentInfo.WorkingDirectory);
         TestProjectDirectory = ExecutionDirectory.FindParentOrSelf(x => x.ContainsFile("*.csproj"));
-        TestTempDirectory = ExecutionDirectory / "temp"  / $"{GetType().Name}.{TestName}";
+        TestTempDirectory = ExecutionDirectory / "temp" / $"{GetType().Name}.{TestName}";
 
         TestTempDirectory.CreateOrCleanDirectory();
     }

--- a/source/Nuke.Utilities.Tests/IO/MoveCopyTest.cs
+++ b/source/Nuke.Utilities.Tests/IO/MoveCopyTest.cs
@@ -1,0 +1,136 @@
+﻿// Copyright 2024 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using Nuke.Common.IO;
+using Nuke.Common.Utilities.Collections;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Nuke.Common.Tests;
+
+public class MoveCopyTest : FileSystemDependentTest
+{
+    public MoveCopyTest(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    {
+        AbsolutePathExtensions.DefaultEofLineBreak = false;
+    }
+
+    [Fact]
+    public void TestCopyFile()
+    {
+        var source = TestTempDirectory / "source.txt";
+        source.WriteAllText("foobar");
+
+        var target = TestTempDirectory / "target.txt";
+        source.Copy(target);
+
+        target.FileExists().Should().BeTrue();
+
+        new Action(() => source.Copy(target))
+            .Should().Throw<Exception>().WithMessage("* already exists");
+
+        new Action(() => source.Copy(target, policy: ExistsPolicy.FileFail | ExistsPolicy.FileOverwrite))
+            .Should().Throw<Exception>().WithMessage("Multiple file policies *");
+
+        source.WriteAllText("fizzbuzz");
+        source.Copy(target, policy: ExistsPolicy.FileOverwrite)
+            .Should().Be(target);
+        target.ReadAllText().Should().Be("fizzbuzz");
+    }
+
+    [Fact]
+    public void TestMoveFile()
+    {
+        var source1 = TestTempDirectory / "source1.txt";
+        var source2 = TestTempDirectory / "source2.txt";
+        var source3 = TestTempDirectory / "source3.txt";
+        source1.WriteAllText(nameof(source1));
+        source2.WriteAllText(nameof(source2));
+        source3.WriteAllText(nameof(source3));
+
+        var target = TestTempDirectory / "target.txt";
+        source2.Move(target);
+
+        target.FileExists().Should().BeTrue();
+        source2.FileExists().Should().BeFalse();
+
+        new Action(() => source1.Move(target, policy: ExistsPolicy.FileFail))
+            .Should().Throw<Exception>().WithMessage("* already exists");
+
+        source1.Move(target, policy: ExistsPolicy.FileSkip).Should().Be(source1);
+        source1.Move(target, policy: ExistsPolicy.FileOverwriteIfNewer).Should().Be(source1);
+        source3.Move(target, policy: ExistsPolicy.FileOverwriteIfNewer).Should().Be(target);
+    }
+
+    [Fact]
+    public void TestCopyDirectory()
+    {
+        var source = TestTempDirectory / "source";
+        var sourceFiles = new[]
+        {
+            source / "source1.txt",
+            source / "source2.txt",
+            source / "sub" / "source3.txt",
+            source / "sub" / "source4.txt",
+        };
+        sourceFiles.ForEach(x => x.WriteAllText("source"));
+
+        var target = TestTempDirectory / "target";
+        source.Copy(target);
+        target.GetFiles(depth: int.MaxValue).Select(x => target.GetRelativePathTo(x).ToString())
+            .Should().BeEquivalentTo(sourceFiles.Select(x => source.GetRelativePathTo(x).ToString()));
+
+        target.CreateOrCleanDirectory();
+        var target0 = (target / "source0.txt").TouchFile();
+        var target3 = (target / "sub" / "source3.txt").WriteAllText("target");
+        var target4 = (target / "sub" / "source4.txt").WriteAllText("target");
+        (source / target.GetRelativePathTo(target4)).TouchFile();
+
+        new Action(() => source.Copy(target, ExistsPolicy.DirectoryFail))
+            .Should().Throw<Exception>().WithMessage("Policy disallows merging directories");
+        target.GetFiles(depth: int.MaxValue).Should().HaveCount(3);
+
+        source.Copy(target, ExistsPolicy.MergeAndSkip);
+        target0.FileExists().Should().BeTrue();
+        target3.ReadAllText().Should().Be("target");
+        target4.ReadAllText().Should().Be("target");
+
+        source.Copy(target, ExistsPolicy.MergeAndOverwriteIfNewer);
+        target3.ReadAllText().Should().Be("target");
+        target4.ReadAllText().Should().Be("source");
+
+        source.Copy(target, ExistsPolicy.MergeAndOverwrite);
+        target3.ReadAllText().Should().Be("source");
+    }
+
+    [Fact]
+    public void TestMoveDirectory()
+    {
+        var source = TestTempDirectory / "source";
+        var sourceFiles = new[]
+                          {
+                              source / "source1.txt",
+                              source / "source2.txt",
+                              source / "sub" / "source3.txt",
+                              source / "sub" / "source4.txt",
+                          };
+        sourceFiles.ForEach(x => x.WriteAllText("source"));
+
+        var target = TestTempDirectory / "target";
+        (target / "source1.txt").TouchFile();
+        (target / "sub" / "source3.txt").TouchFile();
+
+        new Action(() => source.Move(target)).Should().Throw<Exception>();
+
+        source.Move(target, ExistsPolicy.MergeAndSkip);
+        source.GetFiles(depth: int.MaxValue).Should().HaveCount(2);
+
+        source.Move(target, ExistsPolicy.MergeAndSkip, deleteRemainingFiles: true)
+            .Should().Be(target);
+        source.DirectoryExists().Should().BeFalse();
+    }
+}

--- a/source/Nuke.Utilities.Tests/IO/MoveCopyTest.cs
+++ b/source/Nuke.Utilities.Tests/IO/MoveCopyTest.cs
@@ -45,12 +45,9 @@ public class MoveCopyTest : FileSystemDependentTest
     [Fact]
     public void TestMoveFile()
     {
-        var source1 = TestTempDirectory / "source1.txt";
-        var source2 = TestTempDirectory / "source2.txt";
-        var source3 = TestTempDirectory / "source3.txt";
-        source1.WriteAllText(nameof(source1));
-        source2.WriteAllText(nameof(source2));
-        source3.WriteAllText(nameof(source3));
+        var source1 = (TestTempDirectory / "source1.txt").TouchFile();
+        var source2 = (TestTempDirectory / "source2.txt").TouchFile();
+        var source3 = (TestTempDirectory / "source3.txt").TouchFile();
 
         var target = TestTempDirectory / "target.txt";
         source2.Move(target);

--- a/source/Nuke.Utilities.Tests/IO/MoveCopyTest.cs
+++ b/source/Nuke.Utilities.Tests/IO/MoveCopyTest.cs
@@ -63,6 +63,8 @@ public class MoveCopyTest : FileSystemDependentTest
 
         source1.Move(target, policy: ExistsPolicy.FileSkip).Should().Be(source1);
         source1.Move(target, policy: ExistsPolicy.FileOverwriteIfNewer).Should().Be(source1);
+
+        source3.TouchFile();
         source3.Move(target, policy: ExistsPolicy.FileOverwriteIfNewer).Should().Be(target);
     }
 

--- a/source/Nuke.Utilities/Collections/Enumerable.WhereNotNull.cs
+++ b/source/Nuke.Utilities/Collections/Enumerable.WhereNotNull.cs
@@ -18,4 +18,13 @@ public static partial class EnumerableExtensions
     {
         return enumerable.Where(x => x != null);
     }
+
+    /// <summary>
+    /// Filters the collection to elements that don't meet the condition.
+    /// </summary>
+    public static IEnumerable<T> WhereNot<T>(this IEnumerable<T> enumerable, Func<T, bool> condition)
+        where T : class
+    {
+        return enumerable.Where(x => condition == null || !condition(x));
+    }
 }

--- a/source/Nuke.Utilities/IO/AbsolutePath.MoveCopy.cs
+++ b/source/Nuke.Utilities/IO/AbsolutePath.MoveCopy.cs
@@ -4,73 +4,257 @@
 
 using System;
 using System.IO;
+using System.Linq;
+using Nuke.Common.Utilities.Collections;
 
 namespace Nuke.Common.IO;
+
+[Flags]
+public enum ExistsPolicy
+{
+    DirectoryFail = 1,
+    DirectoryMerge = 2,
+    FileFail = 4,
+    FileSkip = 8,
+    FileOverwrite = 16,
+    FileOverwriteIfNewer = 32,
+
+    Fail = DirectoryFail | FileFail,
+    MergeAndSkip = DirectoryMerge | FileSkip,
+    MergeAndOverwrite = DirectoryMerge | FileOverwrite,
+    MergeAndOverwriteIfNewer = DirectoryMerge | FileOverwriteIfNewer
+}
 
 partial class AbsolutePathExtensions
 {
     /// <summary>
     /// Renames the file or directory.
     /// </summary>
-    public static AbsolutePath Rename(this AbsolutePath path, string newName)
+    public static AbsolutePath Rename(
+        this AbsolutePath source,
+        string newName,
+        ExistsPolicy policy = ExistsPolicy.Fail)
     {
-        return path.Move(path.Parent / newName);
+        return source.Move(source.Parent / newName, policy);
     }
 
     /// <summary>
     /// Renames the file or directory.
     /// </summary>
-    public static AbsolutePath Rename(this AbsolutePath path, Func<AbsolutePath, string> newName)
+    public static AbsolutePath Rename(
+        this AbsolutePath source,
+        Func<AbsolutePath, string> newName,
+        ExistsPolicy policy = ExistsPolicy.Fail)
     {
-        return path.Rename(newName.Invoke(path));
+        return source.Rename(newName.Invoke(source), policy);
     }
 
     /// <summary>
     /// Renames the file without changing the extension.
     /// </summary>
-    public static AbsolutePath RenameWithoutExtension(this AbsolutePath path, string newName)
+    public static AbsolutePath RenameWithoutExtension(
+        this AbsolutePath source,
+        string newName,
+        ExistsPolicy policy = ExistsPolicy.Fail)
     {
-        Assert.True(path.FileExists());
-        return path.Move(path.Parent / newName + path.Extension);
+        return source.Move(source.Parent / newName + source.Extension, policy);
     }
 
     /// <summary>
     /// Renames the file without changing the extension.
     /// </summary>
-    public static AbsolutePath RenameWithoutExtension(this AbsolutePath path, Func<AbsolutePath, string> newName)
+    public static AbsolutePath RenameWithoutExtension(
+        this AbsolutePath source,
+        Func<AbsolutePath, string> newName,
+        ExistsPolicy policy = ExistsPolicy.Fail)
     {
-        return path.RenameWithoutExtension(newName.Invoke(path));
+        return source.RenameWithoutExtension(newName.Invoke(source), policy);
     }
 
     /// <summary>
     /// Moves the file or directory to another directory.
     /// </summary>
-    public static AbsolutePath MoveToDirectory(this AbsolutePath path, AbsolutePath directory)
+    public static AbsolutePath MoveToDirectory(
+        this AbsolutePath source,
+        AbsolutePath target,
+        ExistsPolicy policy = ExistsPolicy.Fail,
+        bool createDirectories = true)
     {
-        Assert.True(directory.Exists());
-        return path.Move(directory / path.Name);
+        return source.Move(target / source.Name, policy, createDirectories);
     }
 
     /// <summary>
     /// Moves the file or directory.
     /// </summary>
-    public static AbsolutePath Move(this AbsolutePath path, Func<AbsolutePath, AbsolutePath> newPath)
+    public static AbsolutePath Move(
+        this AbsolutePath source,
+        Func<AbsolutePath, AbsolutePath> newPath,
+        ExistsPolicy policy = ExistsPolicy.Fail,
+        bool createDirectories = true)
     {
-        return path.Move(newPath.Invoke(path));
+        return source.Move(newPath.Invoke(source), policy, createDirectories);
     }
 
     /// <summary>
     /// Moves the file or directory.
     /// </summary>
-    public static AbsolutePath Move(this AbsolutePath path, AbsolutePath newPath)
+    public static AbsolutePath Move(
+        this AbsolutePath source,
+        AbsolutePath target,
+        ExistsPolicy policy = ExistsPolicy.Fail,
+        bool createDirectories = true,
+        bool deleteRemainingFiles = false)
     {
-        Assert.True(path.DirectoryExists() || path.FileExists());
+        Assert.True(source.DirectoryExists() || source.FileExists());
 
-        if (path.DirectoryExists())
-            Directory.Move(path, newPath);
-        else if (path.FileExists())
-            File.Move(path, newPath);
+        if (source.DirectoryExists())
+            return MoveDirectory(source, target, policy, createDirectories, deleteRemainingFiles);
 
-        return path;
+        if (source.FileExists())
+            return MoveFile(source, target, policy, createDirectories);
+
+        throw new Exception("Unreachable");
+    }
+
+    /// <summary>
+    /// Copies the file or directory to another directory.
+    /// </summary>
+    public static AbsolutePath CopyToDirectory(
+        this AbsolutePath source,
+        AbsolutePath target,
+        ExistsPolicy policy = ExistsPolicy.Fail,
+        Func<AbsolutePath, bool> excludeDirectory = null,
+        Func<AbsolutePath, bool> excludeFile = null,
+        bool createDirectories = true)
+    {
+        return source.Copy(target / source.Name, policy, excludeDirectory, excludeFile, createDirectories);
+    }
+
+    /// <summary>
+    /// Copies the file or directory.
+    /// </summary>
+    public static AbsolutePath Copy(
+        this AbsolutePath source,
+        AbsolutePath target,
+        ExistsPolicy policy = ExistsPolicy.Fail,
+        Func<AbsolutePath, bool> excludeDirectory = null,
+        Func<AbsolutePath, bool> excludeFile = null,
+        bool createDirectories = true)
+    {
+        Assert.True(source.DirectoryExists() || source.FileExists());
+
+        if (source.DirectoryExists())
+            return CopyDirectory(source, target, policy, excludeDirectory, excludeFile, createDirectories);
+
+        if (source.FileExists())
+            return CopyFile(source, target, policy, createDirectories);
+
+        throw new Exception("Unreachable");
+    }
+
+    private static AbsolutePath MoveFile(
+        this AbsolutePath source,
+        AbsolutePath target,
+        ExistsPolicy policy = ExistsPolicy.Fail,
+        bool createDirectories = true)
+    {
+        return HandleFile(source, target, policy, createDirectories, () =>
+        {
+            target.DeleteFile();
+            File.Move(source, target);
+        });
+    }
+
+    private static AbsolutePath CopyFile(
+        this AbsolutePath source,
+        AbsolutePath target,
+        ExistsPolicy policy = ExistsPolicy.Fail,
+        bool createDirectories = true)
+    {
+        return HandleFile(source, target, policy, createDirectories, () =>
+        {
+            File.Copy(source, target, overwrite: true);
+        });
+    }
+
+    private static AbsolutePath HandleFile(
+        AbsolutePath source,
+        AbsolutePath target,
+        ExistsPolicy policy,
+        bool createDirectories,
+        Action action)
+    {
+        if (File.Exists(target) && !Permitted())
+            return source;
+
+        if (createDirectories)
+            target.Parent.CreateDirectory();
+
+        action.Invoke();
+        return target;
+
+        bool Permitted()
+        {
+            var filePolicies = ExistsPolicy.FileFail | ExistsPolicy.FileSkip | ExistsPolicy.FileOverwrite | ExistsPolicy.FileOverwriteIfNewer;
+            return (policy & filePolicies) switch
+            {
+                ExistsPolicy.FileFail => throw new Exception($"File '{target}' already exists"),
+                ExistsPolicy.FileSkip => false,
+                ExistsPolicy.FileOverwrite => true,
+                ExistsPolicy.FileOverwriteIfNewer => File.GetLastWriteTimeUtc(target) < File.GetLastWriteTimeUtc(source),
+                _ => throw new ArgumentOutOfRangeException(nameof(policy), policy, message: "Multiple file policies set")
+            };
+        }
+    }
+
+    private static AbsolutePath MoveDirectory(
+        this AbsolutePath source,
+        AbsolutePath target,
+        ExistsPolicy policy = ExistsPolicy.Fail,
+        bool createDirectories = true,
+        bool deleteRemainingFiles = false)
+    {
+        return HandleDirectory(source, target, policy, createDirectories, () =>
+        {
+            source.GetDirectories().ForEach(x => x.MoveDirectory(target / source.GetRelativePathTo(x), policy));
+            source.GetFiles().ForEach(x => x.MoveFile(target / source.GetRelativePathTo(x), policy));
+
+            if (!source.ToDirectoryInfo().EnumerateFileSystemInfos().Any() || deleteRemainingFiles)
+                source.DeleteDirectory();
+        });
+    }
+
+    private static AbsolutePath CopyDirectory(
+        this AbsolutePath source,
+        AbsolutePath target,
+        ExistsPolicy policy = ExistsPolicy.Fail,
+        Func<AbsolutePath, bool> excludeDirectory = null,
+        Func<AbsolutePath, bool> excludeFile = null,
+        bool createDirectories = true)
+    {
+        return HandleDirectory(source, target, policy, createDirectories, () =>
+        {
+            source.GetDirectories().WhereNot(excludeDirectory).ForEach(x => x.CopyDirectory(target / source.GetRelativePathTo(x), policy, excludeDirectory, excludeFile));
+            source.GetFiles().WhereNot(excludeFile).ForEach(x => x.CopyFile(target / source.GetRelativePathTo(x), policy));
+        });
+    }
+
+    private static AbsolutePath HandleDirectory(
+        AbsolutePath source,
+        AbsolutePath target,
+        ExistsPolicy policy,
+        bool createDirectories,
+        Action action)
+    {
+        Assert.DirectoryExists(source);
+        Assert.False(source.Contains(target), $"Target directory '{target}' must not be in source directory '{source}'");
+        Assert.True(!Directory.Exists(target) || (policy.HasFlag(ExistsPolicy.DirectoryMerge) && !policy.HasFlag(ExistsPolicy.DirectoryFail)),
+            "Policy disallows merging directories");
+
+        if (createDirectories)
+            target.CreateDirectory();
+
+        action.Invoke();
+        return target;
     }
 }


### PR DESCRIPTION
Resolves #1386 

The `NuGetPackageResolver` class now handles that a NuGet package folder can contain multiple useless .nupkg files.

This is a workaround for a .NET SDK 8 problem (https://github.com/dotnet/sdk/issues/40528) introduced by https://github.com/dotnet/sdk/pull/33835. 

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
