### PR TITLE
fix(tools): update OctoVersion PackageId (#1492)

### DIFF
--- a/source/Nuke.Common/Tools/OctoVersion/OctoVersion.json
+++ b/source/Nuke.Common/Tools/OctoVersion/OctoVersion.json
@@ -5,7 +5,7 @@
   ],
   "name": "OctoVersion",
   "officialUrl": "https://github.com/OctopusDeploy/OctoVersion",
-  "nugetPackageId": "OctoVersion.Tool",
+  "nugetPackageId": "Octopus.OctoVersion.Tool",
   "nugetFramework": true,
   "packageExecutable": "OctoVersion.Tool.dll",
   "tasks": [


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Updated OctoVersion.json from deprecated tool to supported one

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer

Also ran `nuke GenerateTools` and didn't throw an error