### PR TITLE
Add support for AzurePipelines NuGetAuthenticate and NpmAuthenticate

### DIFF
--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.Test_testName=null_attribute=AzurePipelinesAttribute.verified.txt
@@ -63,6 +63,12 @@ stages:
               key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(HOME)/.nuget/packages
+          - task: NuGetAuthenticate@1
+            displayName: 'NuGet Authenticate'
+          - task: npmAuthenticate@0
+            displayName: 'npm Authenticate .npmrc'
+            inputs:
+              workingFile: '.npmrc'
           - task: CmdLine@2
             displayName: 'Run: Restore'
             inputs:
@@ -96,6 +102,12 @@ stages:
               key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(HOME)/.nuget/packages
+          - task: NuGetAuthenticate@1
+            displayName: 'NuGet Authenticate'
+          - task: npmAuthenticate@0
+            displayName: 'npm Authenticate .npmrc'
+            inputs:
+              workingFile: '.npmrc'
           - task: CmdLine@2
             displayName: 'Run: Compile'
             inputs:
@@ -131,6 +143,12 @@ stages:
               key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(HOME)/.nuget/packages
+          - task: NuGetAuthenticate@1
+            displayName: 'NuGet Authenticate'
+          - task: npmAuthenticate@0
+            displayName: 'npm Authenticate .npmrc'
+            inputs:
+              workingFile: '.npmrc'
           - task: CmdLine@2
             displayName: 'Run: Test'
             inputs:
@@ -164,6 +182,12 @@ stages:
               key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(HOME)/.nuget/packages
+          - task: NuGetAuthenticate@1
+            displayName: 'NuGet Authenticate'
+          - task: npmAuthenticate@0
+            displayName: 'npm Authenticate .npmrc'
+            inputs:
+              workingFile: '.npmrc'
           - task: CmdLine@2
             displayName: 'Run: Coverage'
             inputs:
@@ -203,6 +227,12 @@ stages:
               key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(USERPROFILE)/.nuget/packages
+          - task: NuGetAuthenticate@1
+            displayName: 'NuGet Authenticate'
+          - task: npmAuthenticate@0
+            displayName: 'npm Authenticate .npmrc'
+            inputs:
+              workingFile: '.npmrc'
           - task: CmdLine@2
             displayName: 'Run: Restore'
             inputs:
@@ -236,6 +266,12 @@ stages:
               key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(USERPROFILE)/.nuget/packages
+          - task: NuGetAuthenticate@1
+            displayName: 'NuGet Authenticate'
+          - task: npmAuthenticate@0
+            displayName: 'npm Authenticate .npmrc'
+            inputs:
+              workingFile: '.npmrc'
           - task: CmdLine@2
             displayName: 'Run: Compile'
             inputs:
@@ -271,6 +307,12 @@ stages:
               key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(USERPROFILE)/.nuget/packages
+          - task: NuGetAuthenticate@1
+            displayName: 'NuGet Authenticate'
+          - task: npmAuthenticate@0
+            displayName: 'npm Authenticate .npmrc'
+            inputs:
+              workingFile: '.npmrc'
           - task: CmdLine@2
             displayName: 'Run: Test'
             inputs:
@@ -304,6 +346,12 @@ stages:
               key: $(Agent.OS) | nuget-packages | **/global.json, **/*.csproj, **/Directory.Packages.props
               restoreKeys: $(Agent.OS) | nuget-packages
               path: $(USERPROFILE)/.nuget/packages
+          - task: NuGetAuthenticate@1
+            displayName: 'NuGet Authenticate'
+          - task: npmAuthenticate@0
+            displayName: 'npm Authenticate .npmrc'
+            inputs:
+              workingFile: '.npmrc'
           - task: CmdLine@2
             displayName: 'Run: Coverage'
             inputs:

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -96,7 +96,9 @@ public class ConfigurationGenerationTest
                     Submodules = true,
                     LargeFileStorage = false,
                     Clean = true,
-                    FetchDepth = 1
+                    FetchDepth = 1,
+                    EnableNuGetAuthenticate = true,
+                    EnableNpmAuthenticate = true,
                 }
             );
 

--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesAttribute.cs
@@ -117,6 +117,10 @@ public class AzurePipelinesAttribute : ChainedConfigurationAttributeBase
     public string[] ImportVariableGroups { get; set; } = new string[0];
     public string[] ImportSecrets { get; set; } = new string[0];
     public bool EnableAccessToken { get; set; }
+    
+    public bool EnableNuGetAuthenticate { get; set; }
+    public bool EnableNpmAuthenticate { get; set; }
+    public string NpmrcPath { get; set; } = ".npmrc";
 
     public override CustomFileWriter CreateWriter(StreamWriter streamWriter)
     {
@@ -249,6 +253,16 @@ public class AzurePipelinesAttribute : ChainedConfigurationAttributeBase
                                  Path = cachePath
                              };
             }
+        }
+
+        if (EnableNuGetAuthenticate)
+        {
+            yield return new AzurePipelinesNuGetAuthenticateStep();
+        }
+
+        if (EnableNpmAuthenticate && !string.IsNullOrEmpty(NpmrcPath))
+        {
+            yield return new AzurePipelinesNpmAuthenticateStep{ NpmrcPath = NpmrcPath };
         }
 
         string GetArtifactPath(AbsolutePath path)

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesNpmAuthenticateStep.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesNpmAuthenticateStep.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2024 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using Nuke.Common.Utilities;
+
+namespace Nuke.Common.CI.AzurePipelines.Configuration;
+
+public class AzurePipelinesNpmAuthenticateStep : AzurePipelinesStep
+{
+    public string NpmrcPath { get; set; }
+
+    public override void Write(CustomFileWriter writer)
+    {
+        using (writer.WriteBlock("- task: npmAuthenticate@0"))
+        {
+            writer.WriteLine($"displayName: 'npm Authenticate {NpmrcPath}'");
+            using (writer.WriteBlock("inputs:"))
+            {
+                writer.WriteLine($"workingFile: {NpmrcPath.SingleQuote()}");
+            }
+        }
+    }
+}

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesNuGetAuthenticateStep.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesNuGetAuthenticateStep.cs
@@ -1,0 +1,18 @@
+﻿// Copyright 2024 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using Nuke.Common.Utilities;
+
+namespace Nuke.Common.CI.AzurePipelines.Configuration;
+
+public class AzurePipelinesNuGetAuthenticateStep : AzurePipelinesStep
+{
+    public override void Write(CustomFileWriter writer)
+    {
+        using (writer.WriteBlock("- task: NuGetAuthenticate@1"))
+        {
+            writer.WriteLine("displayName: 'NuGet Authenticate'");
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Support for AzurePipelines is improved. Built-in steps NuGetAuthenticate (https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/nuget-authenticate-v1?view=azure-pipelines) and NpmAuthenticate (https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/npm-authenticate-v0?view=azure-pipelines) can be activated at the AzurePipelinesAttribute. This change simplifies working with private feeds in Azure DevOps.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
