### PR TITLE
Add support for Environment tag in Github Actions

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Nuke.Common.CI;
 using Nuke.Common.CI.AppVeyor;
 using Nuke.Common.CI.AzurePipelines;
@@ -48,6 +49,7 @@ public class ConfigurationGenerationTest
         return TestBuild.GetAttributes().Select(x => new object[] { x.TestName, x.Generator });
     }
 
+    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     [AppVeyorSecret("GitHubToken", "encrypted-yaml")]
     [TeamCityToken("GitHubToken", "74928d76-46e8-45cc-ad22-6438915ac070")]
     public class TestBuild : NukeBuild
@@ -161,7 +163,9 @@ public class ConfigurationGenerationTest
                     TimeoutMinutes = 30,
                     ConcurrencyCancelInProgress = true,
                     JobConcurrencyCancelInProgress = true,
-                    JobConcurrencyGroup = "custom-job-group"
+                    JobConcurrencyGroup = "custom-job-group",
+                    EnvironmentName = "environment-name",
+                    EnvironmentUrl = "environment-url"
                 }
             );
 

--- a/source/Nuke.Common/CI/GitHubActions/Configuration/GitHubActionsJob.cs
+++ b/source/Nuke.Common/CI/GitHubActions/Configuration/GitHubActionsJob.cs
@@ -18,6 +18,8 @@ public class GitHubActionsJob : ConfigurationEntity
     public GitHubActionsImage Image { get; set; }
     public int TimeoutMinutes { get; set; }
     public string ConcurrencyGroup { get; set; }
+    public string EnvironmentName { get; set; }
+    public string EnvironmentUrl { get; set; }
     public bool ConcurrencyCancelInProgress { get; set; }
     public GitHubActionsStep[] Steps { get; set; }
 
@@ -52,6 +54,23 @@ public class GitHubActionsJob : ConfigurationEntity
                     if (ConcurrencyCancelInProgress)
                     {
                         writer.WriteLine("cancel-in-progress: true");
+                    }
+                }
+            }
+
+            if (!EnvironmentName.IsNullOrWhiteSpace())
+            {
+                if (EnvironmentUrl.IsNullOrWhiteSpace())
+                {
+                    writer.WriteLine($"environment: {EnvironmentName}");
+                }
+                else
+                {
+                    writer.WriteLine("environment:");
+                    using (writer.Indent())
+                    {
+                        writer.WriteLine($"name: {EnvironmentName}");
+                        writer.WriteLine($"url: {EnvironmentUrl}");
                     }
                 }
             }

--- a/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
+++ b/source/Nuke.Common/CI/GitHubActions/GitHubActionsAttribute.cs
@@ -76,6 +76,9 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
     public string PublishCondition { get; set; }
 
     public int TimeoutMinutes { get; set; }
+    
+    public string EnvironmentName { get; set; }
+    public string EnvironmentUrl { get; set; }
 
     public string ConcurrencyGroup { get; set; }
     public bool ConcurrencyCancelInProgress { get; set; }
@@ -147,6 +150,8 @@ public class GitHubActionsAttribute : ConfigurationAttributeBase
         return new GitHubActionsJob
                {
                    Name = image.GetValue().Replace(".", "_"),
+                   EnvironmentName = EnvironmentName,
+                   EnvironmentUrl = EnvironmentUrl,
                    Steps = GetSteps(image, relevantTargets).ToArray(),
                    Image = image,
                    TimeoutMinutes = TimeoutMinutes,


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

In Github Actions you can specify an optional `environment`; more info can be found [here](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#using-an-environment)

Two properties/attributes are added:
- EnvironmentName
- EnvironmentUrl

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
