### PR TITLE
Add :setup support for slnx solution files

### DIFF
--- a/source/Nuke.GlobalTool.Tests/UpdateSolutionFileContentTests.TestXml_number=1.verified.txt
+++ b/source/Nuke.GlobalTool.Tests/UpdateSolutionFileContentTests.TestXml_number=1.verified.txt
@@ -1,4 +1,6 @@
 ﻿<Solution>
   <Project Path="TestProject1/TestProject1.csproj" />
-  <Project Path="RELATIVE" />
+  <Project Path="RELATIVE">
+    <Build Project="false" />
+  </Project>
 </Solution>

--- a/source/Nuke.GlobalTool.Tests/UpdateSolutionFileContentTests.TestXml_number=1.verified.txt
+++ b/source/Nuke.GlobalTool.Tests/UpdateSolutionFileContentTests.TestXml_number=1.verified.txt
@@ -1,0 +1,4 @@
+﻿<Solution>
+  <Project Path="TestProject1/TestProject1.csproj" />
+  <Project Path="RELATIVE" />
+</Solution>

--- a/source/Nuke.GlobalTool.Tests/UpdateSolutionFileContentTests.cs
+++ b/source/Nuke.GlobalTool.Tests/UpdateSolutionFileContentTests.cs
@@ -155,7 +155,9 @@ public class UpdateSolutionFileContentTests
         """
         <Solution>
           <Project Path="TestProject1/TestProject1.csproj" />
-          <Project Path="RELATIVE" />
+          <Project Path="RELATIVE">
+            <Build Project="false" />
+          </Project>
         </Solution>
         """)]
     public Task TestXml(int number, string input, string expected)

--- a/source/Nuke.GlobalTool.Tests/UpdateSolutionFileContentTests.cs
+++ b/source/Nuke.GlobalTool.Tests/UpdateSolutionFileContentTests.cs
@@ -3,8 +3,11 @@
 // https://github.com/nuke-build/nuke/blob/master/LICENSE
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
 using Nuke.Common.Utilities;
 using VerifyXunit;
 using Xunit;
@@ -138,6 +141,35 @@ public class UpdateSolutionFileContentTests
         Program.UpdateSolutionFileContent(content, "RELATIVE", "GUID", "NAME");
 
         return Verifier.Verify(expected)
+            .UseParameters(number);
+    }
+
+    [Theory]
+    [InlineData(
+        1,
+        """
+        <Solution>
+          <Project Path="TestProject1/TestProject1.csproj" />
+        </Solution>
+        """,
+        """
+        <Solution>
+          <Project Path="TestProject1/TestProject1.csproj" />
+          <Project Path="RELATIVE" />
+        </Solution>
+        """)]
+    public Task TestXml(int number, string input, string expected)
+    {
+        var content = XDocument.Load(new StringReader(input));
+        Program.UpdateSolutionXmlFileContent(content, "RELATIVE");
+        
+        var settings = new XmlWriterSettings { OmitXmlDeclaration = true, Indent = true };
+        var stringStream = new StringWriter();
+        using var writer = XmlWriter.Create(stringStream, settings);
+        content.Save(writer);
+        writer.Flush();
+
+        return Verifier.Verify(stringStream.ToString())
             .UseParameters(number);
     }
 }

--- a/source/Nuke.GlobalTool/Program.Setup.cs
+++ b/source/Nuke.GlobalTool/Program.Setup.cs
@@ -213,7 +213,9 @@ partial class Program
             return;
         }
 
-        solutionElement.Add(new XElement("Project", new XAttribute("Path", path)));
+        var projectElement = new XElement("Project", new XAttribute("Path", path));
+        projectElement.Add(new XElement("Build", new XAttribute("Project", value: false)));
+        solutionElement.Add(projectElement);
     }
     
     private static string[] GetTemplate(string templateName)

--- a/source/Nuke.GlobalTool/templates/_build.csproj
+++ b/source/Nuke.GlobalTool/templates/_build.csproj
@@ -9,6 +9,8 @@
     <NukeScriptDirectory>_SCRIPT_DIRECTORY_</NukeScriptDirectory>
     <NukeTelemetryVersion>_TELEMETRY_VERSION_</NukeTelemetryVersion>
     <IsPackable>false</IsPackable>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <UseArtifactsOutput>false</UseArtifactsOutput>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* support `nuke :setup` for slnx format based solutions
* set generated csproj TFM to `net10.0`
* add `ManagePackageVersionsCentrally` and `UseArtifactsOutput` = `false` directive to generated build.csproj to avoid problems CPM enabled solutions and output path clashes

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
