### PR TITLE
build: update `Microsoft.Build*` dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,17 +62,17 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
 
-    <PackageVersion Include="Microsoft.Build" Version="17.12.6" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.12.6" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.12.6" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.12.6" />
+    <PackageVersion Include="Microsoft.Build" Version="17.12.50" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.12.50" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.12.50" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.12.50" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Update="Microsoft.Build" Version="17.11.4" />
-    <PackageVersion Update="Microsoft.Build.Framework" Version="17.11.4" />
-    <PackageVersion Update="Microsoft.Build.Tasks.Core" Version="17.11.4" />
-    <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="17.11.4" />
+    <PackageVersion Update="Microsoft.Build" Version="17.11.48" />
+    <PackageVersion Update="Microsoft.Build.Framework" Version="17.11.48" />
+    <PackageVersion Update="Microsoft.Build.Tasks.Core" Version="17.11.48" />
+    <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="17.11.48" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Address high-severity vulnerabilities in MSBuild packages that Nuke depends on:
- https://github.com/advisories/GHSA-w3q9-fxm7-j8fq
- https://github.com/advisories/GHSA-h4j7-5rxr-p4wc

Fixes https://github.com/nuke-build/nuke/issues/1544

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
