### PR TITLE
Make JetBrains.Annotations a private reference

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -53,6 +53,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
     <PackageReference Include="linqtotwitter" Version="6.15.0" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.0.1" />
     <PackageDownload Include="Codecov.Tool" Version="[1.13.0]" />

--- a/source/Nuke.Build.Shared/Nuke.Build.Shared.csproj
+++ b/source/Nuke.Build.Shared/Nuke.Build.Shared.csproj
@@ -9,7 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.Build.Tests/Nuke.Build.Tests.csproj
+++ b/source/Nuke.Build.Tests/Nuke.Build.Tests.csproj
@@ -8,4 +8,8 @@
     <ProjectReference Include="..\Nuke.Build\Nuke.Build.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" />
+  </ItemGroup>
+
 </Project>

--- a/source/Nuke.Build/Nuke.Build.csproj
+++ b/source/Nuke.Build/Nuke.Build.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
     <PackageReference Include="Microsoft.ApplicationInsights" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" />
     <PackageReference Include="NJsonSchema" />

--- a/source/Nuke.Common.Tests/Nuke.Common.Tests.csproj
+++ b/source/Nuke.Common.Tests/Nuke.Common.Tests.csproj
@@ -8,4 +8,8 @@
     <ProjectReference Include="..\Nuke.Common\Nuke.Common.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" />
+  </ItemGroup>
+
 </Project>

--- a/source/Nuke.Common/Nuke.Common.csproj
+++ b/source/Nuke.Common/Nuke.Common.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Certificates" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
     <PackageReference Include="Octokit" />
   </ItemGroup>
 

--- a/source/Nuke.Components/Nuke.Components.csproj
+++ b/source/Nuke.Components/Nuke.Components.csproj
@@ -8,4 +8,8 @@
     <ProjectReference Include="..\Nuke.Common\Nuke.Common.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/source/Nuke.GlobalTool/Nuke.GlobalTool.csproj
+++ b/source/Nuke.GlobalTool/Nuke.GlobalTool.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
     <PackageReference Include="matkoch.spectre.console" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />

--- a/source/Nuke.MSBuildTasks/Nuke.MSBuildTasks.csproj
+++ b/source/Nuke.MSBuildTasks/Nuke.MSBuildTasks.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
     <PackageReference Include="NuGet.Packaging" />
   </ItemGroup>
 

--- a/source/Nuke.ProjectModel/Nuke.ProjectModel.csproj
+++ b/source/Nuke.ProjectModel/Nuke.ProjectModel.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />

--- a/source/Nuke.SolutionModel/Nuke.SolutionModel.csproj
+++ b/source/Nuke.SolutionModel/Nuke.SolutionModel.csproj
@@ -8,4 +8,8 @@
     <ProjectReference Include="..\Nuke.Utilities\Nuke.Utilities.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/source/Nuke.SourceGenerators/Nuke.SourceGenerators.csproj
+++ b/source/Nuke.SourceGenerators/Nuke.SourceGenerators.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.7.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" PrivateAssets="all" GeneratePathProperty="true" />

--- a/source/Nuke.Tooling.Generator/Nuke.Tooling.Generator.csproj
+++ b/source/Nuke.Tooling.Generator/Nuke.Tooling.Generator.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" />
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Humanizer" />
     <PackageReference Include="Serilog" />

--- a/source/Nuke.Tooling/Nuke.Tooling.csproj
+++ b/source/Nuke.Tooling/Nuke.Tooling.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="Serilog" />

--- a/source/Nuke.Utilities.IO.Compression/Nuke.Utilities.IO.Compression.csproj
+++ b/source/Nuke.Utilities.IO.Compression/Nuke.Utilities.IO.Compression.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
     <PackageReference Include="SharpZipLib" />
   </ItemGroup>
 

--- a/source/Nuke.Utilities.IO.Globbing/Nuke.Utilities.IO.Globbing.csproj
+++ b/source/Nuke.Utilities.IO.Globbing/Nuke.Utilities.IO.Globbing.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Glob" />
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.Utilities.Net/Nuke.Utilities.Net.csproj
+++ b/source/Nuke.Utilities.Net/Nuke.Utilities.Net.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/source/Nuke.Utilities.Tests/Nuke.Utilities.Tests.csproj
+++ b/source/Nuke.Utilities.Tests/Nuke.Utilities.Tests.csproj
@@ -12,4 +12,8 @@
     <ProjectReference Include="..\Nuke.Utilities.Text.Yaml\Nuke.Utilities.Text.Yaml.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/source/Nuke.Utilities.Text.Json/Nuke.Utilities.Text.Json.csproj
+++ b/source/Nuke.Utilities.Text.Json/Nuke.Utilities.Text.Json.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/source/Nuke.Utilities.Text.Yaml/Nuke.Utilities.Text.Yaml.csproj
+++ b/source/Nuke.Utilities.Text.Yaml/Nuke.Utilities.Text.Yaml.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
     <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 

--- a/source/Nuke.Utilities/Nuke.Utilities.csproj
+++ b/source/Nuke.Utilities/Nuke.Utilities.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" />
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is a bit of a vanity change. Removes JetBrains.Annotations as a true dependency and also only refers to STJ if doesn't come in the box on the target platform. Basically cleans up dependency tree a bit with some csproj noise. Can totally understand if not wanted.

So basically these will go away

![image](https://github.com/user-attachments/assets/3955045a-4519-46c4-9fba-344bf11a8e50)


I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
