### PR TITLE
Update Build.cs

### DIFF
--- a/source/Nuke.GlobalTool/templates/Build.cs
+++ b/source/Nuke.GlobalTool/templates/Build.cs
@@ -14,7 +14,6 @@ using Nuke.Common.Tools.NuGet;                                                  
 using Nuke.Common.Utilities.Collections;
 using static Nuke.Common.ChangeLog.ChangelogTasks;                                              // CHANGELOG
 using static Nuke.Common.EnvironmentInfo;
-using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.IO.PathConstruction;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;                                              // DOTNET
 using static Nuke.Common.Tools.MSBuild.MSBuildTasks;                                            // MSBUILD


### PR DESCRIPTION
Nuke.Common.IO.FileSystemTasks does not exist and broke my first time use.

<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
When using the latest version 9.0.4 on macOS, I could not follow the first baby steps: install, setup and run. The setup template referenced a non existent FileSystemTasks. I don't know where it was moved to, but since it is not used in code anyway, I propose to at least remove it.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [ x] Follows the contribution guidelines
- [ x] Is based on my own work
- [ x] Is in compliance with my employer
