### PR TITLE
feat: Add Interactive mode with target selection

### DIFF
--- a/build/AwtrixNotificationsAttribute.cs
+++ b/build/AwtrixNotificationsAttribute.cs
@@ -1,0 +1,107 @@
+﻿// Copyright 2024 Maintainers of NUKE.
+// Distributed under the MIT License.
+// https://github.com/nuke-build/nuke/blob/master/LICENSE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using JetBrains.Annotations;
+using MQTTnet;
+using MQTTnet.Client;
+using MQTTnet.Protocol;
+using Newtonsoft.Json;
+using Nuke.Common;
+using Nuke.Common.Execution;
+
+[PublicAPI]
+public class AwtrixNotificationsAttribute : BuildExtensionAttributeBase,
+    IOnBuildCreated,
+    IOnTargetRunning,
+    IOnBuildFinished
+{
+    private readonly IMqttClient _mqttClient;
+
+    public string MqttHost => EnvironmentInfo.GetVariable("NUKE_AWTRIX_MQTT_HOST");
+    public int? MqttPort => EnvironmentInfo.GetVariable<int?>("NUKE_AWTRIX_MQTT_PORT").NotNull();
+    public string MqttTopicPrefix => EnvironmentInfo.GetVariable("NUKE_AWTRIX_MQTT_PREFIX").NotNullOrWhiteSpace();
+
+    public AwtrixNotificationsAttribute()
+    {
+        if (MqttHost == null)
+            return;
+
+        _mqttClient = new MqttFactory().CreateMqttClient();
+        _mqttClient.ConnectAsync(new MqttClientOptionsBuilder()
+                .WithTcpServer(MqttHost, MqttPort)
+                .Build(),
+            CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    public int RunningIconId { get; set; } = 13546;
+    public int SuccessIconId { get; set; } = 39396;
+    public int FailureIconId { get; set; } = 8510;
+    public string ProjectName { get; set; } = "Build";
+
+    protected virtual object CreateBuildCreatedPayload()
+    {
+        return new
+               {
+                   icon = RunningIconId,
+                   text = ProjectName,
+                   hold = true,
+                   stack = false,
+               };
+    }
+
+    protected virtual object CreateTargetRunningPayload(ExecutableTarget target)
+    {
+        var progress = (Build.SucceededTargets.Count + Build.FailedTargets.Count) / (double)Build.ExecutionPlan.Count * 100;
+        return new
+               {
+                   icon = RunningIconId,
+                   text = target.Name,
+                   progress,
+                   progressC = Build.IsSucceeding ? "#00ff00" : "#ff0000",
+                   progressBC = "#333333",
+                   hold = true,
+                   stack = false,
+               };
+    }
+
+    protected virtual object CreateBuildFinishedPayload()
+    {
+        return new
+               {
+                   icon = Build.IsSucceeding ? SuccessIconId : FailureIconId,
+                   text = ProjectName,
+                   hold = !Build.IsSucceeding,
+                   stack = false,
+               };
+    }
+
+    public void OnBuildCreated(IReadOnlyCollection<ExecutableTarget> executableTargets)
+    {
+        PublishMqttMessage(CreateBuildCreatedPayload());
+    }
+
+    public void OnTargetRunning(ExecutableTarget target)
+    {
+        PublishMqttMessage(CreateTargetRunningPayload(target));
+    }
+
+    public void OnBuildFinished()
+    {
+        PublishMqttMessage(CreateBuildFinishedPayload());
+    }
+
+    private void PublishMqttMessage(object payload)
+    {
+        _mqttClient?.PublishAsync(new MqttApplicationMessageBuilder()
+                .WithTopic($"{MqttTopicPrefix}/notify")
+                .WithPayload(JsonConvert.SerializeObject(payload))
+                .WithQualityOfServiceLevel(MqttQualityOfServiceLevel.ExactlyOnce)
+                .Build(),
+            CancellationToken.None).GetAwaiter().GetResult();
+    }
+}

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -54,6 +54,7 @@
 
   <ItemGroup>
     <PackageReference Include="linqtotwitter" Version="6.15.0" />
+    <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.0.1" />
     <PackageDownload Include="Codecov.Tool" Version="[1.13.0]" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.12.0]" />

--- a/source/Nuke.Build.Tests/ExecutionPlannerTest.cs
+++ b/source/Nuke.Build.Tests/ExecutionPlannerTest.cs
@@ -96,9 +96,7 @@ public class ExecutionPlannerTest
 
     private IEnumerable<ExecutableTarget> GetPlan(ExecutableTarget[] invokedTargets = null)
     {
-        static string[] SelectNames(ExecutableTarget[] targets) => targets?.Select(x => x.Name).ToArray();
-
-        return ExecutionPlanner.GetExecutionPlan(new[] { A, B, C }, SelectNames(invokedTargets));
+        return ExecutionPlanner.GetExecutionPlan(new[] { A, B, C }, invokedTargets);
     }
 
     private void AddTrigger(ExecutableTarget source, ExecutableTarget target)

--- a/source/Nuke.Build.Tests/SchemaUtilityTest.TestCustomParameterAttributeAttribute.verified.json
+++ b/source/Nuke.Build.Tests/SchemaUtilityTest.TestCustomParameterAttributeAttribute.verified.json
@@ -42,6 +42,10 @@
           "description": "Host for execution. Default is 'automatic'",
           "$ref": "#/definitions/Host"
         },
+        "Interactive": {
+          "type": "boolean",
+          "description": "Activates the interactive mode when asking for user inputs"
+        },
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"

--- a/source/Nuke.Build.Tests/SchemaUtilityTest.TestEmptyBuild.verified.json
+++ b/source/Nuke.Build.Tests/SchemaUtilityTest.TestEmptyBuild.verified.json
@@ -37,6 +37,10 @@
           "description": "Host for execution. Default is 'automatic'",
           "$ref": "#/definitions/Host"
         },
+        "Interactive": {
+          "type": "boolean",
+          "description": "Activates the interactive mode when asking for user inputs"
+        },        
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"

--- a/source/Nuke.Build.Tests/SchemaUtilityTest.TestParameterBuild.verified.json
+++ b/source/Nuke.Build.Tests/SchemaUtilityTest.TestParameterBuild.verified.json
@@ -142,6 +142,10 @@
           "description": "Host for execution. Default is 'automatic'",
           "$ref": "#/definitions/Host"
         },
+        "Interactive": {
+          "type": "boolean",
+          "description": "Activates the interactive mode when asking for user inputs"
+        },        
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"

--- a/source/Nuke.Build.Tests/SchemaUtilityTest.TestTargetBuild.verified.json
+++ b/source/Nuke.Build.Tests/SchemaUtilityTest.TestTargetBuild.verified.json
@@ -43,6 +43,10 @@
           "description": "Host for execution. Default is 'automatic'",
           "$ref": "#/definitions/Host"
         },
+        "Interactive": {
+          "type": "boolean",
+          "description": "Activates the interactive mode when asking for user inputs"
+        },        
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"

--- a/source/Nuke.Build/CICD/ChainedConfigurationAttributeBase.cs
+++ b/source/Nuke.Build/CICD/ChainedConfigurationAttributeBase.cs
@@ -35,7 +35,7 @@ public abstract class ChainedConfigurationAttributeBase : ConfigurationAttribute
 
         Assert.True(invokedTargets.Except(new[] { executableTarget }).Count(x => x.PartitionSize != null) == 0,
             $"Non-entry targets for {executableTarget.Name} cannot define partitions");
-        return ExecutionPlanner.GetExecutionPlan(invokedTargets, new[] { executableTarget.Name });
+        return ExecutionPlanner.GetExecutionPlan(invokedTargets, new[] { executableTarget });
     }
 
     protected IEnumerable<ExecutableTarget> GetTargetDependencies(ExecutableTarget executableTarget)

--- a/source/Nuke.Build/CICD/ConfigurationAttributeBase.cs
+++ b/source/Nuke.Build/CICD/ConfigurationAttributeBase.cs
@@ -44,7 +44,7 @@ public abstract class ConfigurationAttributeBase : Attribute, IConfigurationGene
     public void Generate(IReadOnlyCollection<ExecutableTarget> executableTargets)
     {
         var relevantTargets = RelevantTargetNames
-            .SelectMany(x => ExecutionPlanner.GetExecutionPlan(executableTargets, new[] { x }))
+            .SelectMany(x => ExecutionPlanner.GetExecutionPlan(executableTargets, new[] { ExecutableTargetFactory.GetExecutableTarget(x, executableTargets) }))
             .Distinct()
             .Where(x => !IrrelevantTargetNames.Contains(x.Name)).ToList();
         var configuration = GetConfiguration(relevantTargets);

--- a/source/Nuke.Build/Execution/BuildManager.cs
+++ b/source/Nuke.Build/Execution/BuildManager.cs
@@ -75,7 +75,7 @@ internal static class BuildManager
                 build,
                 ParameterService.GetParameter<string[]>(() => build.SkippedTargets));
 
