### PR TITLE
Use `LogErrorAsStandard` for `DockerTasks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [vNext]
+- Added `LogErrorAsStandard` to `DockerTasks` to not handle text on error output as tool error
 
 ## [9.0.1] / 2024-11-21
 - Fixed `Options` serialization to JSON

--- a/source/Nuke.Common/Tools/Docker/DockerTasks.cs
+++ b/source/Nuke.Common/Tools/Docker/DockerTasks.cs
@@ -10,4 +10,5 @@ using Serilog.Events;
 namespace Nuke.Common.Tools.Docker;
 
 [LogLevelPattern(LogEventLevel.Warning, "^WARNING!")]
+[LogErrorAsStandard]
 partial class DockerTasks;


### PR DESCRIPTION
Ref. #1472, #1470

<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Not only git logs std to err, Docker does the same...

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
