### PR TITLE
Update GlobalTool Template .editorconfig

### DIFF
--- a/source/Nuke.GlobalTool/templates/.editorconfig
+++ b/source/Nuke.GlobalTool/templates/.editorconfig
@@ -9,3 +9,8 @@ csharp_style_expression_bodied_methods = true:silent
 csharp_style_expression_bodied_properties = true:warning
 csharp_style_expression_bodied_indexers = true:warning
 csharp_style_expression_bodied_accessors = true:warning
+
+dotnet_diagnostic.IDE0055.severity = none
+dotnet_diagnostic.IDE0052.severity = none
+dotnet_diagnostic.IDE0051.severity = none
+dotnet_diagnostic.IDE0044.severity = none


### PR DESCRIPTION
A recent change to VS2022 caused unused code sections to be faded. Due to the nature of how nuke-build works this means some targets in a build file are faded making them harder to see. 

This change adds some settings to the editorconfig to disable the feature.

I confirm that the pull-request:

- [/] Follows the contribution guidelines
- [/] Is based on my own work  
  ish, I got the solution from the following SO post https://stackoverflow.com/a/79220346
- [/] Is in compliance with my employer