-            return build.ExitCode ??= build.IsSuccessful ? 0 : ErrorExitCode;
+            return build.ExitCode ??= build.IsSucceeding ? 0 : ErrorExitCode;
         }
         catch (Exception exception)
         {

--- a/source/Nuke.Build/Execution/BuildManager.cs
+++ b/source/Nuke.Build/Execution/BuildManager.cs
@@ -62,10 +62,10 @@ internal static class BuildManager
             if (!build.NoLogo)
                 build.WriteLogo();
 
-            // TODO: move InvokedTargets to ExecutableTargetFactory
+            var invokedTargets = ExecutableTargetFactory.CollectInvokedTargets(build);
             build.ExecutionPlan = ExecutionPlanner.GetExecutionPlan(
                 build.ExecutableTargets,
-                ParameterService.GetParameter<string[]>(() => build.InvokedTargets));
+                invokedTargets);
 
             ToolRequirementService.EnsureToolRequirements(build, build.ExecutionPlan);
             build.ExecuteExtension<IOnBuildInitialized>(x => x.OnBuildInitialized(build.ExecutableTargets, build.ExecutionPlan));

--- a/source/Nuke.Build/Execution/ExecutionPlanner.cs
+++ b/source/Nuke.Build/Execution/ExecutionPlanner.cs
@@ -19,9 +19,8 @@ internal static class ExecutionPlanner
 {
     public static IReadOnlyCollection<ExecutableTarget> GetExecutionPlan(
         IReadOnlyCollection<ExecutableTarget> executableTargets,
-        [CanBeNull] IReadOnlyCollection<string> invokedTargetNames)
+        [CanBeNull] IReadOnlyCollection<ExecutableTarget> invokedTargets)
     {
-        var invokedTargets = invokedTargetNames?.Select(x => GetExecutableTarget(x, executableTargets)).ToList();
         invokedTargets?.ForEach(x => x.Invoked = true);
 
         // Repeat to create the plan with triggers taken into account until plan doesn't change
@@ -42,7 +41,7 @@ internal static class ExecutionPlanner
 
     private static IReadOnlyCollection<ExecutableTarget> GetExecutionPlanInternal(
         IReadOnlyCollection<ExecutableTarget> executableTargets,
-        ICollection<ExecutableTarget> invokedTargets)
+        IReadOnlyCollection<ExecutableTarget> invokedTargets)
     {
         var vertexDictionary = GetVertexDictionary(executableTargets);
         var graphAsList = vertexDictionary.Values.ToList();
@@ -94,21 +93,5 @@ internal static class ExecutionPlanner
             vertex.Dependencies.AddRange(executable.AllDependencies.Select(x => vertexDictionary.GetValueOrDefault(x)).WhereNotNull());
 
         return vertexDictionary;
-    }
-
-    private static ExecutableTarget GetExecutableTarget(
-        string targetName,
-        IReadOnlyCollection<ExecutableTarget> executableTargets)
-    {
-        targetName = targetName.Replace("-", string.Empty);
-        var executableTarget = executableTargets.SingleOrDefault(x => x.Name.EqualsOrdinalIgnoreCase(targetName));
-        if (executableTarget == null)
-        {
-            Assert.Fail($"Target with name {targetName.SingleQuote()} does not exist. Available targets are:"
-                .Concat(executableTargets.Select(x => $"  - {x.Name}").OrderBy(x => x))
-                .JoinNewLine());
-        }
-
-        return executableTarget;
     }
 }

--- a/source/Nuke.Build/Execution/Extensions/HandleHelpRequestsAttribute.cs
+++ b/source/Nuke.Build/Execution/Extensions/HandleHelpRequestsAttribute.cs
@@ -36,16 +36,29 @@ internal class HandleHelpRequestsAttribute : BuildExtensionAttributeBase, IOnBui
         builder.AppendLine();
         foreach (var target in Build.ExecutableTargets.Where(x => x.Listed))
         {
-            var dependencies = target.ExecutionDependencies.Count > 0
-                ? $" -> {target.ExecutionDependencies.Select(x => x.Name).JoinCommaSpace()}"
-                : string.Empty;
-            var targetEntry = target.Name + (target.IsDefault ? " (default)" : string.Empty);
-            builder.AppendLine($"  {targetEntry.PadRight(padRightTargets)}{dependencies}");
-            if (!string.IsNullOrWhiteSpace(target.Description))
-                builder.AppendLine($"    {target.Description}");
+            AppendTargetText(builder, target, 
+                "  ",
+                "    ",
+                padRightTargets);
         }
 
         return builder.ToString();
