### PR TITLE
Add support for MSBuildTask for VS2026

### DIFF
--- a/source/Nuke.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
@@ -40,7 +40,7 @@ public static class MSBuildToolPathResolver
         var instances = new List<Instance>();
 
         instances.AddRange(
-            from version in new[] { MSBuildVersion.VS2022, MSBuildVersion.VS2019, MSBuildVersion.VS2017 }
+            from version in new[] { MSBuildVersion.VS2026, MSBuildVersion.VS2022, MSBuildVersion.VS2019, MSBuildVersion.VS2017 }
             from platform in s_platforms
             from edition in typeof(VisualStudioEdition).GetEnumValues<VisualStudioEdition>()
             let folder = version == MSBuildVersion.VS2022 && edition != VisualStudioEdition.BuildTools

--- a/source/Nuke.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
@@ -43,9 +43,7 @@ public static class MSBuildToolPathResolver
             from version in new[] { MSBuildVersion.VS2026, MSBuildVersion.VS2022, MSBuildVersion.VS2019, MSBuildVersion.VS2017 }
             from platform in s_platforms
             from edition in typeof(VisualStudioEdition).GetEnumValues<VisualStudioEdition>()
-            let folder = version == MSBuildVersion.VS2022 && edition != VisualStudioEdition.BuildTools
-                ? SpecialFolders.ProgramFiles
-                : SpecialFolders.ProgramFilesX86
+            let folder = GetProgramFilesFolder(version, edition)
             select GetFromVs2017Instance(version, platform, edition, folder));
 
         instances.AddRange(
@@ -96,6 +94,24 @@ public static class MSBuildToolPathResolver
             platform == MSBuildPlatform.x64
                 ? Path.Combine(basePath, "amd64")
                 : basePath);
+    }
+
+    private static SpecialFolders GetProgramFilesFolder(MSBuildVersion version, VisualStudioEdition edition)
+    {
+        if (edition == VisualStudioEdition.BuildTools)
+        {
+            return SpecialFolders.ProgramFilesX86;
+        }
+
+        return version switch
+        {
+            MSBuildVersion.VS2013 => SpecialFolders.ProgramFilesX86,
+            MSBuildVersion.VS2015 => SpecialFolders.ProgramFilesX86,
+            MSBuildVersion.VS2017 => SpecialFolders.ProgramFilesX86,
+            MSBuildVersion.VS2019 => SpecialFolders.ProgramFilesX86,
+            // Versions VS2022+ are 64-bit
+            _ => SpecialFolders.ProgramFiles
+        };
     }
 
     private static string GetVersionFolder(MSBuildVersion version)

--- a/source/Nuke.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuildToolPathResolver.cs
@@ -69,10 +69,9 @@ public static class MSBuildToolPathResolver
         VisualStudioEdition edition,
         SpecialFolders specialFolder)
     {
-        var versionDirectoryName = version.ToString().TrimStart("VS");
         var basePath = Path.Combine(
             EnvironmentInfo.SpecialFolder(specialFolder).NotNull(),
-            $@"Microsoft Visual Studio\{versionDirectoryName}\{edition}\MSBuild\{GetVersionFolder(version)}\Bin");
+            $@"Microsoft Visual Studio\{GetVisualStudioFolder(version)}\{edition}\MSBuild\{GetVersionFolder(version)}\Bin");
 
         return new Instance(
             version,
@@ -111,6 +110,15 @@ public static class MSBuildToolPathResolver
             MSBuildVersion.VS2019 => SpecialFolders.ProgramFilesX86,
             // Versions VS2022+ are 64-bit
             _ => SpecialFolders.ProgramFiles
+        };
+    }
+
+    private static string GetVisualStudioFolder(MSBuildVersion version)
+    {
+        return version switch
+        {
+            MSBuildVersion.VS2026 => "18",
+            _ => version.ToString().TrimStart("VS")
         };
     }
 

--- a/source/Nuke.Common/Tools/MSBuild/MSBuildVersion.cs
+++ b/source/Nuke.Common/Tools/MSBuild/MSBuildVersion.cs
@@ -15,6 +15,7 @@ namespace Nuke.Common.Tools.MSBuild;
 [PublicAPI]
 public enum MSBuildVersion
 {
+    VS2026,
     VS2022,
     VS2019,
     VS2017,


### PR DESCRIPTION
Fixes #1566

Add support for MSBuildTask for VS2026.

Now, there is no possibility to use 2026 without manually setting paths.

While reviewing, consider checking commit by commit. It brings explanations for the particular steps.

Needed for https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer
