### PR TITLE
Fix wrong prefix calculation for solution folders starting with digits

### DIFF
--- a/source/Nuke.SourceGenerators/StronglyTypedSolutionGenerator.cs
+++ b/source/Nuke.SourceGenerators/StronglyTypedSolutionGenerator.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -68,7 +69,7 @@ public class StronglyTypedSolutionGenerator : ISourceGenerator
                 continue;
 
                 [CanBeNull]
-                string GetDeclaration(IProjectContainer container)
+                string GetDeclaration(IProjectContainer container, string folderName = null)
                 {
                     var prefix = new string('_', container.Descendants(x => x.Parent).Count() + 1);
                     var model = new
@@ -78,21 +79,21 @@ public class StronglyTypedSolutionGenerator : ISourceGenerator
                         Name = GetEscapedName(container switch
                         {
                             Solution => member.Name,
-                            SolutionFolder folder => prefix.Substring(1) + folder.Name,
+                            SolutionFolder folder => folderName ?? folder.Name,
                             _ => throw new ArgumentOutOfRangeException(nameof(container), container, null)
                         }),
                         Projects = container.Projects.OrderBy(x => x.Name).Select(x => new
                         {
                             x.Name,
-                            EscapedName = GetEscapedName(x.Name),
+                            EscapedName = GetEscapedName(x.Name)
                         }),
                         Folders = container.SolutionFolders.OrderBy(x => x.Name).Select(x => new
                         {
                             x.Name,
-                            TypeName = prefix + GetEscapedName(x.Name),
-                            EscapedName = GetEscapedName(x.Name),
+                            TypeName = folderName ?? $"{prefix}{GetEscapedName(x.Name)}",
+                            EscapedName = GetEscapedName(x.Name)
                         }),
-                        Declarations = container.SolutionFolders.OrderBy(x => x.Name).Select(GetDeclaration).ToArray(),
+                        Declarations = container.SolutionFolders.OrderBy(x => x.Name).Select(x => GetDeclaration(x, $"{prefix}{GetEscapedName(x.Name)}")).ToArray(),
                     };
 
                     // lang=csharp
@@ -118,10 +119,18 @@ public class StronglyTypedSolutionGenerator : ISourceGenerator
                         """);
                     return template.Render(model);
 
-                    string GetEscapedName(string name) => name
-                        // .Replace(".", fancyNaming ? "丨" : "_")
-                        .Replace(".", fancyNaming ? "٠" : "_")
-                        .ReplaceRegex(@"(^[\W^\d]|[\W])", _ => "_");
+                    string GetEscapedName(string name)
+                    {
+                        name = name
+                            // .Replace(".", fancyNaming ? "丨" : "_")
+                            .Replace(".", fancyNaming ? "٠" : "_")
+                            .ReplaceRegex(@"[^A-Za-z0-9_]", _ => "_");
+                        
+                        if (Regex.IsMatch(name, @"^[0-9]"))
+                            return "_" + name;
+
+                        return name;
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Thanks for your contribution! -->
<!-- Please describe what you did below this line -->

Fixes the wrong prefix calculation for solution folders starting with digits

Fixes: #1578 

<!-- Make sure to tick all the boxes if possible -->

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
