### PR TITLE
Use name of class for schema property 'build'.

### DIFF
--- a/source/Nuke.GlobalTool/Program.Secrets.cs
+++ b/source/Nuke.GlobalTool/Program.Secrets.cs
@@ -109,7 +109,7 @@ partial class Program
         var jobject = buildSchemaFile.ReadJson();
         return jobject
             .GetPropertyValue("definitions")
-            .GetPropertyValue("build")
+            .GetPropertyValue(nameof(NukeBuild))
             .GetPropertyValue("properties")
             .Children<JProperty>()
             .Where(x => x.Value.Value<JObject>().GetPropertyValueOrNull<string>("default") != null)


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

The global tool command `nuke :secrets` was not working. It was because the property name 'build' did not exist anymore. In an earlier change it was changed to `nameof(NukeBuild)`.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [ ] Follows the contribution guidelines
- [ ] Is based on my own work
- [ ] Is in compliance with my employer
