### PR TITLE
Also detect Unity version from project when running UnityTasks.UnityRunTests

### DIFF
--- a/build/Build.Announce.cs
+++ b/build/Build.Announce.cs
@@ -71,11 +71,9 @@ partial class Build
     }
 
     IEnumerable<(string Text, string Url)> AnnouncementSponsors =>
-        new (string Text, string Url)[]
-        {
-            ("Octopus Deploy", "https://octopus.com/"),
-            ("Amazon Web Services", "https://aws.amazon.com/"),
-        };
+    [
+        ("Octopus Deploy", "https://octopus.com/")
+    ];
 
     // https://api.slack.com/apps/A050ZLH0V40/incoming-webhooks?
     [Parameter] [Secret] readonly string SlackWebhook;

--- a/docs/02-fundamentals/05-targets.md
+++ b/docs/02-fundamentals/05-targets.md
@@ -207,7 +207,7 @@ class Build : NukeBuild
         // highlight-start
         .OnlyWhenDynamic(() => Data.Any())
         // highlight-end
-        .Execute(() => { });
+        .Executes(() => { });
 }
 ```
 
@@ -229,7 +229,7 @@ class Build : NukeBuild
         .WhenSkipped(DependencyBehavior.Execute)
         // highlight-end
         .DependsOn(A)
-        .Execute(() => { });
+        .Executes(() => { });
 }
 ```
 
@@ -286,7 +286,7 @@ class Build : NukeBuild
 
     Target B => _ => _
         .DependsOn(A)
-        .Execute(() => { });
+        .Executes(() => { });
 }
 ```
 
@@ -309,7 +309,7 @@ class Build : NukeBuild
         .AssuredAfterFailure()
         // highlight-end
         .DependsOn(A)
-        .Execute(() => { });
+        .Executes(() => { });
 }
 ```
 

