### PR TITLE
feat(execution): Add flexible build execution methods and options

### DIFF
--- a/source/Nuke.Build/ExecuteOptions.cs
+++ b/source/Nuke.Build/ExecuteOptions.cs
@@ -1,0 +1,16 @@
+﻿// Copyright 2023 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+namespace Nuke.Common;
+
+/// <summary>
+/// Options for the execution of a build.
+/// </summary>
+public class ExecuteOptions
+{
+    /// <summary>
+    /// Disable default log configuration
+    /// </summary>
+    public bool DisableDefaultLogConfiguration { get; set; }
+}

--- a/source/Nuke.Build/NukeBuild.cs
+++ b/source/Nuke.Build/NukeBuild.cs
@@ -72,10 +72,28 @@ public abstract partial class NukeBuild : INukeBuild
     /// Executes the build. The provided expression defines the <em>default</em> target that is invoked,
     /// if no targets have been specified via command-line arguments.
     /// </summary>
+    /// <param name="defaultTargetExpressions">The default target expressions</param>
+    /// <returns>Built exit code</returns>
     protected static int Execute<T>(params Expression<Func<T, Target>>[] defaultTargetExpressions)
         where T : NukeBuild, new()
     {
         return BuildManager.Execute(defaultTargetExpressions);
+    }
+
+    /// <summary>
+    /// Executes the build. The provided expression defines the <em>default</em> target that is invoked,
+    /// if no targets have been specified via command-line arguments.
+    /// </summary>
+    /// <param name="executeOptions">The options for the execution of the build.</param>
+    /// <param name="defaultTargetExpressions">The default target expressions</param>
+    /// <returns>Built exit code</returns>
+    protected static int ExecuteWithOptions<T>(
+        ExecuteOptions executeOptions,
+        params Expression<Func<T, Target>>[] defaultTargetExpressions
+    )
+        where T : NukeBuild, new()
+    {
+        return BuildManager.ExecuteWithOptions(executeOptions, defaultTargetExpressions);
     }
 
     internal IReadOnlyCollection<ExecutableTarget> ExecutableTargets { get; set; }


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
# A Big Thank You for a Great Product
First and foremost, I want to express my gratitude for creating such a fantastic tool. It has been invaluable in our build processes, and the flexibility it offers is truly appreciated.

<!-- Please describe what you did below this line -->

# Description of the Issue:
While running multiple build types, I encountered an issue with the following exception:
`The process cannot access the file '...\.nuke\temp\build.log' because it is being used by another process.`

Upon investigation, I found that in the `DeleteOldLogFiles` method, the second call to `filestream.SetLength(0);` triggers this exception. This happens because the log file remains locked even after calling `Log.CloseAndFlush();` in the preceding step.

# Solution:
To address this issue, I introduced a new approach that allows for more flexible log configuration during build execution. Specifically:

# New Method:

Added `ExecuteWithOptions<T>` methods in both `BuildManager` and `NukeBuild`.
These methods allow for optional execution parameters to be specified, including whether or not the log should be configured.

# New Class:

Introduced an `ExecuteOptions` class to manage these execution parameters.
This class includes an option to disable the default log configuration, preventing the aforementioned file lock issue.

# Logging Configuration:

Updated `BuildManager` to conditionally configure logging based on the provided `ExecuteOptions`.
This solution ensures that build execution can proceed without file locking issues while providing more control over logging behavior.

<!-- Make sure to tick all the boxes if possible -->

# I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
