### PR TITLE
- added AzurePipelinesPool as a abstraction for vmImage and on prem p…

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -46,14 +46,8 @@
       "type": "string",
       "default": "Secrets must be entered via 'nuke :secrets [profile]'"
     },
-    "SignPathOrganizationId": {
-      "type": "string"
-    },
-    "SignPathPolicySlug": {
-      "type": "string"
-    },
-    "SignPathProjectSlug": {
-      "type": "string"
+    "SignPathSettings": {
+      "$ref": "#/definitions/SignPathSettings"
     },
     "SlackWebhook": {
       "type": "string",
@@ -107,6 +101,29 @@
         "VisualStudio",
         "VSCode"
       ]
+    },
+    "SignPathSettings": {
+      "type": "object",
+      "properties": {
+        "OrganizationId": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "ProjectSlug": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "PolicySlug": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
     },
     "ExecutableTarget": {
       "type": "string",

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,76 +1,174 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "$ref": "#/definitions/build",
-  "title": "Build Schema",
+  "properties": {
+    "AutoStash": {
+      "type": "boolean"
+    },
+    "CodecovToken": {
+      "type": "string",
+      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+    },
+    "Configuration": {
+      "type": "string",
+      "enum": [
+        "Debug",
+        "Release"
+      ]
+    },
+    "DiscordWebhook": {
+      "type": "string",
+      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+    },
+    "FeedzNuGetApiKey": {
+      "type": "string",
+      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+    },
+    "GitHubReleaseGitHubToken": {
+      "type": "string",
+      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+    },
+    "IgnoreFailedSources": {
+      "type": "boolean",
+      "description": "Ignore unreachable sources during Restore"
+    },
+    "Major": {
+      "type": "boolean"
+    },
+    "MastodonAccessToken": {
+      "type": "string",
+      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+    },
+    "PublicNuGetApiKey": {
+      "type": "string",
+      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+    },
+    "SignPathApiToken": {
+      "type": "string",
+      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+    },
+    "SignPathOrganizationId": {
+      "type": "string"
+    },
+    "SignPathPolicySlug": {
+      "type": "string"
+    },
+    "SignPathProjectSlug": {
+      "type": "string"
+    },
+    "SlackWebhook": {
+      "type": "string",
+      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+    },
+    "Solution": {
+      "type": "string",
+      "description": "Path to a solution file that is automatically loaded"
+    },
+    "TestDegreeOfParallelism": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "TwitterAccessToken": {
+      "type": "string",
+      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+    },
+    "TwitterAccessTokenSecret": {
+      "type": "string",
+      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+    },
+    "TwitterConsumerKey": {
+      "type": "string",
+      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+    },
+    "TwitterConsumerSecret": {
+      "type": "string",
+      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+    },
+    "UseHttps": {
+      "type": "boolean"
+    }
+  },
   "definitions": {
-    "build": {
-      "type": "object",
+    "Host": {
+      "type": "string",
+      "enum": [
+        "AppVeyor",
+        "AzurePipelines",
+        "Bamboo",
+        "Bitbucket",
+        "Bitrise",
+        "GitHubActions",
+        "GitLab",
+        "Jenkins",
+        "Rider",
+        "SpaceAutomation",
+        "TeamCity",
+        "Terminal",
+        "TravisCI",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string",
+      "enum": [
+        "Announce",
+        "AnnounceDiscord",
+        "AnnounceMastodon",
+        "AnnounceSlack",
+        "AnnounceTwitter",
+        "Changelog",
+        "CheckoutExternalRepositories",
+        "Clean",
+        "Compile",
+        "CreateGitHubRelease",
+        "DeletePackages",
+        "DownloadLicenses",
+        "GenerateGlobalSolution",
+        "GeneratePublicApi",
+        "GenerateTools",
+        "Hotfix",
+        "Install",
+        "InstallFonts",
+        "Milestone",
+        "Pack",
+        "Publish",
+        "References",
+        "Release",
+        "ReleaseImage",
+        "ReportCoverage",
+        "ReportDuplicates",
+        "ReportIssues",
+        "Restore",
+        "RunTargetInDockerImageTest",
+        "SignPackages",
+        "Test",
+        "UpdateContributors",
+        "UpdateStargazers"
+      ]
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
       "properties": {
-        "AutoStash": {
-          "type": "boolean"
-        },
-        "CodecovToken": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
-        "Configuration": {
-          "type": "string",
-          "enum": [
-            "Debug",
-            "Release"
-          ]
-        },
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
-        },
-        "DiscordWebhook": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
-        "FeedzNuGetApiKey": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
-        "GitHubReleaseGitHubToken": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
         "Help": {
           "type": "boolean",
           "description": "Shows the help text for this build assembly"
         },
         "Host": {
-          "type": "string",
           "description": "Host for execution. Default is 'automatic'",
-          "enum": [
-            "AppVeyor",
-            "AzurePipelines",
-            "Bamboo",
-            "Bitbucket",
-            "Bitrise",
-            "GitHubActions",
-            "GitLab",
-            "Jenkins",
-            "Rider",
-            "SpaceAutomation",
-            "TeamCity",
-            "Terminal",
-            "TravisCI",
-            "VisualStudio",
-            "VSCode"
-          ]
-        },
-        "IgnoreFailedSources": {
-          "type": "boolean",
-          "description": "Ignore unreachable sources during Restore"
-        },
-        "Major": {
-          "type": "boolean"
-        },
-        "MastodonAccessToken": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+          "$ref": "#/definitions/Host"
         },
         "NoLogo": {
           "type": "boolean",
@@ -91,152 +189,30 @@
             "type": "string"
           }
         },
-        "PublicNuGetApiKey": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
         "Root": {
           "type": "string",
           "description": "Root directory during build execution"
-        },
-        "SignPathApiToken": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
-        "SignPathOrganizationId": {
-          "type": "string"
-        },
-        "SignPathPolicySlug": {
-          "type": "string"
-        },
-        "SignPathProjectSlug": {
-          "type": "string"
         },
         "Skip": {
           "type": "array",
           "description": "List of targets to be skipped. Empty list skips all dependencies",
           "items": {
-            "type": "string",
-            "enum": [
-              "Announce",
-              "AnnounceDiscord",
-              "AnnounceMastodon",
-              "AnnounceSlack",
-              "AnnounceTwitter",
-              "Changelog",
-              "CheckoutExternalRepositories",
-              "Clean",
-              "Compile",
-              "CreateGitHubRelease",
-              "DeletePackages",
-              "DownloadLicenses",
-              "GenerateGlobalSolution",
-              "GeneratePublicApi",
-              "GenerateTools",
-              "Hotfix",
-              "Install",
-              "InstallFonts",
-              "Milestone",
-              "Pack",
-              "Publish",
-              "References",
-              "Release",
-              "ReleaseImage",
-              "ReportCoverage",
-              "ReportDuplicates",
-              "ReportIssues",
-              "Restore",
-              "RunTargetInDockerImageTest",
-              "SignPackages",
-              "Test",
-              "UpdateContributors",
-              "UpdateStargazers"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
-        },
-        "SlackWebhook": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
-        "Solution": {
-          "type": "string",
-          "description": "Path to a solution file that is automatically loaded"
         },
         "Target": {
           "type": "array",
           "description": "List of targets to be invoked. Default is '{default_target}'",
           "items": {
-            "type": "string",
-            "enum": [
-              "Announce",
-              "AnnounceDiscord",
-              "AnnounceMastodon",
-              "AnnounceSlack",
-              "AnnounceTwitter",
-              "Changelog",
-              "CheckoutExternalRepositories",
-              "Clean",
-              "Compile",
-              "CreateGitHubRelease",
-              "DeletePackages",
-              "DownloadLicenses",
-              "GenerateGlobalSolution",
-              "GeneratePublicApi",
-              "GenerateTools",
-              "Hotfix",
-              "Install",
-              "InstallFonts",
-              "Milestone",
-              "Pack",
-              "Publish",
-              "References",
-              "Release",
-              "ReleaseImage",
-              "ReportCoverage",
-              "ReportDuplicates",
-              "ReportIssues",
-              "Restore",
-              "RunTargetInDockerImageTest",
-              "SignPackages",
-              "Test",
-              "UpdateContributors",
-              "UpdateStargazers"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
         },
-        "TestDegreeOfParallelism": {
-          "type": "integer"
-        },
-        "TwitterAccessToken": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
-        "TwitterAccessTokenSecret": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
-        "TwitterConsumerKey": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
-        "TwitterConsumerSecret": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
-        "UseHttps": {
-          "type": "boolean"
-        },
         "Verbosity": {
-          "type": "string",
           "description": "Logging verbosity during build execution. Default is 'Normal'",
-          "enum": [
-            "Minimal",
-            "Normal",
-            "Quiet",
-            "Verbose"
-          ]
+          "$ref": "#/definitions/Verbosity"
         }
       }
     }
-  }
+  },
+  "$ref": "#/definitions/NukeBuild"
 }

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,21 +1,9 @@
 {
   "$schema": "./build.schema.json",
   "Solution": "nuke-common.sln",
-  "SignPathOrganizationId": "0fdaf334-6910-41f4-83d2-e58e4cccb087",
-  "SignPathProjectSlug": "nuke",
-  "SignPathPolicySlug": "release-signing",
-  "Data2": [
-    {
-      "FirstName": "foo",
-      "Nested": {
-        "FirstName": "bar"
-      }
-    },
-    {
-      "FirstName": "foo2",
-      "Nested": {
-        "FirstName": "bar2"
-      }
-    }
-  ]
+  "SignPathSettings": {
+    "OrganizationId": "0fdaf334-6910-41f4-83d2-e58e4cccb087",
+    "ProjectSlug": "nuke",
+    "PolicySlug": "release-signing"
+  }
 }

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -3,5 +3,19 @@
   "Solution": "nuke-common.sln",
   "SignPathOrganizationId": "0fdaf334-6910-41f4-83d2-e58e4cccb087",
   "SignPathProjectSlug": "nuke",
-  "SignPathPolicySlug": "release-signing"
+  "SignPathPolicySlug": "release-signing",
+  "Data2": [
+    {
+      "FirstName": "foo",
+      "Nested": {
+        "FirstName": "bar"
+      }
+    },
+    {
+      "FirstName": "foo2",
+      "Nested": {
+        "FirstName": "bar2"
+      }
+    }
+  ]
 }

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./build.schema.json",
+  "$schema": "build.schema.json",
   "Solution": "nuke-common.sln",
   "SignPathSettings": {
     "OrganizationId": "0fdaf334-6910-41f4-83d2-e58e4cccb087",

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -47,12 +47,6 @@ project {
             value = "Release",
             options = listOf("Debug" to "Debug", "Release" to "Release"),
             display = ParameterDisplay.NORMAL)
-        text (
-            "env.Data2",
-            label = "Data2",
-            value = "Build+Data Build+Data",
-            allowEmpty = true,
-            display = ParameterDisplay.NORMAL)
         checkbox (
             "env.IgnoreFailedSources",
             label = "IgnoreFailedSources",
@@ -69,21 +63,9 @@ project {
             unchecked = "False",
             display = ParameterDisplay.NORMAL)
         text (
-            "env.SignPathOrganizationId",
-            label = "SignPathOrganizationId",
-            value = "0fdaf334-6910-41f4-83d2-e58e4cccb087",
-            allowEmpty = true,
-            display = ParameterDisplay.NORMAL)
-        text (
-            "env.SignPathPolicySlug",
-            label = "SignPathPolicySlug",
-            value = "release-signing",
-            allowEmpty = true,
-            display = ParameterDisplay.NORMAL)
-        text (
-            "env.SignPathProjectSlug",
-            label = "SignPathProjectSlug",
-            value = "nuke",
+            "env.SignPathSettings",
+            label = "SignPathSettings",
+            value = "",
             allowEmpty = true,
             display = ParameterDisplay.NORMAL)
         text (

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -47,6 +47,12 @@ project {
             value = "Release",
             options = listOf("Debug" to "Debug", "Release" to "Release"),
             display = ParameterDisplay.NORMAL)
+        text (
+            "env.Data2",
+            label = "Data2",
+            value = "Build+Data Build+Data",
+            allowEmpty = true,
+            display = ParameterDisplay.NORMAL)
         checkbox (
             "env.IgnoreFailedSources",
             label = "IgnoreFailedSources",

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,84 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Azure.Identity" Version="1.12.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+    <PackageVersion Include="Basic.Reference.Assemblies.NetStandard20" Version="1.7.2" />
+    <PackageVersion Include="Glob" Version="1.1.9" />
+    <PackageVersion Include="HtmlAgilityPack" Version="1.11.61" />
+    <PackageVersion Include="Humanizer" Version="2.14.1" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
+    <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.22.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="NJsonSchema" Version="10.9.0" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.10.1" />
+    <PackageVersion Include="Octokit" Version="13.0.1" />
+    <PackageVersion Include="Serilog" Version="4.0.0" />
+    <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
+    <PackageVersion Include="Serilog.Formatting.Compact.Reader" Version="4.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageVersion Include="SharpZipLib" Version="1.4.2" />
+    <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.3" />
+    <PackageVersion Include="YamlDotNet" Version="15.3.0" />
+    <PackageVersion Include="matkoch.spectre.console" Version="0.46.0" />
+  </ItemGroup>
+
+  <!-- Testing -->
+  <ItemGroup>
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="TeamCity.VSTest.TestAdapter" Version="1.0.40" />
+    <PackageVersion Include="Verify.Xunit" Version="25.0.2" />
+    <PackageVersion Include="Verify.DiffPlex" Version="2.3.0" />
+    <PackageVersion Include="Verify.SourceGenerators" Version="2.2.0" />
+    <PackageVersion Include="xunit" Version="2.8.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
+  </ItemGroup>
+
+  <!-- Roslyn (Nuke.SourceGenerator + Nuke.GlobalTool) -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.10.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.10.0" />
+  </ItemGroup>
+  
+  <!-- MSBuild (Nuke.ProjectModel + Nuke.MSBuildTasks) -->
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
+
+    <PackageVersion Include="Microsoft.Build" Version="17.10.4" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.10.4" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.10.4" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.10.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageVersion Update="Microsoft.Build" Version="17.5.0" />
+    <PackageVersion Update="Microsoft.Build.Framework" Version="17.5.0" />
+    <PackageVersion Update="Microsoft.Build.Tasks.Core" Version="17.5.0" />
+    <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="17.5.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageVersion Update="Microsoft.Build" Version="16.9.0" />
+    <PackageVersion Update="Microsoft.Build.Framework" Version="16.9.0" />
+    <PackageVersion Update="Microsoft.Build.Tasks.Core" Version="16.9.0" />
+    <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="16.9.0" />
+  </ItemGroup>
+
+</Project>

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -50,6 +50,20 @@ partial class Build
     ///   - Microsoft VSCode           https://nuke.build/vscode
     public static int Main() => Execute<Build>(x => ((IPack)x).Pack);
 
+    public class Data
+    {
+        public string FirstName;
+        public Data Nested;
+    }
+
+    [Parameter] readonly Data[] Data2;
+
+    Target Foo => _ => _
+        .Executes(() =>
+        {
+            Console.WriteLine(Data2);
+        });
+
     [CI] readonly TeamCity TeamCity;
     [CI] readonly AzurePipelines AzurePipelines;
     [CI] readonly AppVeyor AppVeyor;

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -50,20 +50,6 @@ partial class Build
     ///   - Microsoft VSCode           https://nuke.build/vscode
     public static int Main() => Execute<Build>(x => ((IPack)x).Pack);
 
-    public class Data
-    {
-        public string FirstName;
-        public Data Nested;
-    }
-
-    [Parameter] readonly Data[] Data2;
-
-    Target Foo => _ => _
-        .Executes(() =>
-        {
-            Console.WriteLine(Data2);
-        });
-
     [CI] readonly TeamCity TeamCity;
     [CI] readonly AzurePipelines AzurePipelines;
     [CI] readonly AppVeyor AppVeyor;

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -10,6 +10,7 @@
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>.\..</NukeRootDirectory>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <!-- Test properties for MSBuild integration -->

--- a/docs/03-common/06-versioning.md
+++ b/docs/03-common/06-versioning.md
@@ -86,7 +86,7 @@ Please refer to the [MinVer documentation](https://github.com/adamralph/minver#u
 
 ```powershell title="Tool Installation"
 # terminal-command
-nuke :add-package MinVer
+nuke :add-package minver-cli
 ```
 
 ```csharp title="Build.cs"

--- a/nuke-common.sln.DotSettings
+++ b/nuke-common.sln.DotSettings
@@ -1,5 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">Copyright $CURRENT_YEAR$ Maintainers of NUKE.&#xD;
+	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">Copyright ${CurrentDate.Year} Maintainers of NUKE.&#xD;
 Distributed under the MIT License.&#xD;
 https://github.com/nuke-build/nuke/blob/master/LICENSE</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb_AaBb" /&gt;</s:String>
@@ -17,4 +17,5 @@ https://github.com/nuke-build/nuke/blob/master/LICENSE</s:String>
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileA321B7F1C678C84CAFFD23C2D9D03A36/RelativePriority/@EntryValue">3</s:Double>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileA68CFA51EFE4364DA61BFD270E021A11/@KeyIndexDefined">True</s:Boolean>
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileA68CFA51EFE4364DA61BFD270E021A11/RelativePriority/@EntryValue">1</s:Double>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	</wpf:ResourceDictionary>

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -36,19 +36,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('Tests'))">
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0"/>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
-    <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.40"/>
-    <PackageReference Include="Verify.Xunit" Version="25.0.2" />
-    <PackageReference Include="Verify.DiffPlex" Version="2.3.0" />
-    <PackageReference Include="xunit" Version="2.8.1"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1"/>
+    <PackageReference Include="coverlet.msbuild"  />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="GitHubActionsTestLogger" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="TeamCity.VSTest.TestAdapter" />
+    <PackageReference Include="Verify.Xunit"  />
+    <PackageReference Include="Verify.DiffPlex"  />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Nuke.Build.Shared/Nuke.Build.Shared.csproj
+++ b/source/Nuke.Build.Shared/Nuke.Build.Shared.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.Build.Tests/CompletionUtilityTest.TestGetCompletionItemsFromSchema.verified.txt
+++ b/source/Nuke.Build.Tests/CompletionUtilityTest.TestGetCompletionItemsFromSchema.verified.txt
@@ -1,0 +1,14 @@
+﻿{
+  Configuration: [
+    Debug,
+    Release
+  ],
+  NoLogo: [],
+  Profile: [
+    dev
+  ],
+  Target: [
+    Restore,
+    Compile
+  ]
+}

--- a/source/Nuke.Build.Tests/CompletionUtilityTest.TestGetCompletionItemsParameterBuild.verified.txt
+++ b/source/Nuke.Build.Tests/CompletionUtilityTest.TestGetCompletionItemsParameterBuild.verified.txt
@@ -1,0 +1,38 @@
+﻿{
+  BooleanParam: [],
+  ComponentInheritedParam: [],
+  Continue: [],
+  CustomEnumerationArrayParam: [
+    Debug,
+    Release
+  ],
+  CustomEnumerationParam: [
+    Debug,
+    Release
+  ],
+  Help: [],
+  Host: [
+    Rider,
+    Terminal,
+    VisualStudio,
+    VSCode
+  ],
+  IntegerArrayParam: [],
+  NoLogo: [],
+  NullableBooleanParam: [],
+  Partition: [],
+  Plan: [],
+  Profile: [],
+  RegularParam: [],
+  Root: [],
+  SecretParam: [],
+  Skip: [],
+  StringArrayParam: [],
+  Target: [],
+  Verbosity: [
+    Verbose,
+    Normal,
+    Minimal,
+    Quiet
+  ]
+}

--- a/source/Nuke.Build.Tests/CompletionUtilityTest.TestGetCompletionItemsTargetBuild.verified.txt
+++ b/source/Nuke.Build.Tests/CompletionUtilityTest.TestGetCompletionItemsTargetBuild.verified.txt
@@ -1,0 +1,35 @@
+﻿{
+  Continue: [],
+  Help: [],
+  Host: [
+    Rider,
+    Terminal,
+    VisualStudio,
+    VSCode
+  ],
+  NoLogo: [],
+  Partition: [],
+  Plan: [],
+  Profile: [
+    dev
+  ],
+  Root: [],
+  Skip: [
+    ExplicitTarget,
+    ImplementedTarget,
+    InheritedTarget,
+    RegularTarget
+  ],
+  Target: [
+    ExplicitTarget,
+    ImplementedTarget,
+    InheritedTarget,
+    RegularTarget
+  ],
+  Verbosity: [
+    Verbose,
+    Normal,
+    Minimal,
+    Quiet
+  ]
+}

--- a/source/Nuke.Build.Tests/CompletionUtilityTest.cs
+++ b/source/Nuke.Build.Tests/CompletionUtilityTest.cs
@@ -6,16 +6,48 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using FluentAssertions;
+using Nuke.Common.IO;
 using Nuke.Common.Utilities;
+using VerifyTests;
+using VerifyXunit;
 using Xunit;
 
 namespace Nuke.Common.Tests;
 
 public class CompletionUtilityTest
 {
+    private readonly VerifySettings _verifySettings;
+    private static AbsolutePath RootDirectory => Constants.TryGetRootDirectoryFrom(EnvironmentInfo.WorkingDirectory).NotNull();
+    private static AbsolutePath TestDirectory => RootDirectory / "source" / "Nuke.Build.Tests";
+
+    public CompletionUtilityTest()
+    {
+        _verifySettings = new VerifySettings();
+        _verifySettings.DontIgnoreEmptyCollections();
+    }
+
     [Fact]
-    public void TestGetCompletionItemsFromSchema()
+    public async Task TestGetCompletionItemsTargetBuild()
+    {
+        var file = TestDirectory / "SchemaUtilityTest.TestTargetBuild.verified.json";
+        var schema = JsonDocument.Parse(file.ReadAllText());
+        var items = CompletionUtility.GetItemsFromSchema(schema, new[] { "dev" });
+        await Verifier.Verify(items, _verifySettings);
+    }
+
+    [Fact]
+    public async Task TestGetCompletionItemsParameterBuild()
+    {
+        var file = TestDirectory / "SchemaUtilityTest.TestParameterBuild.verified.json";
+        var schema = JsonDocument.Parse(file.ReadAllText());
+        var items = CompletionUtility.GetItemsFromSchema(schema, []);
+        await Verifier.Verify(items, _verifySettings);
+    }
+
+    [Fact]
+    public async Task TestGetCompletionItemsFromSchema()
     {
         var schema = JsonDocument.Parse("""
                 {
@@ -62,14 +94,7 @@ public class CompletionUtilityTest
                 """);
         var profileNames = new[] { "dev" };
         var items = CompletionUtility.GetItemsFromSchema(schema, profileNames);
-        items.Should().BeEquivalentTo(
-            new Dictionary<string, string[]>
-            {
-                ["NoLogo"] = null,
-                ["Configuration"] = new[] { "Debug", "Release" },
-                ["Target"] = new[] { "Restore", "Compile" },
-                [Constants.LoadedLocalProfilesParameterName] = profileNames
-            });
+        await Verifier.Verify(items, _verifySettings);
     }
 
     [Theory]
@@ -94,9 +119,9 @@ public class CompletionUtilityTest
         var completionItems =
             new Dictionary<string, string[]>
             {
-                { Constants.InvokedTargetsParameterName, new[] { "Compile", "GitHubPublish" } },
-                { "ApiKey", null },
-                { "NuGetSource", null }
+                { Constants.InvokedTargetsParameterName, ["Compile", "GitHubPublish"] },
+                { "ApiKey", [] },
+                { "NuGetSource", [] }
             };
         CompletionUtility.GetRelevantItems(words, completionItems)
             .Should()

--- a/source/Nuke.Build.Tests/Nuke.Build.Tests.csproj
+++ b/source/Nuke.Build.Tests/Nuke.Build.Tests.csproj
@@ -8,4 +8,8 @@
     <ProjectReference Include="..\Nuke.Build\Nuke.Build.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="NJsonSchema" Version="10.9.0" />
+  </ItemGroup>
+
 </Project>

--- a/source/Nuke.Build.Tests/Nuke.Build.Tests.csproj
+++ b/source/Nuke.Build.Tests/Nuke.Build.Tests.csproj
@@ -8,8 +8,4 @@
     <ProjectReference Include="..\Nuke.Build\Nuke.Build.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="NJsonSchema" Version="10.9.0" />
-  </ItemGroup>
-
 </Project>

--- a/source/Nuke.Build.Tests/ParameterServiceTest.cs
+++ b/source/Nuke.Build.Tests/ParameterServiceTest.cs
@@ -48,12 +48,11 @@ public class ParameterServiceTest
     public void TestEnvironmentVariables(string parameter, Type destinationType, object expectedValue)
     {
         var service = GetService(
-            new[]
-            {
+            [
                 "-arg1",
                 "value1",
                 "-switch1"
-            },
+            ],
             new Dictionary<string, string>
             {
                 { "arg1", "value2" },
@@ -68,15 +67,14 @@ public class ParameterServiceTest
     public void TestExpression()
     {
         var service = GetService(
-            new[]
-            {
+            [
                 "--string",
                 "--set",
                 "1",
                 "2",
                 "3",
                 "--interface-param"
-            });
+            ]);
 
         var build = new TestBuild();
 
@@ -98,12 +96,12 @@ public class ParameterServiceTest
     {
         var build = new TestBuild();
         var verbosities = new[]
-                          {
-                              (nameof(Verbosity.Minimal), Verbosity.Minimal),
-                              (nameof(Verbosity.Normal), Verbosity.Normal),
-                              (nameof(Verbosity.Quiet), Verbosity.Quiet),
-                              (nameof(Verbosity.Verbose), Verbosity.Verbose),
-                          };
+        {
+            (nameof(Verbosity.Minimal), Verbosity.Minimal),
+            (nameof(Verbosity.Normal), Verbosity.Normal),
+            (nameof(Verbosity.Quiet), Verbosity.Quiet),
+            (nameof(Verbosity.Verbose), Verbosity.Verbose),
+        };
         ParameterService.GetParameterValueSet(GetMemberInfo(() => NukeBuild.Verbosity), instance: null)
             .Should().BeEquivalentTo(verbosities);
         ParameterService.GetParameterValueSet(GetMemberInfo(() => build.Verbosities), instance: null)
@@ -118,13 +116,13 @@ public class ParameterServiceTest
 
         var environmentVariables = new Dictionary<string, string> { ["string"] = "environmentVariables" };
         var commandLineArguments = new ArgumentParser("--string commandLine");
-        var parameterFileArguments = new ArgumentParser("--string parameterFile");
+        var parameterFileArguments = new Func<string, Type, object>((_, _) => "parameterFile");
         var commitMessageArguments = new ArgumentParser("--string commitMessage");
 
         var service = new ParameterService(() => emptyArguments, () => emptyEnvironmentVariables)
-                      {
-                          ArgumentsFromFilesService = parameterFileArguments
-                      };
+        {
+            ArgumentsFromFilesService = parameterFileArguments
+        };
         service.GetParameter("string", typeof(string), separator: null).Should().Be("parameterFile");
 
         service = new ParameterService(() => emptyArguments, () => environmentVariables) { ArgumentsFromFilesService = parameterFileArguments };
@@ -134,10 +132,10 @@ public class ParameterServiceTest
         service.GetParameter("string", typeof(string), separator: null).Should().Be("commandLine");
 
         service = new ParameterService(() => emptyArguments, () => emptyEnvironmentVariables)
-                  {
-                      ArgumentsFromFilesService = parameterFileArguments,
-                      ArgumentsFromCommitMessageService = commitMessageArguments
-                  };
+        {
+            ArgumentsFromFilesService = parameterFileArguments,
+            ArgumentsFromCommitMessageService = commitMessageArguments
+        };
         service.GetParameter("string", typeof(string), separator: null).Should().Be("commitMessage");
     }
 

--- a/source/Nuke.Build.Tests/SchemaUtilityTest.TestCustomParameterAttributeAttribute.verified.json
+++ b/source/Nuke.Build.Tests/SchemaUtilityTest.TestCustomParameterAttributeAttribute.verified.json
@@ -1,111 +1,11 @@
 ﻿{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "properties": {
-    "BooleanParam": {
-      "type": "boolean"
-    },
-    "ComplexTypeArrayParam": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/ComplexType"
-      }
-    },
-    "ComplexTypeParam": {
-      "$ref": "#/definitions/ComplexType"
-    },
-    "ComponentInheritedParam": {
+    "ComplexTypeParamWithAttribute": {
       "type": "string"
-    },
-    "CustomEnumerationArrayParam": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "enum": [
-          "Debug",
-          "Release"
-        ]
-      }
-    },
-    "CustomEnumerationParam": {
-      "type": "string",
-      "enum": [
-        "Debug",
-        "Release"
-      ]
-    },
-    "IntegerArrayParam": {
-      "type": "array",
-      "items": {
-        "type": "integer",
-        "format": "int32"
-      }
-    },
-    "NullableBooleanParam": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "RegularParam": {
-      "type": "string"
-    },
-    "SecretParam": {
-      "type": "string",
-      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-    },
-    "StringArrayParam": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
     }
   },
   "definitions": {
-    "ComplexType": {
-      "type": "object",
-      "properties": {
-        "String": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "Number": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "Paths": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "SubObject": {
-          "oneOf": [
-            {
-              "type": "null"
-            },
-            {
-              "$ref": "#/definitions/ComplexSubType"
-            }
-          ]
-        }
-      }
-    },
-    "ComplexSubType": {
-      "type": "object",
-      "properties": {
-        "Boolean": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        }
-      }
-    },
     "Host": {
       "type": "string",
       "enum": [

--- a/source/Nuke.Build.Tests/SchemaUtilityTest.TestEmptyBuild.verified.json
+++ b/source/Nuke.Build.Tests/SchemaUtilityTest.TestEmptyBuild.verified.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {
+    "Host": {
+      "type": "string",
+      "enum": [
+        "Rider",
+        "Terminal",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string"
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
+      "properties": {
+        "Continue": {
+          "type": "boolean",
+          "description": "Indicates to continue a previously failed build attempt"
+        },
+        "Help": {
+          "type": "boolean",
+          "description": "Shows the help text for this build assembly"
+        },
+        "Host": {
+          "description": "Host for execution. Default is 'automatic'",
+          "$ref": "#/definitions/Host"
+        },
+        "NoLogo": {
+          "type": "boolean",
+          "description": "Disables displaying the NUKE logo"
+        },
+        "Partition": {
+          "type": "string",
+          "description": "Partition to use on CI"
+        },
+        "Plan": {
+          "type": "boolean",
+          "description": "Shows the execution plan (HTML)"
+        },
+        "Profile": {
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Root": {
+          "type": "string",
+          "description": "Root directory during build execution"
+        },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Verbosity": {
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "$ref": "#/definitions/Verbosity"
+        }
+      }
+    }
+  },
+  "$ref": "#/definitions/NukeBuild"
+}

--- a/source/Nuke.Build.Tests/SchemaUtilityTest.TestGetBuildSchema.verified.json
+++ b/source/Nuke.Build.Tests/SchemaUtilityTest.TestGetBuildSchema.verified.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "$ref": "#/definitions/build",
   "title": "Build Schema",
@@ -6,10 +6,16 @@
     "build": {
       "type": "object",
       "properties": {
-        "BoolParam": {
+        "BooleanParam": {
           "type": "boolean"
         },
-        "ComplexParam": {
+        "ComplexTypeArrayParam": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ComplexTypeParam": {
           "type": "string"
         },
         "ComponentInheritedParam": {
@@ -19,29 +25,43 @@
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
         },
+        "CustomEnumerationArrayParam": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Debug",
+              "Release"
+            ]
+          }
+        },
+        "CustomEnumerationParam": {
+          "type": "string",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
         "Help": {
           "type": "boolean",
           "description": "Shows the help text for this build assembly"
         },
         "Host": {
           "type": "string",
-          "description": "Host for execution. Default is 'automatic'",
-          "enum": [
-            "Rider",
-            "Terminal",
-            "VisualStudio",
-            "VSCode"
-          ]
+          "description": "Host for execution. Default is 'automatic'"
+        },
+        "IntegerArrayParam": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
         },
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
         },
-        "NullableBoolParam": {
+        "NullableBooleanParam": {
           "type": "boolean"
-        },
-        "NullableIntegerParam": {
-          "type": "integer"
         },
         "Partition": {
           "type": "string",
@@ -58,11 +78,14 @@
             "type": "string"
           }
         },
+        "RegularParam": {
+          "type": "string"
+        },
         "Root": {
           "type": "string",
           "description": "Root directory during build execution"
         },
-        "Secret": {
+        "SecretParam": {
           "type": "string",
           "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
@@ -70,41 +93,20 @@
           "type": "array",
           "description": "List of targets to be skipped. Empty list skips all dependencies",
           "items": {
-            "type": "string",
-            "enum": [
-              "ExplicitTarget",
-              "ImplementedTarget",
-              "InheritedTarget",
-              "RegularTarget"
-            ]
+            "type": "string"
           }
         },
-        "StringParam": {
-          "type": "string"
+        "StringArrayParam": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "Target": {
           "type": "array",
           "description": "List of targets to be invoked. Default is '{default_target}'",
           "items": {
-            "type": "string",
-            "enum": [
-              "ExplicitTarget",
-              "ImplementedTarget",
-              "InheritedTarget",
-              "RegularTarget"
-            ]
-          }
-        },
-        "Verbosities": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "Minimal",
-              "Normal",
-              "Quiet",
-              "Verbose"
-            ]
+            "type": "string"
           }
         },
         "Verbosity": {

--- a/source/Nuke.Build.Tests/SchemaUtilityTest.TestGetBuildSchema.verified.json
+++ b/source/Nuke.Build.Tests/SchemaUtilityTest.TestGetBuildSchema.verified.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$ref": "#/definitions/build",
+  "title": "Build Schema",
+  "definitions": {
+    "build": {
+      "type": "object",
+      "properties": {
+        "BoolParam": {
+          "type": "boolean"
+        },
+        "ComplexParam": {
+          "type": "string"
+        },
+        "ComponentInheritedParam": {
+          "type": "string"
+        },
+        "Continue": {
+          "type": "boolean",
+          "description": "Indicates to continue a previously failed build attempt"
+        },
+        "Help": {
+          "type": "boolean",
+          "description": "Shows the help text for this build assembly"
+        },
+        "Host": {
+          "type": "string",
+          "description": "Host for execution. Default is 'automatic'",
+          "enum": [
+            "Rider",
+            "Terminal",
+            "VisualStudio",
+            "VSCode"
+          ]
+        },
+        "NoLogo": {
+          "type": "boolean",
+          "description": "Disables displaying the NUKE logo"
+        },
+        "NullableBoolParam": {
+          "type": "boolean"
+        },
+        "NullableIntegerParam": {
+          "type": "integer"
+        },
+        "Partition": {
+          "type": "string",
+          "description": "Partition to use on CI"
+        },
+        "Plan": {
+          "type": "boolean",
+          "description": "Shows the execution plan (HTML)"
+        },
+        "Profile": {
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Root": {
+          "type": "string",
+          "description": "Root directory during build execution"
+        },
+        "Secret": {
+          "type": "string",
+          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+        },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ExplicitTarget",
+              "ImplementedTarget",
+              "InheritedTarget",
+              "RegularTarget"
+            ]
+          }
+        },
+        "StringParam": {
+          "type": "string"
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ExplicitTarget",
+              "ImplementedTarget",
+              "InheritedTarget",
+              "RegularTarget"
+            ]
+          }
+        },
+        "Verbosities": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Minimal",
+              "Normal",
+              "Quiet",
+              "Verbose"
+            ]
+          }
+        },
+        "Verbosity": {
+          "type": "string",
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "enum": [
+            "Minimal",
+            "Normal",
+            "Quiet",
+            "Verbose"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/source/Nuke.Build.Tests/SchemaUtilityTest.TestParameterBuild.verified.json
+++ b/source/Nuke.Build.Tests/SchemaUtilityTest.TestParameterBuild.verified.json
@@ -1,0 +1,190 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "BooleanParam": {
+      "type": "boolean"
+    },
+    "ComplexTypeArrayParam": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ComplexType"
+      }
+    },
+    "ComplexTypeParam": {
+      "$ref": "#/definitions/ComplexType"
+    },
+    "ComponentInheritedParam": {
+      "type": "string"
+    },
+    "CustomEnumerationArrayParam": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "Debug",
+          "Release"
+        ]
+      }
+    },
+    "CustomEnumerationParam": {
+      "type": "string",
+      "enum": [
+        "Debug",
+        "Release"
+      ]
+    },
+    "IntegerArrayParam": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "NullableBooleanParam": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "RegularParam": {
+      "type": "string"
+    },
+    "SecretParam": {
+      "type": "string",
+      "default": "Secrets must be entered via 'nuke :secrets [profile]'"
+    },
+    "StringArrayParam": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "definitions": {
+    "ComplexType": {
+      "type": "object",
+      "properties": {
+        "String": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "Number": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "Paths": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "SubObject": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/ComplexSubType"
+            }
+          ]
+        }
+      }
+    },
+    "ComplexSubType": {
+      "type": "object",
+      "properties": {
+        "Boolean": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "Host": {
+      "type": "string",
+      "enum": [
+        "Rider",
+        "Terminal",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string"
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
+      "properties": {
+        "Continue": {
+          "type": "boolean",
+          "description": "Indicates to continue a previously failed build attempt"
+        },
+        "Help": {
+          "type": "boolean",
+          "description": "Shows the help text for this build assembly"
+        },
+        "Host": {
+          "description": "Host for execution. Default is 'automatic'",
+          "$ref": "#/definitions/Host"
+        },
+        "NoLogo": {
+          "type": "boolean",
+          "description": "Disables displaying the NUKE logo"
+        },
+        "Partition": {
+          "type": "string",
+          "description": "Partition to use on CI"
+        },
+        "Plan": {
+          "type": "boolean",
+          "description": "Shows the execution plan (HTML)"
+        },
+        "Profile": {
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Root": {
+          "type": "string",
+          "description": "Root directory during build execution"
+        },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Verbosity": {
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "$ref": "#/definitions/Verbosity"
+        }
+      }
+    }
+  },
+  "$ref": "#/definitions/NukeBuild"
+}

--- a/source/Nuke.Build.Tests/SchemaUtilityTest.TestTargetBuild.verified.json
+++ b/source/Nuke.Build.Tests/SchemaUtilityTest.TestTargetBuild.verified.json
@@ -1,14 +1,36 @@
-﻿{
+{
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "$ref": "#/definitions/build",
-  "title": "Build Schema",
   "definitions": {
-    "build": {
-      "type": "object",
+    "Host": {
+      "type": "string",
+      "enum": [
+        "Rider",
+        "Terminal",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string",
+      "enum": [
+        "ExplicitTarget",
+        "ImplementedTarget",
+        "InheritedTarget",
+        "RegularTarget"
+      ]
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
       "properties": {
-        "ComponentParam1": {
-          "type": "string"
-        },
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
@@ -18,27 +40,12 @@
           "description": "Shows the help text for this build assembly"
         },
         "Host": {
-          "type": "string",
           "description": "Host for execution. Default is 'automatic'",
-          "enum": [
-            "Rider",
-            "Terminal",
-            "VisualStudio",
-            "VSCode"
-          ]
+          "$ref": "#/definitions/Host"
         },
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
-        },
-        "NullableBool": {
-          "type": "boolean"
-        },
-        "NullableInteger": {
-          "type": "integer"
-        },
-        "Param": {
-          "type": "string"
         },
         "Partition": {
           "type": "string",
@@ -59,57 +66,26 @@
           "type": "string",
           "description": "Root directory during build execution"
         },
-        "Secret": {
-          "type": "string",
-          "default": "Secrets must be entered via 'nuke :secrets [profile]'"
-        },
         "Skip": {
           "type": "array",
           "description": "List of targets to be skipped. Empty list skips all dependencies",
           "items": {
-            "type": "string",
-            "enum": [
-              "Bar",
-              "Foo",
-              "Zoo"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
         },
         "Target": {
           "type": "array",
           "description": "List of targets to be invoked. Default is '{default_target}'",
           "items": {
-            "type": "string",
-            "enum": [
-              "Bar",
-              "Foo",
-              "Zoo"
-            ]
-          }
-        },
-        "Verbosities": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "Minimal",
-              "Normal",
-              "Quiet",
-              "Verbose"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
         },
         "Verbosity": {
-          "type": "string",
           "description": "Logging verbosity during build execution. Default is 'Normal'",
-          "enum": [
-            "Minimal",
-            "Normal",
-            "Quiet",
-            "Verbose"
-          ]
+          "$ref": "#/definitions/Verbosity"
         }
       }
     }
-  }
+  },
+  "$ref": "#/definitions/NukeBuild"
 }

--- a/source/Nuke.Build.Tests/SchemaUtilityTest.cs
+++ b/source/Nuke.Build.Tests/SchemaUtilityTest.cs
@@ -3,11 +3,25 @@
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Namotion.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using NJsonSchema;
+using NJsonSchema.Generation;
+using NuGet.Packaging;
 using Nuke.Common.Execution;
+using Nuke.Common.IO;
+using Nuke.Common.Tooling;
+using Nuke.Common.Utilities;
+using Nuke.Common.ValueInjection;
 using VerifyXunit;
 using Xunit;
 
@@ -15,40 +29,228 @@ namespace Nuke.Common.Tests;
 
 public class SchemaUtilityTest
 {
+    public class Resolver : DefaultContractResolver
+    {
+        protected override List<MemberInfo> GetSerializableMembers(Type objectType)
+        {
+            return objectType == typeof(ExecutableTarget) || objectType == typeof(Host)
+                ? new List<MemberInfo>()
+                : base.GetSerializableMembers(objectType);
+        }
+    }
+
+    private class BuildSchemaGenerator : JsonSchemaGenerator
+    {
+        public static JsonSchema Generate<T>(T build)
+            where T : INukeBuild
+        {
+            return new BuildSchemaGenerator(
+                build,
+                new JsonSchemaGeneratorSettings
+                {
+                    FlattenInheritanceHierarchy = true,
+                    SerializerSettings =
+                        new JsonSerializerSettings
+                        {
+                            ContractResolver = new Resolver(),
+                            Converters = new JsonConverter[] { new StringEnumConverter() }
+                        }
+                }).Generate();
+        }
+
+        private readonly INukeBuild _build;
+
+        private BuildSchemaGenerator(INukeBuild build, JsonSchemaGeneratorSettings settings)
+            : base(settings)
+        {
+            _build = build;
+        }
+
+        public JsonSchema Generate()
+        {
+            var userSchema = new JsonSchema();
+            var baseSchema = new JsonSchema();
+            var schemaResolver = new JsonSchemaResolver(userSchema, Settings);
+
+            var parameterMembers = ValueInjectionUtility.GetParameterMembers(_build.GetType(), includeUnlisted: true);
+            foreach (var parameterMember in parameterMembers)
+            {
+                var schema = parameterMember.DeclaringType == typeof(NukeBuild) ? baseSchema : userSchema;
+                var name = ParameterService.GetParameterMemberName(parameterMember);
+                var property = CreateProperty(parameterMember, schemaResolver);
+                schema.Properties[name] = property;
+            }
+
+            // ValueInjectionUtility.GetParameterMembers(_build.GetType(), includeUnlisted: true)
+            //     // .Where(x => x.Name.EqualsAnyOrdinalIgnoreCase(
+            //     //     nameof(NukeBuild.SkippedTargets),
+            //     //     nameof(NukeBuild.InvokedTargets),
+            //     //     nameof(NukeBuild.Verbosity)
+            //     // ))
+            //     .ToDictionary(ParameterService.GetParameterMemberName, x => CreateProperty(x, schemaResolver))
+            //     .ForEach(x =>
+            //     {
+            //         baseSchema.Properties[x.Key] = x.Value;
+            //     });
+
+            userSchema.Reference = baseSchema;
+            userSchema.Definitions["NukeBuild"] = baseSchema;
+
+            JsonSchema UpdatePropertySchema(string name, IEnumerable<string> values)
+            {
+                var schema = userSchema.Definitions[name];
+                schema.Type = JsonObjectType.String;
+                schema.AllowAdditionalProperties = true;
+                schema.Enumeration.AddRange(values);
+                return schema;
+            }
+
+            // TODO: why can't this use value sets?
+            var targetNames = ExecutableTargetFactory.GetTargetProperties(_build.GetType()).Select(x => x.GetDisplayShortName()).OrderBy(x => x);
+            var executableTargetSchema = UpdatePropertySchema("ExecutableTarget", targetNames);
+            baseSchema.Properties["Target"].Item = baseSchema.Properties["Skip"].Item = new JsonSchema { Reference = executableTargetSchema };
+
+            var hostNames = Host.AvailableTypes.Select(x => x.Name).OrderBy(x => x);
+            var hostSchema = UpdatePropertySchema("Host", hostNames);
+            baseSchema.Properties["Host"].Reference = hostSchema;
+
+            foreach (var definition in userSchema.Definitions.Values)
+            {
+                definition.EnumerationNames.Clear();
+                definition.AllowAdditionalProperties = true;
+            }
+
+            return userSchema;
+        }
+
+        private JsonSchemaProperty CreateProperty(MemberInfo parameterMember, JsonSchemaResolver schemaResolver)
+        {
+            var property = GenerateWithReference<JsonSchemaProperty>(
+                parameterMember.ToContextualAccessor().AccessorType,
+                schemaResolver);
+
+            property.Description = ParameterService.GetParameterDescription(parameterMember);
+            property.Default = parameterMember.HasCustomAttribute<SecretAttribute>()
+                ? "Secrets must be entered via 'nuke :secrets [profile]'"
+                : null;
+
+            var values = ParameterService.GetParameterValueSet(parameterMember, _build)
+                ?.Select(x => (object)x.Text);
+            if (values != null && !parameterMember.GetMemberType().IsEnum)
+            {
+                property.Type = !parameterMember.GetMemberType().IsCollectionLike()
+                    ? JsonObjectType.String
+                    : JsonObjectType.Array;
+                var propertySchema = property.Reference ?? property;
+                if (property.Type == JsonObjectType.String)
+                    propertySchema.Enumeration.AddRange(values);
+                else
+                    propertySchema.Item.Enumeration.AddRange(values);
+            }
+
+            if (Nullable.GetUnderlyingType(parameterMember.GetMemberType()) != null)
+                property.Type |= JsonObjectType.Null;
+
+            return property;
+        }
+    }
+
+    [Fact]
+    public Task TestEmptyBuild()
+    {
+        var jsonSchema = BuildSchemaGenerator.Generate(new EmptyBuild());
+        return Verifier.Verify(jsonSchema.ToJson(), "json");
+    }
+
+    [Fact]
+    public Task TestTargetBuild()
+    {
+        var jsonSchema = BuildSchemaGenerator.Generate(new TargetBuild());
+        return Verifier.Verify(jsonSchema.ToJson(), "json");
+    }
+
+    [Fact]
+    public Task TestParameterBuild()
+    {
+        var jsonSchema = BuildSchemaGenerator.Generate(new ParameterBuild());
+        return Verifier.Verify(jsonSchema.ToJson(), "json");
+    }
+
     [Fact]
     public Task TestGetBuildSchema()
     {
-        var schema = SchemaUtility.GetBuildSchema(new TestBuild());
+        var schema = SchemaUtility.GetBuildSchema(new ParameterBuild());
         var options = new JsonSerializerOptions { WriteIndented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
-        var json = JsonSerializer.Serialize(schema, options);
-        return Verifier.Verify(json);
+        var json = System.Text.Json.JsonSerializer.Serialize(schema, options);
+        return Verifier.Verify(json, "json");
     }
 
-#pragma warning disable CS0649
-    private class TestBuild : NukeBuild, ITestComponent
+    // ReSharper disable All
+    private class EmptyBuild : NukeBuild
     {
-        [Parameter] public string Param;
-        [Parameter] public bool? NullableBool;
-        [Parameter] public int? NullableInteger;
-        [Parameter] public Verbosity[] Verbosities;
-        [Parameter] [Secret] public string Secret;
-        public string Param2 => "";
-        string ITestComponent.Param3 => "";
+    }
 
-        Target ITestComponent.Bar => _ => _;
-        public Target Zoo => _ => _;
+    private class TargetBuild : NukeBuild, ITargetComponent
+    {
+        Target RegularTarget => _ => _;
+        public Target ImplementedTarget => _ => _;
+        Target ITargetComponent.ExplicitTarget => _ => _;
+    }
+
+    private interface ITargetComponent : INukeBuild
+    {
+        Target InheritedTarget => _ => _;
+        Target ImplementedTarget => _ => _;
+        Target ExplicitTarget => _ => _;
+    }
+
+    private class ParameterBuild : NukeBuild, IParameterComponent
+    {
+        [Parameter] readonly string RegularParam;
+        [Parameter] [Secret] readonly string SecretParam;
+
+        [Parameter] readonly bool BooleanParam;
+        [Parameter] readonly bool? NullableBooleanParam;
+
+        [Parameter] readonly string[] StringArrayParam;
+        [Parameter] readonly int[] IntegerArrayParam;
+
+        [Parameter] readonly CustomEnumeration CustomEnumerationParam;
+        [Parameter] readonly CustomEnumeration[] CustomEnumerationArrayParam;
+
+        [Parameter] readonly ComplexType ComplexTypeParam;
+        [Parameter] readonly ComplexType[] ComplexTypeArrayParam;
     }
 
     [ParameterPrefix("Component")]
-    private interface ITestComponent : INukeBuild
+    private interface IParameterComponent : INukeBuild
     {
-        [Parameter] string Param1 => TryGetValue(() => Param1);
-        [Parameter] string Param2 => TryGetValue(() => Param2);
-        [Parameter] string Param3 => TryGetValue(() => Param3);
-
-        Target Foo => _ => _;
-        Target Bar => _ => _;
-        Target Zoo => _ => _;
+        [Parameter] string InheritedParam => TryGetValue(() => InheritedParam);
     }
-#pragma warning restore CS0649
+
+    private class ComplexType
+    {
+        public string String;
+        public int Number;
+        public AbsolutePath[] Paths;
+        public ComplexSubType SubObject;
+    }
+
+    private class ComplexSubType
+    {
+        public bool? Boolean;
+    }
+
+    [TypeConverter(typeof(TypeConverter<CustomEnumeration>))]
+    public class CustomEnumeration : Enumeration
+    {
+        public static CustomEnumeration Debug = new() { Value = nameof(Debug) };
+        public static CustomEnumeration Release = new() { Value = nameof(Release) };
+
+        public static implicit operator string(CustomEnumeration configuration)
+        {
+            return configuration.Value;
+        }
+    }
+    // ReSharper restore All
 }

--- a/source/Nuke.Build.Tests/SchemaUtilityTest.cs
+++ b/source/Nuke.Build.Tests/SchemaUtilityTest.cs
@@ -3,189 +3,53 @@
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
-using System.Text.Encodings.Web;
-using System.Text.Json;
 using System.Threading.Tasks;
-using Namotion.Reflection;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Serialization;
-using NJsonSchema;
-using NJsonSchema.Generation;
-using NuGet.Packaging;
 using Nuke.Common.Execution;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
 using Nuke.Common.Utilities;
-using Nuke.Common.ValueInjection;
 using VerifyXunit;
 using Xunit;
+
+#pragma warning disable CS0169 // Field is never used
 
 namespace Nuke.Common.Tests;
 
 public class SchemaUtilityTest
 {
-    public class Resolver : DefaultContractResolver
-    {
-        protected override List<MemberInfo> GetSerializableMembers(Type objectType)
-        {
-            return objectType == typeof(ExecutableTarget) || objectType == typeof(Host)
-                ? new List<MemberInfo>()
-                : base.GetSerializableMembers(objectType);
-        }
-    }
-
-    private class BuildSchemaGenerator : JsonSchemaGenerator
-    {
-        public static JsonSchema Generate<T>(T build)
-            where T : INukeBuild
-        {
-            return new BuildSchemaGenerator(
-                build,
-                new JsonSchemaGeneratorSettings
-                {
-                    FlattenInheritanceHierarchy = true,
-                    SerializerSettings =
-                        new JsonSerializerSettings
-                        {
-                            ContractResolver = new Resolver(),
-                            Converters = new JsonConverter[] { new StringEnumConverter() }
-                        }
-                }).Generate();
-        }
-
-        private readonly INukeBuild _build;
-
-        private BuildSchemaGenerator(INukeBuild build, JsonSchemaGeneratorSettings settings)
-            : base(settings)
-        {
-            _build = build;
-        }
-
-        public JsonSchema Generate()
-        {
-            var userSchema = new JsonSchema();
-            var baseSchema = new JsonSchema();
-            var schemaResolver = new JsonSchemaResolver(userSchema, Settings);
-
-            var parameterMembers = ValueInjectionUtility.GetParameterMembers(_build.GetType(), includeUnlisted: true);
-            foreach (var parameterMember in parameterMembers)
-            {
-                var schema = parameterMember.DeclaringType == typeof(NukeBuild) ? baseSchema : userSchema;
-                var name = ParameterService.GetParameterMemberName(parameterMember);
-                var property = CreateProperty(parameterMember, schemaResolver);
-                schema.Properties[name] = property;
-            }
-
-            // ValueInjectionUtility.GetParameterMembers(_build.GetType(), includeUnlisted: true)
-            //     // .Where(x => x.Name.EqualsAnyOrdinalIgnoreCase(
-            //     //     nameof(NukeBuild.SkippedTargets),
-            //     //     nameof(NukeBuild.InvokedTargets),
-            //     //     nameof(NukeBuild.Verbosity)
-            //     // ))
-            //     .ToDictionary(ParameterService.GetParameterMemberName, x => CreateProperty(x, schemaResolver))
-            //     .ForEach(x =>
-            //     {
-            //         baseSchema.Properties[x.Key] = x.Value;
-            //     });
-
-            userSchema.Reference = baseSchema;
-            userSchema.Definitions["NukeBuild"] = baseSchema;
-
-            JsonSchema UpdatePropertySchema(string name, IEnumerable<string> values)
-            {
-                var schema = userSchema.Definitions[name];
-                schema.Type = JsonObjectType.String;
-                schema.AllowAdditionalProperties = true;
-                schema.Enumeration.AddRange(values);
-                return schema;
-            }
-
-            // TODO: why can't this use value sets?
-            var targetNames = ExecutableTargetFactory.GetTargetProperties(_build.GetType()).Select(x => x.GetDisplayShortName()).OrderBy(x => x);
-            var executableTargetSchema = UpdatePropertySchema("ExecutableTarget", targetNames);
-            baseSchema.Properties["Target"].Item = baseSchema.Properties["Skip"].Item = new JsonSchema { Reference = executableTargetSchema };
-
-            var hostNames = Host.AvailableTypes.Select(x => x.Name).OrderBy(x => x);
-            var hostSchema = UpdatePropertySchema("Host", hostNames);
-            baseSchema.Properties["Host"].Reference = hostSchema;
-
-            foreach (var definition in userSchema.Definitions.Values)
-            {
-                definition.EnumerationNames.Clear();
-                definition.AllowAdditionalProperties = true;
-            }
-
-            return userSchema;
-        }
-
-        private JsonSchemaProperty CreateProperty(MemberInfo parameterMember, JsonSchemaResolver schemaResolver)
-        {
-            var property = GenerateWithReference<JsonSchemaProperty>(
-                parameterMember.ToContextualAccessor().AccessorType,
-                schemaResolver);
-
-            property.Description = ParameterService.GetParameterDescription(parameterMember);
-            property.Default = parameterMember.HasCustomAttribute<SecretAttribute>()
-                ? "Secrets must be entered via 'nuke :secrets [profile]'"
-                : null;
-
-            var values = ParameterService.GetParameterValueSet(parameterMember, _build)
-                ?.Select(x => (object)x.Text);
-            if (values != null && !parameterMember.GetMemberType().IsEnum)
-            {
-                property.Type = !parameterMember.GetMemberType().IsCollectionLike()
-                    ? JsonObjectType.String
-                    : JsonObjectType.Array;
-                var propertySchema = property.Reference ?? property;
-                if (property.Type == JsonObjectType.String)
-                    propertySchema.Enumeration.AddRange(values);
-                else
-                    propertySchema.Item.Enumeration.AddRange(values);
-            }
-
-            if (Nullable.GetUnderlyingType(parameterMember.GetMemberType()) != null)
-                property.Type |= JsonObjectType.Null;
-
-            return property;
-        }
-    }
-
     [Fact]
     public Task TestEmptyBuild()
     {
-        var jsonSchema = BuildSchemaGenerator.Generate(new EmptyBuild());
-        return Verifier.Verify(jsonSchema.ToJson(), "json");
+        var jsonSchema = SchemaUtility.GetJsonString(new EmptyBuild());
+        return Verifier.Verify(jsonSchema, "json");
     }
 
     [Fact]
     public Task TestTargetBuild()
     {
-        var jsonSchema = BuildSchemaGenerator.Generate(new TargetBuild());
-        return Verifier.Verify(jsonSchema.ToJson(), "json");
+        var jsonSchema = SchemaUtility.GetJsonString(new TargetBuild());
+        return Verifier.Verify(jsonSchema, "json");
     }
 
     [Fact]
     public Task TestParameterBuild()
     {
-        var jsonSchema = BuildSchemaGenerator.Generate(new ParameterBuild());
-        return Verifier.Verify(jsonSchema.ToJson(), "json");
+        var jsonSchema = SchemaUtility.GetJsonString(new ParameterBuild());
+        return Verifier.Verify(jsonSchema, "json");
     }
 
     [Fact]
-    public Task TestGetBuildSchema()
+    public Task TestCustomParameterAttributeAttribute()
     {
-        var schema = SchemaUtility.GetBuildSchema(new ParameterBuild());
-        var options = new JsonSerializerOptions { WriteIndented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
-        var json = System.Text.Json.JsonSerializer.Serialize(schema, options);
-        return Verifier.Verify(json, "json");
+        var jsonSchema = SchemaUtility.GetJsonString(new CustomParameterAttributeBuild());
+        return Verifier.Verify(jsonSchema, "json");
     }
 
     // ReSharper disable All
+#pragma warning disable CS0414 // Field is assigned but its value is never used
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
     private class EmptyBuild : NukeBuild
     {
     }
@@ -242,7 +106,7 @@ public class SchemaUtilityTest
     }
 
     [TypeConverter(typeof(TypeConverter<CustomEnumeration>))]
-    public class CustomEnumeration : Enumeration
+    private class CustomEnumeration : Enumeration
     {
         public static CustomEnumeration Debug = new() { Value = nameof(Debug) };
         public static CustomEnumeration Release = new() { Value = nameof(Release) };
@@ -252,5 +116,15 @@ public class SchemaUtilityTest
             return configuration.Value;
         }
     }
+
+    private class CustomParameterAttributeBuild : NukeBuild
+    {
+        [CustomParameter] readonly ComplexType ComplexTypeParamWithAttribute;
+    }
+
+    private class CustomParameterAttribute : ParameterAttribute;
+
+#pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
+#pragma warning restore CS0414 // Field is assigned but its value is never used
     // ReSharper restore All
 }

--- a/source/Nuke.Build.Tests/parameters.json
+++ b/source/Nuke.Build.Tests/parameters.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "./SchemaUtilityTest.TestParameterBuild.received.json",
+  "Verbosity": "Minimal",
+  "Target": ["ExplicitTarget"],
+  "NullableBooleanParam": false,
+  "CustomEnumerationArrayParam": ["Debug", "Release"]
+}

--- a/source/Nuke.Build.Tests/parameters.json
+++ b/source/Nuke.Build.Tests/parameters.json
@@ -1,7 +1,5 @@
 {
-  "$schema": "./SchemaUtilityTest.TestParameterBuild.received.json",
+  "$schema": "./SchemaUtilityTest.TestTargetBuild.verified.json",
   "Verbosity": "Minimal",
-  "Target": ["ExplicitTarget"],
-  "NullableBooleanParam": false,
-  "CustomEnumerationArrayParam": ["Debug", "Release"]
+  "Target": ["ExplicitTarget", "InheritedTarget"]
 }

--- a/source/Nuke.Build/Execution/Extensions/ArgumentsFromParametersFileAttribute.cs
+++ b/source/Nuke.Build/Execution/Extensions/ArgumentsFromParametersFileAttribute.cs
@@ -10,7 +10,6 @@ using JetBrains.Annotations;
 using Newtonsoft.Json.Linq;
 using Nuke.Common.CI;
 using Nuke.Common.IO;
-using Nuke.Common.ProjectModel;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
 using Nuke.Common.ValueInjection;
@@ -76,10 +75,8 @@ public class ArgumentsFromParametersFileAttribute : BuildExtensionAttributeBase,
 
             var member = parameterMembers.SingleOrDefault(x => ParameterService.GetParameterMemberName(x).EqualsOrdinalIgnoreCase(parameter));
             var scalarType = member?.GetMemberType().GetScalarType();
-            if (scalarType == typeof(AbsolutePath) ||
-                typeof(Solution).IsAssignableFrom(scalarType) ||
-                scalarType == typeof(Project))
-                return NukeBuild.RootDirectory / property.Value.ToObject<string>();
+            if (typeof(IAbsolutePathHolder).IsAssignableFrom(scalarType))
+                return property.Value.ToObject<string>().Apply(x => !PathConstruction.HasPathRoot(x) ? NukeBuild.RootDirectory / x : (AbsolutePath)x);
 
             if ((member?.HasCustomAttribute<SecretAttribute>() ?? false) &&
                 !BuildServerConfigurationGeneration.IsActive)

--- a/source/Nuke.Build/Execution/Extensions/ArgumentsFromParametersFileAttribute.cs
+++ b/source/Nuke.Build/Execution/Extensions/ArgumentsFromParametersFileAttribute.cs
@@ -10,36 +10,55 @@ using JetBrains.Annotations;
 using Newtonsoft.Json.Linq;
 using Nuke.Common.CI;
 using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
 using Nuke.Common.ValueInjection;
-using Serilog;
 
 namespace Nuke.Common.Execution;
 
-internal class ArgumentsFromParametersFileAttribute : BuildExtensionAttributeBase, IOnBuildCreated
+[PublicAPI]
+public class ArgumentsFromParametersFileAttribute : BuildExtensionAttributeBase, IOnBuildCreated
 {
     public void OnBuildCreated(IReadOnlyCollection<ExecutableTarget> executableTargets)
     {
         // TODO: probably remove
-        if (!Directory.Exists(Constants.GetNukeDirectory(Build.RootDirectory)))
+        if (!Constants.GetNukeDirectory(NukeBuild.RootDirectory).DirectoryExists())
             return;
 
-        var parameterMembers = ValueInjectionUtility.GetParameterMembers(Build.GetType(), includeUnlisted: true);
-        var passwords = new Dictionary<string, string>();
 
-        IEnumerable<string> ConvertToArguments(string profile, string name, string[] values)
-        {
-            var member = parameterMembers.SingleOrDefault(x => ParameterService.GetParameterMemberName(x).EqualsOrdinalIgnoreCase(name));
-            var scalarType = member?.GetMemberType().GetScalarType();
-            var mustDecrypt = (member?.HasCustomAttribute<SecretAttribute>() ?? false) && !BuildServerConfigurationGeneration.IsActive;
-            var decryptedValues = values.Select(x => mustDecrypt ? DecryptValue(profile, name, x) : x);
-            var convertedValues = decryptedValues.Select(x => ConvertValue(scalarType, x)).ToList();
-            Log.Verbose("Passing value for {Member} ({Value})",
-                member?.GetDisplayName() ?? "<unresolved>",
-                !mustDecrypt ? convertedValues.JoinComma() : "secret");
-            return new[] { $"--{ParameterService.GetParameterDashedName(name)}" }.Concat(convertedValues);
-        }
+        // IEnumerable<string> ConvertToArguments(string profile, string name, string[] values)
+        // {
+        //     var member = parameterMembers.SingleOrDefault(x => ParameterService.GetParameterMemberName(x).EqualsOrdinalIgnoreCase(name));
+        //     var scalarType = member?.GetMemberType().GetScalarType();
+        //     var mustDecrypt = (member?.HasCustomAttribute<SecretAttribute>() ?? false) && !BuildServerConfigurationGeneration.IsActive;
+        //     var decryptedValues = values.Select(x => mustDecrypt ? DecryptValue(profile, name, x) : x);
+        //     var convertedValues = decryptedValues.Select(x => ConvertValue(scalarType, x)).ToList();
+        //     Log.Verbose("Passing value for {Member} ({Value})",
+        //         member?.GetDisplayName() ?? "<unresolved>",
+        //         !mustDecrypt ? convertedValues.JoinComma() : "secret");
+        //     return new[] { $"--{ParameterService.GetParameterDashedName(name)}" }.Concat(convertedValues);
+        // }
+        //
+
+        //
+        // // TODO: Abstract AbsolutePath/Solution/Project etc.
+        // string ConvertValue(Type scalarType, string value)
+        //     => scalarType == typeof(AbsolutePath) ||
+        //        typeof(Solution).IsAssignableFrom(scalarType) ||
+        //        scalarType == typeof(Project)
+        //         ? EnvironmentInfo.WorkingDirectory.GetUnixRelativePathTo(NukeBuild.RootDirectory / value)
+        //         : value;
+
+        var parameterMembers = ValueInjectionUtility.GetParameterMembers(Build.GetType(), includeUnlisted: true);
+        var jobjectsAndProfiles = new[] { (File: Constants.GetDefaultParametersFile(NukeBuild.RootDirectory), Profile: Constants.DefaultProfileName) }
+            .Where(x => File.Exists(x.File))
+            .Concat(NukeBuild.LoadedLocalProfiles.Select(x => (File: Constants.GetParametersProfileFile(NukeBuild.RootDirectory, x), Profile: x)))
+            .ForEachLazy(x => Assert.FileExists(x.File))
+            .Select(x => (JObject: JObject.Parse(File.ReadAllText(x.File)), x.Profile))
+            .Reverse();
+
+        var passwords = new Dictionary<string, string>();
 
         string DecryptValue(string profile, string name, string value)
             => EncryptionUtility.Decrypt(
@@ -47,45 +66,26 @@ internal class ArgumentsFromParametersFileAttribute : BuildExtensionAttributeBas
                 passwords[profile] = passwords.GetValueOrDefault(profile) ?? CredentialStore.GetPassword(profile, Build.RootDirectory),
                 name);
 
-        // TODO: Abstract AbsolutePath/Solution/Project etc.
-        string ConvertValue([CanBeNull] Type scalarType, string value)
-            => typeof(IAbsolutePathHolder).IsAssignableFrom(scalarType) &&
-               !PathConstruction.HasPathRoot(value)
-                ? EnvironmentInfo.WorkingDirectory.GetUnixRelativePathTo(Build.RootDirectory / value)
-                : value;
-
-        var arguments = GetParameters().SelectMany(x => ConvertToArguments(x.Profile, x.Name, x.Values)).ToArray();
-        ParameterService.Instance.ArgumentsFromFilesService = new ArgumentParser(arguments);
-    }
-
-    private IEnumerable<(string Profile, string Name, string[] Values)> GetParameters()
-    {
-        IEnumerable<string> GetValues(JProperty property)
-            // TODO: if property is object || property is array && array contains objects => base64
-            => property.Value is JArray array
-                ? array.Values<string>()
-                : property.Values<string>();
-
-        IEnumerable<(string Name, string[] Values)> Load(AbsolutePath file)
+        ParameterService.Instance.ArgumentsFromFilesService = (parameter, destinationType) =>
         {
-            try
-            {
-                var jobject = JObject.Parse(file.ReadAllText());
-                // TODO: use NukeBuild instance to match members and walk through structure to replace secrets and absolute-paths
-                return jobject.Properties()
-                    .Where(x => x.Name != "$schema")
-                    .Select(x => (x.Name, GetValues(x).ToArray()));
-            }
-            catch (Exception exception)
-            {
-                throw new Exception($"Failed parsing parameters file '{file}'.", exception);
-            }
-        }
+            var (property, profile) = jobjectsAndProfiles.Select(x => (Property: x.JObject.Property(parameter), x.Profile))
+                .Where(x => x.Property != null)
+                .FirstOrDefault();
+            if (property == null)
+                return null;
 
-        return new[] { (File: Constants.GetDefaultParametersFile(Build.RootDirectory), Profile: Constants.DefaultProfileName) }
-            .Where(x => x.File.Exists())
-            .Concat(Build.LoadedLocalProfiles.Select(x => (File: Constants.GetParametersProfileFile(Build.RootDirectory, x), Profile: x)))
-            .ForEachLazy(x => Assert.FileExists(x.File))
-            .SelectMany(x => Load(x.File), (x, r) => (x.Profile, r.Name, r.Values));
+            var member = parameterMembers.SingleOrDefault(x => ParameterService.GetParameterMemberName(x).EqualsOrdinalIgnoreCase(parameter));
+            var scalarType = member?.GetMemberType().GetScalarType();
+            if (scalarType == typeof(AbsolutePath) ||
+                typeof(Solution).IsAssignableFrom(scalarType) ||
+                scalarType == typeof(Project))
+                return NukeBuild.RootDirectory / property.Value.ToObject<string>();
+
+            if ((member?.HasCustomAttribute<SecretAttribute>() ?? false) &&
+                !BuildServerConfigurationGeneration.IsActive)
+                return DecryptValue(profile, parameter, property.Value.ToObject<string>());
+
+            return property.Value.ToObject(destinationType);
+        };
     }
 }

--- a/source/Nuke.Build/Execution/ParameterService.cs
+++ b/source/Nuke.Build/Execution/ParameterService.cs
@@ -17,7 +17,8 @@ namespace Nuke.Common;
 
 internal partial class ParameterService
 {
-    internal ArgumentParser ArgumentsFromFilesService;
+    // internal ArgumentParser ArgumentsFromFilesService;
+    internal Func<string, Type, object> ArgumentsFromFilesService;
     internal ArgumentParser ArgumentsFromCommitMessageService;
 
     private readonly Func<ArgumentParser> _argumentParserProvider;
@@ -154,7 +155,8 @@ internal partial class ParameterService
 
         // TODO: nuke <target> ?
         object TryFromProfileArguments() =>
-            ArgumentsFromFilesService?.GetNamedArgument(parameterName, destinationType, separator);
+            // ArgumentsFromFilesService?.GetNamedArgument(parameterName, destinationType, separator);
+            ArgumentsFromFilesService?.Invoke(parameterName, destinationType);
 
         object TryFromCommitMessageArguments() =>
             ArgumentsFromCommitMessageService?.GetNamedArgument(parameterName, destinationType, separator);

--- a/source/Nuke.Build/Nuke.Build.csproj
+++ b/source/Nuke.Build/Nuke.Build.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+    <PackageReference Include="NJsonSchema" Version="10.9.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/source/Nuke.Build/Nuke.Build.csproj
+++ b/source/Nuke.Build/Nuke.Build.csproj
@@ -17,13 +17,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
-    <PackageReference Include="NJsonSchema" Version="10.9.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
-    <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="3.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" />
+    <PackageReference Include="NJsonSchema" />
+    <PackageReference Include="Serilog.Formatting.Compact" />
+    <PackageReference Include="Serilog.Formatting.Compact.Reader" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.File" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Nuke.Build/NukeBuild.Statics.cs
+++ b/source/Nuke.Build/NukeBuild.Statics.cs
@@ -82,7 +82,7 @@ public abstract partial class NukeBuild
     /// <summary>
     /// Gets the host for execution. Default is <em>automatic</em>.
     /// </summary>
-    [Parameter("Host for execution. Default is 'automatic'.", ValueProviderMember = nameof(HostNames))]
+    [Parameter("Host for execution. Default is 'automatic'.")]
     public static Host Host { get; set; }
 
     [Parameter("Defines the profiles to load.", Name = LoadedLocalProfilesParameterName)]

--- a/source/Nuke.Build/NukeBuild.cs
+++ b/source/Nuke.Build/NukeBuild.cs
@@ -87,8 +87,7 @@ public abstract partial class NukeBuild : INukeBuild
     /// </summary>
     [Parameter("List of targets to be invoked. Default is '{default_target}'.",
         Name = InvokedTargetsParameterName,
-        Separator = TargetsSeparator,
-        ValueProviderMember = nameof(TargetNames))]
+        Separator = TargetsSeparator)]
     public IReadOnlyCollection<ExecutableTarget> InvokedTargets => ExecutionPlan.Where(x => x.Invoked).ToList();
 
     /// <summary>
@@ -96,8 +95,7 @@ public abstract partial class NukeBuild : INukeBuild
     /// </summary>
     [Parameter("List of targets to be skipped. Empty list skips all dependencies.",
         Name = SkippedTargetsParameterName,
-        Separator = TargetsSeparator,
-        ValueProviderMember = nameof(TargetNames))]
+        Separator = TargetsSeparator)]
     public IReadOnlyCollection<ExecutableTarget> SkippedTargets => ExecutionPlan.Where(x => x.Status == ExecutionStatus.Skipped).ToList();
 
     /// <summary>

--- a/source/Nuke.Build/Utilities/SchemaUtility.cs
+++ b/source/Nuke.Build/Utilities/SchemaUtility.cs
@@ -5,9 +5,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Encodings.Web;
+using System.Reflection;
 using System.Text.Json;
-using Nuke.Common.IO;
+using Namotion.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using NJsonSchema;
+using NJsonSchema.Generation;
+using NuGet.Packaging;
 using Nuke.Common.Utilities;
 using Nuke.Common.ValueInjection;
 using static Nuke.Common.Constants;
@@ -16,93 +22,146 @@ namespace Nuke.Common.Execution;
 
 public class SchemaUtility
 {
-    public static void WriteBuildSchemaFile(INukeBuild build)
+    private class SchemaGenerator : JsonSchemaGenerator
     {
-        var buildSchemaFile = GetBuildSchemaFile(build.RootDirectory);
-        var buildSchema = GetBuildSchema(build);
-        var options = new JsonSerializerOptions { WriteIndented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
-        var json = JsonSerializer.Serialize(buildSchema, options);
-        buildSchemaFile.WriteAllText(json);
-    }
-
-    // ReSharper disable once CognitiveComplexity
-    public static JsonDocument GetBuildSchema(INukeBuild build)
-    {
-        var parameters = ValueInjectionUtility
-            .GetParameterMembers(build.GetType(), includeUnlisted: true)
-            // .Where(x => x.DeclaringType != typeof(NukeBuild))
-            .Select(x =>
-                new
-                {
-                    Name = ParameterService.GetParameterMemberName(x),
-                    Description = ParameterService.GetParameterDescription(x),
-                    MemberType = x.GetMemberType(),
-                    ScalarType = x.GetMemberType().GetScalarType(),
-                    EnumValues = ParameterService.GetParameterValueSet(x, build)?.Select(x => x.Text),
-                    IsRequired = x.HasCustomAttribute<RequiredAttribute>(),
-                    IsSecret = x.HasCustomAttribute<SecretAttribute>()
-                }).ToList();
-
-        string GetJsonType(Type type)
-            => type.IsCollectionLike()
-                ? "array"
-                : type.GetScalarType() == typeof(int)
-                    ? "integer"
-                    : type.GetScalarType() == typeof(bool)
-                        ? "boolean"
-                        : "string";
-
-        var properties = new Dictionary<string, object>();
-        foreach (var parameter in parameters)
+        private class Resolver : DefaultContractResolver
         {
-            var property = new Dictionary<string, object>();
-            property["type"] = GetJsonType(parameter.MemberType);
-
-            if (parameter.Description != null)
-                property["description"] = parameter.Description;
-
-            if (parameter.IsSecret)
-                property["default"] = "Secrets must be entered via 'nuke :secrets [profile]'";
-
-            if (parameter.EnumValues != null && !parameter.MemberType.IsCollectionLike())
-                property["enum"] = parameter.EnumValues;
-
-            if (parameter.MemberType.IsCollectionLike())
+            protected override List<MemberInfo> GetSerializableMembers(Type objectType)
             {
-                var items = new Dictionary<string, object>();
-                items["type"] = GetJsonType(parameter.ScalarType);
-                if (parameter.EnumValues != null)
-                    items["enum"] = parameter.EnumValues;
-                property["items"] = items;
+                return objectType == typeof(ExecutableTarget) || objectType == typeof(Host)
+                    ? new List<MemberInfo>()
+                    : base.GetSerializableMembers(objectType);
             }
-
-            properties[parameter.Name] = property;
         }
 
-        var build2 = new Dictionary<string, object> { ["type"] = "object", ["properties"] = properties };
-        var definitions = new Dictionary<string, object> { ["build"] = build2 };
-        var jsonDictionary = new Dictionary<string, object>
-                             {
-                                 ["$schema"] = "http://json-schema.org/draft-04/schema#",
-                                 ["$ref"] = "#/definitions/build",
-                                 ["title"] = "Build Schema",
-                                 ["definitions"] = definitions
-                             };
-        return JsonDocument.Parse(JsonSerializer.Serialize(jsonDictionary));
+        public static JsonSchema Generate<T>(T build) where T : INukeBuild
+        {
+            return new SchemaGenerator(
+                build,
+                new JsonSchemaGeneratorSettings
+                {
+                    FlattenInheritanceHierarchy = true,
+                    SerializerSettings =
+                        new JsonSerializerSettings
+                        {
+                            ContractResolver = new Resolver(),
+                            Converters = new JsonConverter[] { new StringEnumConverter() }
+                        }
+                }).Generate();
+        }
+
+        private readonly INukeBuild _build;
+
+        private SchemaGenerator(INukeBuild build, JsonSchemaGeneratorSettings settings)
+            : base(settings)
+        {
+            _build = build;
+        }
+
+        private JsonSchema Generate()
+        {
+            var baseSchema = new JsonSchema();
+            var userSchema = new JsonSchema();
+            var schemaResolver = new JsonSchemaResolver(userSchema, Settings);
+
+            var parameterMembers = ValueInjectionUtility.GetParameterMembers(_build.GetType(), includeUnlisted: true);
+            foreach (var parameterMember in parameterMembers)
+            {
+                var schema = parameterMember.DeclaringType == typeof(NukeBuild) ? baseSchema : userSchema;
+                var name = ParameterService.GetParameterMemberName(parameterMember);
+                var property = CreateProperty(parameterMember, schemaResolver);
+                schema.Properties[name] = property;
+            }
+
+            // ValueInjectionUtility.GetParameterMembers(_build.GetType(), includeUnlisted: true)
+            //     // .Where(x => x.Name.EqualsAnyOrdinalIgnoreCase(
+            //     //     nameof(NukeBuild.SkippedTargets),
+            //     //     nameof(NukeBuild.InvokedTargets),
+            //     //     nameof(NukeBuild.Verbosity)
+            //     // ))
+            //     .ToDictionary(ParameterService.GetParameterMemberName, x => CreateProperty(x, schemaResolver))
+            //     .ForEach(x =>
+            //     {
+            //         baseSchema.Properties[x.Key] = x.Value;
+            //     });
+
+            userSchema.Reference = baseSchema;
+            userSchema.Definitions[nameof(NukeBuild)] = baseSchema;
+
+            // TODO: why can't this use value sets?
+            var targetNames = ExecutableTargetFactory.GetTargetProperties(_build.GetType()).Select(x => x.GetDisplayShortName()).OrderBy(x => x);
+            var executableTargetSchema = UpdatePropertySchema(nameof(ExecutableTarget), targetNames);
+            baseSchema.Properties[InvokedTargetsParameterName].Item =
+                baseSchema.Properties[SkippedTargetsParameterName].Item = new JsonSchema { Reference = executableTargetSchema };
+
+            var hostNames = Host.AvailableTypes.Select(x => x.Name).OrderBy(x => x);
+            var hostSchema = UpdatePropertySchema(nameof(NukeBuild.Host), hostNames);
+            baseSchema.Properties[nameof(NukeBuild.Host)].Reference = hostSchema;
+
+            RemoveXEnumValues();
+
+            return userSchema;
+
+            JsonSchema UpdatePropertySchema(string name, IEnumerable<string> values)
+            {
+                var schema = userSchema.Definitions[name];
+                schema.Type = JsonObjectType.String;
+                schema.AllowAdditionalProperties = true;
+                schema.Enumeration.AddRange(values);
+                return schema;
+            }
+
+            void RemoveXEnumValues()
+            {
+                foreach (var definition in userSchema.Definitions.Values)
+                {
+                    definition.EnumerationNames.Clear();
+                    definition.AllowAdditionalProperties = true;
+                }
+            }
+        }
+
+        private JsonSchemaProperty CreateProperty(MemberInfo parameterMember, JsonSchemaResolver schemaResolver)
+        {
+            var property = parameterMember.GetCustomAttribute<ParameterAttribute>().NotNull().GetType() == typeof(ParameterAttribute)
+                ? GenerateWithReference<JsonSchemaProperty>(
+                    parameterMember.ToContextualAccessor().AccessorType,
+                    schemaResolver)
+                : new JsonSchemaProperty { Type = JsonObjectType.String };
+
+            property.Description = ParameterService.GetParameterDescription(parameterMember);
+            property.Default = parameterMember.HasCustomAttribute<SecretAttribute>()
+                ? "Secrets must be entered via 'nuke :secrets [profile]'"
+                : null;
+
+            var values = ParameterService.GetParameterValueSet(parameterMember, _build)
+                ?.Select(x => (object)x.Text);
+            if (values != null && !parameterMember.GetMemberType().IsEnum)
+            {
+                property.Type = !parameterMember.GetMemberType().IsCollectionLike()
+                    ? JsonObjectType.String
+                    : JsonObjectType.Array;
+                var propertySchema = property.Reference ?? property;
+                if (property.Type == JsonObjectType.String)
+                    propertySchema.Enumeration.AddRange(values);
+                else
+                    propertySchema.Item.Enumeration.AddRange(values);
+            }
+
+            if (Nullable.GetUnderlyingType(parameterMember.GetMemberType()) != null)
+                property.Type |= JsonObjectType.Null;
+
+            return property;
+        }
     }
 
-    public static void WriteDefaultParametersFile(INukeBuild build)
+    public static string GetJsonString(INukeBuild build)
     {
-        var parametersFile = GetDefaultParametersFile(build.RootDirectory);
-        if (parametersFile.Exists())
-            return;
+        return SchemaGenerator.Generate(build).ToJson();
+    }
 
-        parametersFile.WriteAllLines(
-            new[]
-            {
-                "{",
-                $"  \"$schema\": \"./{BuildSchemaFileName}\"",
-                "}"
-            });
+    public static JsonDocument GetJsonDocument(INukeBuild build)
+    {
+        return JsonDocument.Parse(GetJsonString(build));
     }
 }

--- a/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
+++ b/source/Nuke.Common.Tests/CI/ConfigurationGenerationTest.cs
@@ -77,8 +77,7 @@ public class ConfigurationGenerationTest
             (
                 null,
                 new TestAzurePipelinesAttribute(
-                    AzurePipelinesImage.Ubuntu2204,
-                    AzurePipelinesImage.Windows2019)
+                    AzurePipelinesImage.Ubuntu2204)
                 {
                     NonEntryTargets = new[] { nameof(Clean) },
                     InvokedTargets = new[] { nameof(Test) },

--- a/source/Nuke.Common.Tests/CI/TestAzurePipelinesAttribute.cs
+++ b/source/Nuke.Common.Tests/CI/TestAzurePipelinesAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2023 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -11,8 +11,8 @@ namespace Nuke.Common.Tests.CI;
 
 public class TestAzurePipelinesAttribute : AzurePipelinesAttribute, ITestConfigurationGenerator
 {
-    public TestAzurePipelinesAttribute(AzurePipelinesImage image, params AzurePipelinesImage[] images)
-        : base(image, images)
+    public TestAzurePipelinesAttribute(AzurePipelinesImage image)
+        : base(image)
     {
     }
 

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesCacheStep.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesCacheStep.cs
@@ -14,14 +14,12 @@ namespace Nuke.Common.CI.AzurePipelines.Configuration;
 [PublicAPI]
 public class AzurePipelinesCacheStep : AzurePipelinesStep
 {
-    public AzurePipelinesImage Image { get; set; }
+    public AzurePipelinesPool Pool { get; set; }
     public string[] KeyFiles { get; set; }
     public string Path { get; set; }
 
     private string AdjustedPath =>
-        Image.GetValue().StartsWithAnyOrdinalIgnoreCase("ubuntu", "macos")
-            ? Path.Replace("~", "$(HOME)")
-            : Path.Replace("~", "$(USERPROFILE)");
+        Path.Replace("~", Pool.GetUserHomeDirectory());
 
     private string Identifier => Path
         .Replace(".", "/")

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesJob.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesJob.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2023 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -16,7 +16,7 @@ public class AzurePipelinesJob : ConfigurationEntity
 {
     public string Name { get; set; }
     public string DisplayName { get; set; }
-    public AzurePipelinesImage? Image { get; set; }
+    public AzurePipelinesPool Pool { get; set; }
     public AzurePipelinesJob[] Dependencies { get; set; }
     public int Parallel { get; set; }
     public AzurePipelinesStep[] Steps { get; set; }
@@ -28,12 +28,9 @@ public class AzurePipelinesJob : ConfigurationEntity
             writer.WriteLine($"displayName: {DisplayName.SingleQuote()}");
             writer.WriteLine($"dependsOn: [ {Dependencies.Select(x => x.Name).JoinCommaSpace()} ]");
 
-            if (Image != null)
+            if (Pool != null)
             {
-                using (writer.WriteBlock("pool:"))
-                {
-                    writer.WriteLine($"vmImage: {Image.Value.GetValue().SingleQuote().SingleQuote()}");
-                }
+                Pool.Write(writer);
             }
 
             if (Parallel > 1)

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesPool.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesPool.cs
@@ -1,0 +1,94 @@
+﻿using JetBrains.Annotations;
+using Nuke.Common.Tooling;
+using Nuke.Common.Utilities;
+using Nuke.Common.Utilities.Collections;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nuke.Common.CI.AzurePipelines.Configuration
+{
+    [PublicAPI]
+    public class AzurePipelinesPool : ConfigurationEntity
+    {
+        public AzurePipelinesPool(AzurePipelinesImage image)
+        {
+            Image = image;
+        }
+
+        public AzurePipelinesPool(string name, params string[] demands)
+        {
+            Name = name;
+            Demands = demands;
+        }
+
+        public string Name { get; }
+        public string[] Demands { get; }
+        public AzurePipelinesImage? Image { get; }
+
+        public string GetNameForStage()
+        {
+            if (Image != null)
+            {
+                return Image.Value.GetValue();
+            }
+            else
+            {
+                return Name;
+            }
+        }
+
+        public override void Write(CustomFileWriter writer)
+        {
+            using (writer.WriteBlock("pool:"))
+            {
+                if (Image != null)
+                {
+                    writer.WriteLine($"vmImage: {Image.Value.GetValue().SingleQuote().SingleQuote()}");
+                }
+                else if (Name != null)
+                {
+                    writer.WriteLine($"name: {Name}");
+
+                    if (Demands?.Any() == true)
+                    {
+                        using (writer.WriteBlock("demands:"))
+                        {
+                            Demands.ForEach(x => writer.WriteLine($"- {x}"));
+                        }
+                    }
+                }
+            }
+        }
+
+        public string GetUserHomeDirectory()
+        {
+            if (Image != null)
+            {
+                return GetUserHomeDirectory(Image.Value.GetValue());
+            }
+            else
+            {
+                var agentOS = Demands?.FirstOrDefault(x => x.StartsWith("Agent.OS"));
+                if (agentOS != null)
+                {
+                    return GetUserHomeDirectory(agentOS.SplitSpace().Last());
+                }
+            }
+
+            // By default, we assume it's Linux based pool
+            return GetUserHomeDirectory("ubuntu");
+        }
+
+        private static string GetUserHomeDirectory(string os)
+        {
+            return os.StartsWithAnyOrdinalIgnoreCase("ubuntu", "macos")
+                ? "$(HOME)"
+                : "$(USERPROFILE)";
+        }
+    }
+}

--- a/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesStage.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/Configuration/AzurePipelinesStage.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2023 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -16,7 +16,7 @@ public class AzurePipelinesStage : ConfigurationEntity
 {
     public string Name { get; set; }
     public string DisplayName { get; set; }
-    public AzurePipelinesImage? Image { get; set; }
+    public AzurePipelinesPool Pool { get; set; }
     public AzurePipelinesStage[] Dependencies { get; set; }
     public AzurePipelinesJob[] Jobs { get; set; }
 
@@ -27,12 +27,9 @@ public class AzurePipelinesStage : ConfigurationEntity
             writer.WriteLine($"displayName: {DisplayName.SingleQuote()}");
             writer.WriteLine($"dependsOn: [ {Dependencies.Select(x => x.Name).JoinCommaSpace()} ]");
 
-            if (Image != null)
+            if (Pool != null)
             {
-                using (writer.WriteBlock("pool:"))
-                {
-                    writer.WriteLine($"vmImage: {Image.Value.GetValue().SingleQuote()}");
-                }
+                Pool.Write(writer);
             }
 
             using (writer.WriteBlock("jobs:"))

--- a/source/Nuke.Common/Nuke.Common.csproj
+++ b/source/Nuke.Common/Nuke.Common.csproj
@@ -23,11 +23,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.11.4" />
-    <PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
-    <PackageReference Include="Octokit" Version="12.0.0" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" />
+    <PackageReference Include="Octokit" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(_IsPacking)' == 'True'">

--- a/source/Nuke.Common/Tools/Codecov/Codecov.json
+++ b/source/Nuke.Common/Tools/Codecov/Codecov.json
@@ -6,7 +6,7 @@
   "name": "Codecov",
   "officialUrl": "https://about.codecov.io/",
   "help": "Code coverage is a measurement used to express which lines of code were executed by a test suite. We use three primary terms to describe each line executed.<para/><ul><li>hit - indicates that the source code was executed by the test suite.</li><li>partial - indicates that the source code was not fully executed by the test suite; there are remaining branches that were not executed.</li><li>miss - indicates that the source code was not executed by the test suite.</li></ul><para/>Coverage is the ratio of <c>hits / (sum of hit + partial + miss)</c>. A code base that has 5 lines executed by tests out of 12 total lines will receive a coverage ratio of 41% (rounding down).<para/>Phrased simply, code coverage provides a visual measurement of what source code is being executed by a test suite. This information indicates to the software developer where they should write new tests in an effort to achieve higher coverage.<para/>Testing source code helps to prevent bugs and syntax errors by executing each line with a known variable and cross-checking it with an expected output.",
-  "nugetPackageId": "Codecov.Tool",
+  "nugetPackageId": "CodecovUploader",
   "customExecutable": true,
   "tasks": [
     {

--- a/source/Nuke.Common/Tools/Codecov/CodecovTasks.cs
+++ b/source/Nuke.Common/Tools/Codecov/CodecovTasks.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
+using System;
 using Nuke.Common.Tooling;
 
 namespace Nuke.Common.Tools.Codecov;
@@ -10,17 +11,27 @@ partial class CodecovSettings
 {
     private string GetProcessToolPath()
     {
-        return CodecovTasks.GetToolPath(Framework);
+        return CodecovTasks.GetToolPath();
     }
 }
 
 partial class CodecovTasks
 {
-    internal static string GetToolPath(string framework = null)
+    internal static string GetToolPath()
     {
         return NuGetToolPathResolver.GetPackageExecutable(
-            packageId: "Codecov.Tool",
-            packageExecutable: "codecov.dll",
-            framework: framework);
+            packageId: "CodecovUploader",
+            packageExecutable: GetPackageExecutable());
+    }
+
+    private static string GetPackageExecutable()
+    {
+        return EnvironmentInfo.Platform switch
+        {
+            PlatformFamily.Windows => "codecov.exe",
+            PlatformFamily.OSX => "codecov-macos",
+            PlatformFamily.Linux => "codecov-linux",
+            _ => throw new ArgumentOutOfRangeException()
+        };
     }
 }

--- a/source/Nuke.Common/Tools/DotNet/DotNet.json
+++ b/source/Nuke.Common/Tools/DotNet/DotNet.json
@@ -691,6 +691,12 @@
             "help": "The project to publish, which defaults to the current directory if not specified."
           },
           {
+            "name": "Architecture",
+            "type": "string",
+            "format": "--arch {value}",
+            "help": "Specifies the target architecture. This is a shorthand syntax for setting the <a href=\"https://learn.microsoft.com/en-us/dotnet/core/rid-catalog\">Runtime Identifier (RID)</a>, where the provided value is combined with the default RID. For example, on a win-x64 machine, specifying --arch x86 sets the RID to win-x86. If you use this option, don't use the -r|--runtime option. Available since .NET 6 Preview 7."
+          },
+          {
             "name": "Configuration",
             "type": "string",
             "format": "--configuration {value}",
@@ -727,6 +733,12 @@
             "help": "Specifies the path for the output directory. If not specified, it defaults to <em>./bin/[configuration]/[framework]/</em> for a framework-dependent deployment or <em>./bin/[configuration]/[framework]/[runtime]</em> for a self-contained deployment.<para/>If a relative path is provided, the output directory generated is relative to the project file location, not to the current working directory."
           },
           {
+            "name": "OperatingSystem",
+            "type": "string",
+            "format": "--os {value}",
+            "help": "Specifies the target operating system (OS). This is a shorthand syntax for setting the <a href\"https://learn.microsoft.com/en-us/dotnet/core/rid-catalog\">Runtime Identifier (RID)</a>, where the provided value is combined with the default RID. For example, on a win-x64 machine, specifying --os linux sets the RID to linux-x64. If you use this option, don't use the -r|--runtime option. Available since .NET 6."
+          },
+          {
             "name": "SelfContained",
             "type": "bool",
             "format": "--self-contained {value}",
@@ -755,6 +767,13 @@
             "type": "bool",
             "format": "--nologo",
             "help": "Doesn't display the startup banner or the copyright message. Available since .NET Core 3.0 SDK."
+          },
+          {
+            "name": "Targets",
+            "type": "List<string>",
+            "format": "/t:{value}",
+            "separator": ";",
+            "help": "<p>Build the specified targets in the project. Specify each target separately, or use a semicolon or comma to separate multiple targets, as the following example shows:<br/><c>/target:Resources;Compile</c></p><p>If you specify any targets by using this switch, they are run instead of any targets in the DefaultTargets attribute in the project file. For more information, see <a href=\"https://msdn.microsoft.com/en-us/library/ee216359.aspx\">Target Build Order</a> and <a href=\"https://msdn.microsoft.com/en-us/library/ms171463.aspx\">How to: Specify Which Target to Build First</a>.</p><p>A target is a group of tasks. For more information, see <a href=\"https://msdn.microsoft.com/en-us/library/ms171462.aspx\">Targets</a>.</p>"
           }
         ]
       }

--- a/source/Nuke.Common/Tools/DotnetPackaging/DotnetPackaging.json
+++ b/source/Nuke.Common/Tools/DotnetPackaging/DotnetPackaging.json
@@ -1,0 +1,264 @@
+{
+  "$schema": "https://raw.githubusercontent.com/nuke-build/nuke/master/source/Nuke.Tooling.Generator/schema.json",
+  "references": [
+    "https://github.com/SuperJMN/DotnetPackaging/tree/master/src/DotnetPackaging.Console"
+  ],
+  "name": "DotnetPackaging",
+  "officialUrl": "https://github.com/superjmn/dotnetpackaging",
+  "help": "DotnetPackaging is able to package your application into various formats, including Deb and AppImage.",
+  "nugetPackageId": "DotnetPackaging.Console",
+  "packageExecutable": "DotnetPackaging.Console.dll",
+  "tasks": [
+    {
+      "help": "Creates a Debian package from the specified directory.",
+      "postfix": "Deb",
+      "definiteArgument": "deb",
+      "settingsClass": {
+        "properties": [
+          {
+            "name": "Directory",
+            "type": "string",
+            "format": "--directory={value}",
+            "help": "The input directory from which to create the package."
+          },
+          {
+            "name": "Metadata",
+            "type": "string",
+            "format": "--metadata={value}",
+            "help": "The metadata file to include in the package."
+          },
+          {
+            "name": "Output",
+            "type": "string",
+            "format": "--output={value}",
+            "help": "The output DEB file to create."
+          }
+        ]
+      }
+    },
+    {
+      "help": "Creates an AppImage package.",
+      "postfix": "AppImage",
+      "definiteArgument": "appimage",
+      "settingsClass": {
+        "properties": [
+          {
+            "name": "Directory",
+            "type": "string",
+            "format": "--directory={value}",
+            "help": "The input directory from which to create the AppImage."
+          },
+          {
+            "name": "Output",
+            "type": "string",
+            "format": "--output={value}",
+            "help": "The output AppImage file to create."
+          },
+          {
+            "name": "ApplicationName",
+            "type": "string",
+            "format": "--application-name={value}",
+            "help": "The name of the application for the AppImage."
+          },
+          {
+            "name": "MainCategory",
+            "type": "DotnetPackagingMainCategory",
+            "format": "--main-category {value}",
+            "help": "Main category of the application."
+          },
+          {
+            "name": "AdditionalCategories",
+            "type": "List<DotnetPackagingAdditionalCategory>",
+            "format": "--additional-categories {value}",
+            "help": "Additional categories for the application."
+          },
+          {
+            "name": "Icon",
+            "type": "string",
+            "format": "--icon {value}",
+            "help": "The icon path for the application. When not provided, the tool looks up for an image called <c>AppImage.png</c>."
+          },
+          {
+            "name": "Homepage",
+            "type": "string",
+            "format": "--homepage {value}",
+            "help": "Home page of the application."
+          },
+          {
+            "name": "License",
+            "type": "string",
+            "format": "--license {value}",
+            "help": "License of the application."
+          },
+          {
+            "name": "Version",
+            "type": "string",
+            "format": "--version {value}",
+            "help": "Version of the application."
+          },
+          {
+            "name": "ScreenshotUrls",
+            "type": "List<string>",
+            "format": "--screenshot-urls {value}",
+            "help": "URLs of screenshots of the application."
+          },
+          {
+            "name": "Summary",
+            "type": "string",
+            "format": "--summary {value}",
+            "help": "Short description of the application."
+          },
+          {
+            "name": "AppId",
+            "type": "string",
+            "format": "--appId {value}",
+            "help": "Application ID, usually a reverse DNS name like <c>com.SomeCompany.SomeApplication</c>."
+          }
+        ]
+      }
+    }
+  ],
+  "enumerations": [
+    {
+      "name": "DotnetPackagingMainCategory",
+      "values": [
+        "AudioVideo",
+        "Audio",
+        "Video",
+        "Development",
+        "Education",
+        "Game",
+        "Graphics",
+        "Network",
+        "Office",
+        "Settings",
+        "Utility"
+      ]
+    },
+    {
+      "name": "DotnetPackagingAdditionalCategory",
+      "values": [
+        "Building",
+        "Debugger",
+        "IDE",
+        "GUIDesigner",
+        "Profiling",
+        "RevisionControl",
+        "Translation",
+        "Calendar",
+        "ContactManagement",
+        "Database",
+        "Dictionary",
+        "Chart",
+        "Email",
+        "Finance",
+        "FlowChart",
+        "PDA",
+        "ProjectManagement",
+        "Presentation",
+        "Spreadsheet",
+        "WordProcessor",
+        "TwoDGraphics",
+        "VectorGraphics",
+        "RasterGraphics",
+        "ThreeDGraphics",
+        "Scanning",
+        "OCR",
+        "Photography",
+        "Publishing",
+        "Viewer",
+        "TextTools",
+        "DesktopSettings",
+        "HardwareSettings",
+        "Printing",
+        "PackageManager",
+        "Dialup",
+        "InstantMessaging",
+        "Chat",
+        "IRCClient",
+        "FileTransfer",
+        "HamRadio",
+        "News",
+        "P2P",
+        "RemoteAccess",
+        "Telephony",
+        "TelephonyTools",
+        "VideoConference",
+        "WebBrowser",
+        "WebDevelopment",
+        "Midi",
+        "Mixer",
+        "Sequencer",
+        "Tuner",
+        "TV",
+        "AudioVideoEditing",
+        "Player",
+        "Recorder",
+        "DiscBurning",
+        "ActionGame",
+        "AdventureGame",
+        "ArcadeGame",
+        "BoardGame",
+        "BlocksGame",
+        "CardGame",
+        "KidsGame",
+        "LogicGame",
+        "RolePlaying",
+        "Simulation",
+        "SportsGame",
+        "StrategyGame",
+        "Art",
+        "Construction",
+        "Music",
+        "Languages",
+        "Science",
+        "ArtificialIntelligence",
+        "Astronomy",
+        "Biology",
+        "Chemistry",
+        "ComputerScience",
+        "DataVisualization",
+        "Economy",
+        "Electricity",
+        "Geography",
+        "Geology",
+        "Geoscience",
+        "History",
+        "ImageProcessing",
+        "Literature",
+        "Math",
+        "NumericalAnalysis",
+        "MedicalSoftware",
+        "Physics",
+        "Robotics",
+        "Sports",
+        "ParallelComputing",
+        "Amusement",
+        "Archiving",
+        "Compression",
+        "Electronics",
+        "Emulator",
+        "Engineering",
+        "FileTools",
+        "FileManager",
+        "TerminalEmulator",
+        "Filesystem",
+        "Monitor",
+        "Security",
+        "Accessibility",
+        "Calculator",
+        "Clock",
+        "TextEditor",
+        "Documentation",
+        "Core",
+        "KDE",
+        "GNOME",
+        "GTK",
+        "Qt",
+        "Motif",
+        "Java",
+        "ConsoleOnly"
+      ]
+    }
+  ]
+}

--- a/source/Nuke.GlobalTool/Nuke.GlobalTool.csproj
+++ b/source/Nuke.GlobalTool/Nuke.GlobalTool.csproj
@@ -14,10 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="matkoch.spectre.console" Version="0.46.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.10.0" />
+    <PackageReference Include="matkoch.spectre.console" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Nuke.GlobalTool/Program.Setup.cs
+++ b/source/Nuke.GlobalTool/Program.Setup.cs
@@ -245,7 +245,7 @@ partial class Program
     private static void WriteConfigurationFile(AbsolutePath rootDirectory, [CanBeNull] AbsolutePath solutionFile)
     {
         var parametersFile = GetDefaultParametersFile(rootDirectory);
-        var dictionary = new Dictionary<string, string> { ["$schema"] = $"./{BuildSchemaFileName}" };
+        var dictionary = new Dictionary<string, string> { ["$schema"] = BuildSchemaFileName };
         if (solutionFile != null)
             dictionary["Solution"] = rootDirectory.GetUnixRelativePathTo(solutionFile).ToString();
         parametersFile.WriteJson(dictionary);

--- a/source/Nuke.MSBuildTasks/Nuke.MSBuildTasks.csproj
+++ b/source/Nuke.MSBuildTasks/Nuke.MSBuildTasks.csproj
@@ -11,13 +11,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Packaging" Version="6.10.0" />
+    <PackageReference Include="NuGet.Packaging" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- MSBuild and dependencies only acquired through MSBuild shall not make it into the final package -->
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.10.4" CopyLocal="false" Publish="false" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.10.4" CopyLocal="false" Publish="false" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" CopyLocal="false" Publish="false" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" CopyLocal="false" Publish="false" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Nuke.ProjectModel.Tests/ProjectModelTest.cs
+++ b/source/Nuke.ProjectModel.Tests/ProjectModelTest.cs
@@ -29,6 +29,7 @@ public class ProjectModelTest
         project.GetTargetFrameworks().Should().Equal("net6.0", "net7.0", "net8.0");
         project.HasPackageReference("Microsoft.Build.Locator").Should().BeTrue();
         project.GetPackageReferenceVersion("Microsoft.Build.Locator").Should().Be("1.7.8");
+        project.GetPackageReferenceVersion("Microsoft.Build").Should().Be("17.10.4");
     }
 
     [Fact]
@@ -37,10 +38,10 @@ public class ProjectModelTest
         var solution = SolutionModelTasks.ParseSolution(SolutionFile);
         var project = solution.Projects.Single(x => x.Name == "Nuke.ProjectModel");
 
-        var msbuildProject = project.GetMSBuildProject(targetFramework: "net6.0");
+        var msbuildProject = project.GetMSBuildProject(targetFramework: "net8.0");
 
-        var package = msbuildProject.GetItems("PackageReference").FirstOrDefault(x => x.EvaluatedInclude == "Microsoft.Build");
+        var package = msbuildProject.GetItems("PackageVersion").FirstOrDefault(x => x.EvaluatedInclude == "Microsoft.Build");
         package.Should().NotBeNull();
-        package.GetMetadataValue("Version").Should().Be("16.9.0");
+        package.GetMetadataValue("Version").Should().Be("17.10.4");
     }
 }

--- a/source/Nuke.ProjectModel/Nuke.ProjectModel.csproj
+++ b/source/Nuke.ProjectModel/Nuke.ProjectModel.csproj
@@ -11,28 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Build" Version="17.9.5" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.9.5" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.9.5" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.9.5" ExcludeAssets="runtime" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="Microsoft.Build" Version="17.5.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.5.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.5.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.5.0" ExcludeAssets="runtime" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Build" Version="16.9.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.9.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="16.9.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" />
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.ProjectModel/Project.Misc.cs
+++ b/source/Nuke.ProjectModel/Project.Misc.cs
@@ -58,7 +58,10 @@ public static partial class ProjectExtensions
     /// </summary>
     public static string GetPackageReferenceVersion(this Project project, string packageId)
     {
-        return project.GetItemMetadataSingleOrDefault("PackageReference", packageId, "Version");
+        var version = project.GetItemMetadataSingleOrDefault("PackageReference", packageId, "Version");
+        return version == string.Empty
+            ? project.GetItemMetadataSingleOrDefault("PackageVersion", packageId, "Version")
+            : null;
     }
 
     [CanBeNull]

--- a/source/Nuke.SolutionModel/SolutionSerializer.cs
+++ b/source/Nuke.SolutionModel/SolutionSerializer.cs
@@ -88,6 +88,7 @@ internal static class SolutionSerializer
             .SkipWhile(x => !Regex.IsMatch(x, $@"^\s*GlobalSection\({name}\) = \w+$"))
             .Skip(count: 1)
             .TakeWhile(x => !Regex.IsMatch(x, @"^\s*EndGlobalSection$"))
+            .Where(x => !x.StartsWith("#"))
             .ToList();
 
         return sectionLines.Count == 0

--- a/source/Nuke.SourceGenerators.Tests/Nuke.SourceGenerators.Tests.csproj
+++ b/source/Nuke.SourceGenerators.Tests/Nuke.SourceGenerators.Tests.csproj
@@ -12,10 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0" />
-    <PackageReference Include="Verify.SourceGenerators" Version="2.2.0" />
-    <PackageReference Include="Basic.Reference.Assemblies.NetStandard20" Version="1.7.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="Verify.SourceGenerators" />
+    <PackageReference Include="Basic.Reference.Assemblies.NetStandard20" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.SourceGenerators/Nuke.SourceGenerators.csproj
+++ b/source/Nuke.SourceGenerators/Nuke.SourceGenerators.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.7.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="Newtonsoft.Json" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Nuke.Tooling.Generator/Nuke.Tooling.Generator.csproj
+++ b/source/Nuke.Tooling.Generator/Nuke.Tooling.Generator.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Humanizer" Version="2.14.1" />
-    <PackageReference Include="Serilog" Version="4.0.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="HtmlAgilityPack" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Humanizer" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="System.ComponentModel.Annotations" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Nuke.Tooling/NuGetPackageResolver.cs
+++ b/source/Nuke.Tooling/NuGetPackageResolver.cs
@@ -211,6 +211,7 @@ public static class NuGetPackageResolver
             // packages can contain false positives due to present/missing version specification
             .Where(x => x.Id.EqualsOrdinalIgnoreCase(packageId))
             .Where(x => !x.Version.IsPrerelease || !includePrereleases.HasValue || includePrereleases.Value)
+            .Distinct(x => x.Directory)
             .OrderByDescending(x => x.Version)
             .ToList();
 

--- a/source/Nuke.Tooling/Nuke.Tooling.csproj
+++ b/source/Nuke.Tooling/Nuke.Tooling.csproj
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NuGet.Packaging" Version="6.10.0" />
-    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="Serilog" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.Utilities.IO.Compression/Nuke.Utilities.IO.Compression.csproj
+++ b/source/Nuke.Utilities.IO.Compression/Nuke.Utilities.IO.Compression.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpZipLib" Version="1.4.2" />
+    <PackageReference Include="SharpZipLib" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.Utilities.IO.Globbing/Nuke.Utilities.IO.Globbing.csproj
+++ b/source/Nuke.Utilities.IO.Globbing/Nuke.Utilities.IO.Globbing.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Glob" Version="1.1.9"/>
+    <PackageReference Include="Glob" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.Utilities.Net/Nuke.Utilities.Net.csproj
+++ b/source/Nuke.Utilities.Net/Nuke.Utilities.Net.csproj
@@ -9,8 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.Utilities.Text.Json/Nuke.Utilities.Text.Json.csproj
+++ b/source/Nuke.Utilities.Text.Json/Nuke.Utilities.Text.Json.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.Utilities.Text.Yaml/Nuke.Utilities.Text.Yaml.csproj
+++ b/source/Nuke.Utilities.Text.Yaml/Nuke.Utilities.Text.Yaml.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="15.1.6" />
+    <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.Utilities/Nuke.Utilities.csproj
+++ b/source/Nuke.Utilities/Nuke.Utilities.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
+    <PackageReference Include="JetBrains.Annotations" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I want to use nuke.build with our on-prem agents. Unfortunately, I didn't find a solution to pass a pool name to be considered in the final yml file.

I saw that other people also had a similar problem: #1173, #749.

My proposition is to create an additional abstraction, AzurePipelinesPool, which can be either a Microsoft-hosted agent (vmImage) or a self-hosted agent, as that is essentially what a pool is in Azure Pipelines.

Here is a proposal for the changes, and I am open to suggestions. 
I also removed `images` parameters from `AzurePipelinesAttribute` because if you really need to run your targets on multiple vmImages, it's probably better to configure multiple `AzurePipelinesAttribute`, am I right?

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
