### PR TITLE
Enhance Solution file parsing to ignore pragma directives in GlobalSection

### DIFF
--- a/source/Nuke.SolutionModel/SolutionSerializer.cs
+++ b/source/Nuke.SolutionModel/SolutionSerializer.cs
@@ -88,6 +88,7 @@ internal static class SolutionSerializer
             .SkipWhile(x => !Regex.IsMatch(x, $@"^\s*GlobalSection\({name}\) = \w+$"))
             .Skip(count: 1)
             .TakeWhile(x => !Regex.IsMatch(x, @"^\s*EndGlobalSection$"))
+            .Where(x => !x.StartsWith('#'))
             .ToList();
 
         return sectionLines.Count == 0


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
This pull request addresses an issue where an exception is thrown when processing solution files (.sln) that contain #pragma directives.
```
[ERR] Target InitializeCoverageCollector has thrown an exception
System.IndexOutOfRangeException: Index was outside the bounds of the array.
```

Problem
When a .sln file contains #pragma directives, the existing GetGlobalSection method does not handle these lines properly, leading to an IndexOutOfRangeException. This is due to the assumption that all lines within a GlobalSection will conform to expected key-value pairs, which is not the case when #pragma lines are present.

The proposed change adds a filter to skip lines starting with # within the GlobalSection.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