--- a/docs/03-common/07-solution-project-model.md
+++ b/docs/03-common/07-solution-project-model.md
@@ -34,7 +34,7 @@ With an instance of the `Solution` type you can **read and write the solution** 
 ```csharp
 // Gather projects
 var globalToolProject = Solution.GetProject("Nuke.GlobalTool");
-var testProjects = Solution.GetProjects("*.Tests");
+var testProjects = Solution.GetAllProjects("*.Tests");
 
 // Gather all solution items
 var allItems = Solution.AllSolutionFolders.SelectMany(x => x.Items);

--- a/source/Nuke.Common/Tools/EntityFramework/EntityFramework.json
+++ b/source/Nuke.Common/Tools/EntityFramework/EntityFramework.json
@@ -10,9 +10,9 @@
   "customExecutable": true,
   "tasks": [
     {
-      "help": "The <c>dotnet ef database drop</c> command is used to drop the database.",
+      "help": "The <c>dotnet-ef database drop</c> command is used to drop the database.",
       "postfix": "DatabaseDrop",
-      "definiteArgument": "ef database drop",
+      "definiteArgument": "database drop",
       "settingsClass": {
         "baseClass": "EntityFrameworkSettings",
         "properties": [
@@ -32,9 +32,9 @@
       }
     },
     {
-      "help": "The <c>dotnet ef database update</c> command is used to update the database to the last migration or to a specified migration.",
+      "help": "The <c>dotnet-ef database update</c> command is used to update the database to the last migration or to a specified migration.",
       "postfix": "DatabaseUpdate",
-      "definiteArgument": "ef database update",
+      "definiteArgument": "database update",
       "settingsClass": {
         "baseClass": "EntityFrameworkSettings",
         "properties": [
@@ -54,23 +54,23 @@
       }
     },
     {
-      "help": "The <c>dotnet ef dbcontext info</c> command is used to get information about a <c>DbContext</c> type.",
+      "help": "The <c>dotnet-ef dbcontext info</c> command is used to get information about a <c>DbContext</c> type.",
       "postfix": "DbContextInfo",
-      "definiteArgument": "ef dbcontext info",
+      "definiteArgument": "dbcontext info",
       "settingsClass": {
         "baseClass": "EntityFrameworkSettings"
       }
     },
     {
-      "help": "The <c>dotnet ef dbcontext list</c> command is used to list available <c>DbContext</c> types.",
+      "help": "The <c>dotnet-ef dbcontext list</c> command is used to list available <c>DbContext</c> types.",
       "postfix": "DbContextList",
-      "definiteArgument": "ef dbcontext list",
+      "definiteArgument": "dbcontext list",
       "settingsClass": {
         "baseClass": "EntityFrameworkSettings"
       }
     },
     {
-      "help": "The <c>dotnet ef dbcontext scaffold</c> command is used to generate code for a <c>DbContext</c> and entity types for a database. In order for this command to generate an entity type, the database table must have a primary key.",
+      "help": "The <c>dotnet-ef dbcontext scaffold</c> command is used to generate code for a <c>DbContext</c> and entity types for a database. In order for this command to generate an entity type, the database table must have a primary key.",
       "postfix": "DbContextScaffold",
       "definiteArgument": "ef dbcontext scaffold",
       "settingsClass": {
@@ -164,9 +164,9 @@
       }
     },
     {
-      "help": "The <c>dotnet ef dbcontext script</c> command is used to generate a SQL script from the <c>DbContext</c>, bypassing any migrations.",
+      "help": "The <c>dotnet-ef dbcontext script</c> command is used to generate a SQL script from the <c>DbContext</c>, bypassing any migrations.",
       "postfix": "DbContextScript",
-      "definiteArgument": "ef dbcontext script",
+      "definiteArgument": "dbcontext script",
       "settingsClass": {
         "baseClass": "EntityFrameworkSettings",
         "properties": [
@@ -180,9 +180,9 @@
       }
     },
     {
-      "help": "The <c>dotnet ef migrations add</c> command is used to add a new migration.",
+      "help": "The <c>dotnet-ef migrations add</c> command is used to add a new migration.",
       "postfix": "MigrationsAdd",
-      "definiteArgument": "ef migrations add",
+      "definiteArgument": "migrations add",
       "settingsClass": {
         "baseClass": "EntityFrameworkSettings",
         "properties": [
@@ -208,9 +208,9 @@
       }
     },
     {
-      "help": "The <c>dotnet ef migrations list</c> command is used to list available migrations.",
+      "help": "The <c>dotnet-ef migrations list</c> command is used to list available migrations.",
       "postfix": "MigrationsList",
-      "definiteArgument": "ef migrations list",
+      "definiteArgument": "migrations list",
       "settingsClass": {
         "baseClass": "EntityFrameworkSettings",
         "properties": [
@@ -230,9 +230,9 @@
       }
     },
     {
-      "help": "The <c>dotnet ef migrations remove</c> command is used to remove the last migration (rolls back the code changes that were done for the migration).",
+      "help": "The <c>dotnet-ef migrations remove</c> command is used to remove the last migration (rolls back the code changes that were done for the migration).",
       "postfix": "MigrationsRemove",
-      "definiteArgument": "ef migrations remove",
+      "definiteArgument": "migrations remove",
       "settingsClass": {
         "baseClass": "EntityFrameworkSettings",
         "properties": [
@@ -246,9 +246,9 @@
       }
     },
     {
-      "help": "The <c>dotnet ef migrations bundle</c> command is used to create a bundle.",
+      "help": "The <c>dotnet-ef migrations bundle</c> command is used to create a bundle.",
       "postfix": "MigrationsBundle",
-      "definiteArgument": "ef migrations bundle",
+      "definiteArgument": "migrations bundle",
       "settingsClass": {
         "baseClass": "EntityFrameworkSettings",
         "properties": [
@@ -280,9 +280,9 @@
       }
     },
     {
-      "help": "The <c>dotnet ef migrations script</c> command is used to generate a SQL script from migrations.",
+      "help": "The <c>dotnet-ef migrations script</c> command is used to generate a SQL script from migrations.",
       "postfix": "MigrationsScript",
-      "definiteArgument": "ef migrations script",
+      "definiteArgument": "migrations script",
       "settingsClass": {
         "baseClass": "EntityFrameworkSettings",
         "properties": [

--- a/source/Nuke.Common/Tools/Unity/UnityTasks.cs
+++ b/source/Nuke.Common/Tools/Unity/UnityTasks.cs
@@ -64,14 +64,26 @@ public partial class UnityTasks
 
     private static void PreProcess(ref UnitySettings unitySettings)
     {
+        var projectSettings = (UnityProjectSettings)unitySettings;
+        PreProcessWithAutoDetect(ref projectSettings);
+    }
+
+    private static void PreProcess(ref UnityRunTestsSettings unitySettings)
+    {
+        var projectSettings = (UnityProjectSettings)unitySettings;
+        PreProcessWithAutoDetect(ref projectSettings);
+    }
+
+    private static void PreProcessWithAutoDetect(ref UnityProjectSettings unitySettings)
+    {
         if (unitySettings.ProjectPath == null)
             Log.Warning("ProjectPath is not set, using last opened/built project");
 
         DetectUnityVersion(ref unitySettings);
-        PreProcess<UnitySettings>(ref unitySettings);
+        PreProcess(ref unitySettings);
     }
 
-    private static void DetectUnityVersion(ref UnitySettings unitySettings)
+    private static void DetectUnityVersion(ref UnityProjectSettings unitySettings)
     {
         if (unitySettings.HubVersion != null ||
             unitySettings.ProjectPath == null)


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

This implements issue #1427.

With this change, the Unity version is detected from the project, not only when using UnityTasks.Unity, but also when using UnityTasks.UnityRunTests.

The generic PreProcess method on line 111 also handles Unity runs that don't directly relate to a project (e.g. license activation). However, for the tasks which deal with projects, we want them to auto-detect the Unity editor version from the project. Previously this was only implemented when starting the general UnityTasks.Unity method, but now it's also used when running tests.

I have tested my changes in the attached repro project of the linked issue.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
