### PR TITLE
Update documentation of NotNullOrWhiteSpace assertion

### DIFF
--- a/source/Nuke.Utilities/Assert.cs
+++ b/source/Nuke.Utilities/Assert.cs
@@ -117,7 +117,7 @@ public static class Assert
     }
 
     /// <summary>
-    /// Asserts that the string is not <c>null</c> or has only whitespace characters with an optional exception message. If no message is provided, the argument expression is used.
+    /// Asserts that the string is not <c>null</c>, empty or has only whitespace characters with an optional exception message. If no message is provided, the argument expression is used.
     /// </summary>
     [ContractAnnotation("str: null => halt")]
     public static string NotNullOrWhiteSpace(
@@ -128,7 +128,7 @@ public static class Assert
         string argumentExpression = null)
     {
         if (string.IsNullOrWhiteSpace(str))
-            throw new ArgumentException(message ?? "Expected string to be not null or whitespace", message == null ? argumentExpression : null);
+            throw new ArgumentException(message ?? "Expected string to be not null, empty or whitespace", message == null ? argumentExpression : null);
         return str;
     }
 


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->
Just a little addition to the documentation of the NotNullOrWhiteSpace assertion to better reflect its behaviour.
The underlying string.IsNullOrWhiteSpace() method also checks if the string is empty (see [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.string.isnullorwhitespace?view=net-9.0)).
I think this avoids confusion when choosing between NotNullOrEmpty and NotNullOrWhiteSpace.

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [X] Follows the contribution guidelines
- [X] Is based on my own work
- [X] Is in compliance with my employer
