### PR TITLE
Add support for Vs2026 MsBuild

### DIFF
--- a/source/Nuke.Common/Tools/MSBuild/MSBuildVersion.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuildVersion.cs
@@ -15,6 +15,7 @@ namespace Nuke.Common.Tools.MSBuild;
 [PublicAPI]
 public enum MSBuildVersion
 {
+    VS2026,
     VS2022,
     VS2019,
     VS2017,


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Added `Vs2026` to `MsBuildVersion`
Added logic for locating MsBuild installed via Vs2026

I've left some questions in the comments

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