+    }
+
+    internal static void AppendTargetText(StringBuilder builder, ExecutableTarget target, 
+        string targetIndent,
+        string descriptionIndent,
+        int padRightTargets)
+    {
+        var dependencies = target.ExecutionDependencies.Count > 0
+            ? $" -> {target.ExecutionDependencies.Select(x => x.Name).JoinCommaSpace()}"
+            : string.Empty;
+        var targetEntry = target.Name + (target.IsDefault ? " (default)" : string.Empty);
+        builder.AppendLine($"{targetIndent}{targetEntry.PadRight(padRightTargets)}{dependencies}");
+        if (!string.IsNullOrWhiteSpace(target.Description))
+        {
+            builder.AppendLine($"{descriptionIndent}{target.Description}");
+        }
     }
 
     public string GetParametersText()

--- a/source/Nuke.Build/Execution/Extensions/HandlePlanRequestsAttribute.cs
+++ b/source/Nuke.Build/Execution/Extensions/HandlePlanRequestsAttribute.cs
@@ -84,13 +84,13 @@ internal class HandlePlanRequestsAttribute : BuildExtensionAttributeBase, IOnBui
 
         // When not hovering anything, highlight the default plan
         var defaultPlan = executableTargets.Where(x => x.IsDefault)
-            .SelectMany(x => ExecutionPlanner.GetExecutionPlan(executableTargets, new[] { x.Name }))
+            .SelectMany(x => ExecutionPlanner.GetExecutionPlan(executableTargets, new[] { x }))
             .Distinct().ToList();
         defaultPlan.ForEach(x => builder.AppendLine($@"  $(""#{x.Name}"").addClass('highlight');"));
 
         foreach (var executableTarget in executableTargets)
         {
-            var executionPlan = ExecutionPlanner.GetExecutionPlan(executableTargets, new[] { executableTarget.Name });
+            var executionPlan = ExecutionPlanner.GetExecutionPlan(executableTargets, new[] { executableTarget });
             builder
                 .AppendLine($@"  $(""#{executableTarget.Name}"").hover(")
                 .AppendLine("    function() {");

--- a/source/Nuke.Build/Host.cs
+++ b/source/Nuke.Build/Host.cs
@@ -163,7 +163,7 @@ public partial class Host
     protected internal virtual void WriteBuildOutcome(INukeBuild build)
     {
         Debug();
-        if (build.IsSuccessful)
+        if (build.IsSucceeding)
             Success($"Build succeeded on {DateTime.Now.ToString(CultureInfo.CurrentCulture)}. ＼（＾ᴗ＾）／");
         else
             Error($"Build failed on {DateTime.Now.ToString(CultureInfo.CurrentCulture)}. (╯°□°）╯︵ ┻━┻");

--- a/source/Nuke.Build/INukeBuild.cs
+++ b/source/Nuke.Build/INukeBuild.cs
@@ -35,7 +35,7 @@ public interface INukeBuild
     IReadOnlyCollection<ExecutableTarget> SucceededTargets { get; }
     IReadOnlyCollection<ExecutableTarget> FinishedTargets { get; }
 
-    bool IsSuccessful { get; }
+    bool IsSucceeding { get; }
     bool IsFailing { get; }
     bool IsFinished { get; }
     int? ExitCode { get; set; }

--- a/source/Nuke.Build/INukeBuild.cs
+++ b/source/Nuke.Build/INukeBuild.cs
@@ -19,7 +19,7 @@ public interface INukeBuild
 {
     void ReportSummary(Configure<Dictionary<string, string>> configurator = null);
 
-    internal IReadOnlyCollection<ExecutableTarget> ExecutableTargets { get; }
+    IReadOnlyCollection<ExecutableTarget> ExecutableTargets { get; }
     internal IReadOnlyCollection<IBuildExtension> BuildExtensions { get; }
     internal bool IsInterceptorExecution { get; }
     internal string[] LoadedLocalProfiles { get; }
@@ -52,6 +52,7 @@ public interface INukeBuild
     bool Plan { get; }
     bool Help { get; }
     bool NoLogo { get; }
+    bool Interactive { get; }
     bool IsLocalBuild { get; }
     bool IsServerBuild { get; }
     bool Continue { get; }
@@ -62,4 +63,7 @@ public interface INukeBuild
 
     [CanBeNull]
     public T TryGetValue<T>(Expression<Func<object>> parameterExpression);
+
+    [CanBeNull]
+    IReadOnlyCollection<ExecutableTarget> OnNoTargetsSpecified();
 }

--- a/source/Nuke.Build/Nuke.Build.csproj
+++ b/source/Nuke.Build/Nuke.Build.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Serilog.Formatting.Compact.Reader" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="matkoch.spectre.console" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Nuke.Build/NukeBuild.Interface.cs
+++ b/source/Nuke.Build/NukeBuild.Interface.cs
@@ -29,6 +29,7 @@ public abstract partial class NukeBuild
     bool INukeBuild.Plan => Plan;
     bool INukeBuild.Help => Help;
     bool INukeBuild.NoLogo => NoLogo;
+    bool INukeBuild.Interactive => Interactive;
     bool INukeBuild.IsLocalBuild => IsLocalBuild;
     bool INukeBuild.IsServerBuild => IsServerBuild;
     bool INukeBuild.Continue => Continue;

--- a/source/Nuke.Build/NukeBuild.cs
+++ b/source/Nuke.Build/NukeBuild.cs
@@ -184,7 +184,7 @@ public abstract partial class NukeBuild : INukeBuild
     internal IEnumerable<string> TargetNames => ExecutableTargetFactory.GetTargetProperties(GetType()).Select(x => x.GetDisplayShortName());
     internal IEnumerable<string> HostNames => Host.AvailableTypes.Select(x => x.Name);
 
-    public bool IsSuccessful => ExecutionPlan.All(x => x.Status is
+    public bool IsSucceeding => ExecutionPlan.All(x => x.Status is
         ExecutionStatus.Succeeded or
         ExecutionStatus.Skipped or
         ExecutionStatus.Collective);

--- a/source/Nuke.Build/NukeBuild.cs
+++ b/source/Nuke.Build/NukeBuild.cs
@@ -184,10 +184,7 @@ public abstract partial class NukeBuild : INukeBuild
     internal IEnumerable<string> TargetNames => ExecutableTargetFactory.GetTargetProperties(GetType()).Select(x => x.GetDisplayShortName());
     internal IEnumerable<string> HostNames => Host.AvailableTypes.Select(x => x.Name);
 
-    public bool IsSucceeding => ExecutionPlan.All(x => x.Status is
-        ExecutionStatus.Succeeded or
-        ExecutionStatus.Skipped or
-        ExecutionStatus.Collective);
+    public bool IsSucceeding => !IsFailing;
 
     public bool IsFailing => ExecutionPlan.Any(x => x.Status is
         ExecutionStatus.Failed or

--- a/source/Nuke.Build/NukeBuild.cs
+++ b/source/Nuke.Build/NukeBuild.cs
@@ -147,6 +147,12 @@ public abstract partial class NukeBuild : INukeBuild
     public bool NoLogo { get; set; }
 
     /// <summary>
+    /// Gets a value whether NUKE should work in an user interactive mode.
+    /// </summary>
+    [Parameter("Activates the interactive mode when asking for user inputs.")]
+    public bool Interactive { get; set; }
+
+    /// <summary>
     /// Gets a value whether a previous failed build should be continued.
     /// </summary>
     [Parameter("Indicates to continue a previously failed build attempt.")]


### PR DESCRIPTION
I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

---

This PR contains a proposal how https://github.com/nuke-build/nuke/issues/1436 could be implemented. Structurally we should still discuss where what should go but it already gives a feeling on what a user gets with this change. 

### Current design decisions

* I opted to the SpecterConsole as proposed in the issue. 
* I moved the `InvokedTarget` loading logic into the `ExecutableTargetFactory`
* I put the implementation of selecting targets into `NukeBuild` to allow people overriding and customizing it. 
* I made the `ExecutableTargets` public so custom implementations can use it. 
* For the sake of simplicity i did not move yet the console logic into the `Terminal` class. 
* I tried to keep the target selection output close to what a user sees when executing `--help`

Any feedback is welcome to complete this change.

### Demo

https://github.com/user-attachments/assets/1a59d2be-1444-4b9e-9361-7d0a788f0d61

```cs
class Build : NukeBuild
{
    public static int Main() => Execute<Build>();

    public Build()
    {
        Interactive = true;
    }

    public Target Compile => t => t
        .Description("Compiles the project")
        .Executes(() => Log.Information("Compile target execute"));

    public Target Test => t => t
        .DependsOn(Compile)
        .Description("Executes all tests")
        .Executes(() => Log.Information("Test target execute"));

    public Target PrepareEnvironment => t => t
        .Before(Compile)
        .Description("Prepares your development environment with all dependencies.")
        .Executes(() => Log.Information("PrepareEnvironment target execute"));
}
```