### PR TITLE
fix(tools): set base class for ReSharper dupfinder

### DIFF
--- a/source/Nuke.Common/Tools/ReSharper/ReSharper.json
+++ b/source/Nuke.Common/Tools/ReSharper/ReSharper.json
@@ -124,6 +124,7 @@
       ],
       "definiteArgument": "dupfinder",
       "settingsClass": {
+        "baseClass": "ReSharperSettingsBase",
         "properties": [
           {
             "name": "Source",


### PR DESCRIPTION
Fixed missing base class for ReSharper dupfinder to solve crash when using `ReSharperDupFinder`:

```
System.InvalidCastException: Unable to cast object of type 'Nuke.Common.Tools.ReSharper.ReSharperDupFinderSettings' to type 'Nuke.Common.Tools.ReSharper.ReSharperSettingsBase'.
   at Nuke.Common.Tools.ReSharper.ReSharperTasks.PreProcess(ToolOptions options) in /_/source/Nuke.Common/Tools/ReSharper/ReSharperTasks.cs:line 22
   at Nuke.Common.Tooling.ToolTasks.Run[T](ToolOptions options) in /_/source/Nuke.Tooling/ToolTasks.Run.cs:line 23
   at Nuke.Common.Tools.ReSharper.ReSharperTasks.ReSharperDupFinder(Configure`1 configurator) in /_/source/Nuke.Common/Tools/ReSharper/ReSharper.Generated.cs:line 49
```

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
