### PR TITLE
Add BuildCompletion to AzurePipelinesBuildReason enum

### DIFF
--- a/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesBuildReason.cs
+++ b/source/Nuke.Common/CI/AzurePipelines/AzurePipelinesBuildReason.cs
@@ -33,5 +33,8 @@ public enum AzurePipelinesBuildReason
     PullRequest,
 
     /// <summary>The build was triggered by a resource trigger or it was triggered by another build.</summary>
-    ResourceTrigger
+    ResourceTrigger,
+
+    /// <summary>Another build triggers the build.</summary>
+    BuildCompletion
 }


### PR DESCRIPTION
The AzurePipelinesBuildReason has one extra value BuildCompletion

According to the documentation: https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services  the AzurePipelinesBuildReason has one extra property: BuildCompletion

<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->



<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
