### PR TITLE
Fix `TaskGenerator` tool path with environment variable

### DIFF
--- a/source/Nuke.Tooling.Generator/Generators/TaskGenerator.cs
+++ b/source/Nuke.Tooling.Generator/Generators/TaskGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 Maintainers of NUKE.
+﻿// Copyright 2023 Maintainers of NUKE.
 // Distributed under the MIT License.
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
@@ -42,7 +42,8 @@ public static class TaskGenerator
             .WriteBlock(w =>
             {
                 w
-                    .WriteLine($"public static string {tool.Name}Path => new {tool.GetClassName()}().GetToolPath();")
+                    .WriteSummary($"Get the {tool.Name} executable path or '{tool.Name.ToUpperInvariant()}_EXE' environment variable.")
+                    .WriteLine($"public static string {tool.Name}Path => ToolTasks.GetToolPath<{tool.GetClassName()}>();")
                     .WriteLineIfTrue(tool.NuGetPackageId != null, $"public const string PackageId = {tool.NuGetPackageId.DoubleQuote()};")
                     .WriteLineIfTrue(tool.PackageExecutable != null, $"public const string PackageExecutable = {tool.PackageExecutable.DoubleQuote()};")
                     .WriteLineIfTrue(tool.NpmPackageId != null, $"public const string PackageId = {tool.NpmPackageId.DoubleQuote()};")


### PR DESCRIPTION
Fix `TaskGenerator` to use `ToolTasks.GetToolPath<T>()` to enable use environment variable like nuke `8.*`.

Related to this PR: #1485

Here is a before and after what change in the `.Generated.cs` files, I add a summery to show that the environment variable is used.

### Before
```C#
public static string AzureSignToolPath => new AzureSignToolTasks().GetToolPath();
```

### After
```C#
/// <summary>Get the AzureSignTool executable path or 'AZURESIGNTOOL_EXE' environment variable.</summary>
public static string AzureSignToolPath => ToolTasks.GetToolPath<AzureSignToolTasks>();
```

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
