### PR TITLE
Set LogErrorAsStandardAttribute on GitTasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [vNext]
+- Added `LogErrorAsStandard` to `GitTasks` to not handle text on error output as tool error
 
 ## [9.0.1] / 2024-11-21
 - Fixed `Options` serialization to JSON

--- a/source/Nuke.Common/Tools/Git/GitTasks.cs
+++ b/source/Nuke.Common/Tools/Git/GitTasks.cs
@@ -4,9 +4,11 @@
 
 using System;
 using System.Linq;
+using Nuke.Common.Tooling;
 
 namespace Nuke.Common.Tools.Git;
 
+[LogErrorAsStandard]
 partial class GitTasks
 {
     public static bool GitIsDetached()


### PR DESCRIPTION
In #1470 was asked to activate `LogErrorAsStandard` for `GitTasks` to fix the problem, that `git` sometimes writes information to the error output even it is not an error.
The issue was closed because the request touches tool wrapper. So, here is the PR which should fix the issue.

The [git Coding Guidelines](https://github.com/git/git/commit/e258eb4800e30da2adbdb2df8d8d8c19d9b443e4) states that different messages are send to error output.
We should check the exit code only.

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [ ] Is based on my own work
- [x] Is in compliance with my employer

I did not check item 2 because I only realize the idea of @georg-eckert-zeiss.
