### PR TITLE
feature: Selectable logging way

### DIFF
--- a/source/Nuke.Build/Execution/BuildManager.cs
+++ b/source/Nuke.Build/Execution/BuildManager.cs
@@ -9,6 +9,7 @@ using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Extensions.DependencyModel;
+using Nuke.Build.Execution;
 using Nuke.Common.Tooling;
 using Nuke.Common.Utilities;
 using Nuke.Common.Utilities.Collections;
@@ -37,7 +38,7 @@ internal static class BuildManager
             .ForEach(x => AppDomain.CurrentDomain.Load(x));
     }
 
-    public static int Execute<T>(Expression<Func<T, Target>>[] defaultTargetExpressions)
+    public static int Execute<T>(Expression<Func<T, Target>>[] defaultTargetExpressions, params LoggingDirection[] LogDirection)
         where T : NukeBuild, new()
     {
         Console.OutputEncoding = Encoding.UTF8;
@@ -49,7 +50,7 @@ internal static class BuildManager
 
         try
         {
-            Logging.Configure(build);
+            Logging.Configure(build, LogDirection);
 
             build.ExecutableTargets = ExecutableTargetFactory.CreateAll(build, defaultTargetExpressions);
             build.ExecuteExtension<IOnBuildCreated>(x => x.OnBuildCreated(build.ExecutableTargets));

--- a/source/Nuke.Build/Execution/LoggingDirection.cs
+++ b/source/Nuke.Build/Execution/LoggingDirection.cs
@@ -1,0 +1,15 @@
+﻿namespace Nuke.Build.Execution
+{
+    /// <summary>
+    /// Will be used to decide where logs can be redirected (cosnosle/files/....)
+    /// </summary>
+    public enum LoggingDirection
+    {
+        Default,
+        Enricher,
+        Host,
+        Console,
+        InMemory,
+        Files
+    }
+}

--- a/source/Nuke.Build/Execution/LoggingDirection.cs
+++ b/source/Nuke.Build/Execution/LoggingDirection.cs
@@ -11,6 +11,11 @@
         Default,
 
         /// <summary>
+        /// No Logging at all
+        /// </summary>
+        None,
+
+        /// <summary>
         /// Use Enricher feature
         /// </summary>
         Enricher,

--- a/source/Nuke.Build/Execution/LoggingDirection.cs
+++ b/source/Nuke.Build/Execution/LoggingDirection.cs
@@ -5,11 +5,36 @@
     /// </summary>
     public enum LoggingDirection
     {
+        /// <summary>
+        /// Will use normal default nuke way of logging configuration
+        /// </summary>
         Default,
+
+        /// <summary>
+        /// Use Enricher feature
+        /// </summary>
         Enricher,
+
+        /// <summary>
+        /// Use Host logging
+        /// </summary>
         Host,
+
+        /// <summary>
+        /// Use Console logging
+        /// </summary>
         Console,
+
+        /// <summary>
+        /// Use Memory Logging
+        /// </summary>
         InMemory,
+
+        /// <summary>
+        /// Use Files Logging 
+        /// <para/>
+        /// (in some scenarios may hurt concurrent instances if they attempt to write on same file, otherwise you need manually create different temp directories)
+        /// </summary>
         Files
     }
 }

--- a/source/Nuke.Build/Logging.cs
+++ b/source/Nuke.Build/Logging.cs
@@ -59,7 +59,7 @@ public static class Logging
 
     public static void Configure(INukeBuild build = null, params LoggingDirection[] LogDirection)
     {
-
+        
         if (
             LogDirection == null
             ||
@@ -114,10 +114,14 @@ public static class Logging
             }
             if (LogDirection.Contains(LoggingDirection.Files))
             {
-                DeleteOldLogFiles(build);
+                if (build != null)
+                {
+                    DeleteOldLogFiles(build);
+                }
                 preLogger.ConfigureFiles(build);
             }
 
+            //finally complete logger initialization
             Log.Logger = preLogger
                 .ConfigureLevel()
                 .ConfigureFilter(build)

--- a/source/Nuke.Build/Logging.cs
+++ b/source/Nuke.Build/Logging.cs
@@ -96,6 +96,10 @@ public static class Logging
 
             var preLogger = new LoggerConfiguration();
 
+            if (LogDirection.Contains(LoggingDirection.None))
+            {
+                //no logging configuration needed at all
+            }
             if (LogDirection.Contains(LoggingDirection.Enricher))
             {
                 preLogger.ConfigureEnricher();


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Since there is no way to override Serilog Configuration outside the project, wanted to add a simple workaround.

#1088

**Made possible select exactly which type of logging the user needs**
By default it uses original way
Yet, its now possible to disable all kinds of undesired sinks (especially files)

Available types (optional parameter):

```csharp
public enum LoggingDirection
{
    /// <summary>
    /// Will use normal default nuke way of logging configuration
    /// </summary>
    Default,

    /// <summary>
    /// No Logging at all
    /// </summary>
    None,

    /// <summary>
    /// Use Enricher feature
    /// </summary>
    Enricher,

    /// <summary>
    /// Use Host logging
    /// </summary>
    Host,

    /// <summary>
    /// Use Console logging
    /// </summary>
    Console,

    /// <summary>
    /// Use Memory Logging
    /// </summary>
    InMemory,

    /// <summary>
    /// Use Files Logging 
    /// <para/>
    /// (in some scenarios may hurt concurrent instances if they attempt to write on same file, otherwise you need manually create different temp directories)
    /// </summary>
    Files
}
```

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer
