### PR TITLE
fix(npm): log npm warn messages as warning

### DIFF
--- a/source/Nuke.Common/Tools/Npm/NpmTasks.cs
+++ b/source/Nuke.Common/Tools/Npm/NpmTasks.cs
@@ -8,6 +8,6 @@ using Serilog.Events;
 
 namespace Nuke.Common.Tools.Npm;
 
-[LogLevelPattern(LogEventLevel.Warning, "^(npmWARN|npm WARN)")]
+[LogLevelPattern(LogEventLevel.Warning, "^(npmWARN|npm WARN|npm warn)")]
 [LogLevelPattern(LogEventLevel.Debug, "^(npm notice)")]
 partial class NpmTasks;


### PR DESCRIPTION
Deprication warnings have "npm warn" as messsage, not npm WARN.

<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

This pull request fixes a problem of marking npm warn messages as errors. 
This is solved by checking for "npm warn" and not only "npm WARN" as warnings string.

![image](https://github.com/user-attachments/assets/4c66d624-dc9c-4886-9965-55fb2ee27357)


<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
