### PR TITLE
chore(deps): patch vulnerable transitives (CVE-2026-33116, Scriban)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
@@ -18,7 +19,7 @@
     <PackageVersion Include="NJsonSchema" Version="11.5.2" />
     <PackageVersion Include="NJsonSchema.NewtonsoftJson" Version="11.5.2" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NuGet.Packaging" Version="6.12.1" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.14.3" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.Formatting.Compact" Version="3.0.0" />
@@ -28,6 +29,7 @@
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageVersion Include="System.Text.Json" Version="10.0.0" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="matkoch.spectre.console" Version="0.46.0" />
@@ -56,7 +58,7 @@
   <!-- Solution Model -->
   <ItemGroup>
     <PackageVersion Include="matkoch.Microsoft.VisualStudio.SolutionPersistence" Version="1.0.61" />
-    <PackageVersion Include="Scriban" Version="6.2.1" />
+    <PackageVersion Include="Scriban" Version="7.1.0" />
   </ItemGroup>
   <!-- MSBuild (Nuke.ProjectModel + Nuke.MSBuildTasks) -->
   <ItemGroup>
@@ -71,11 +73,13 @@
     <PackageVersion Update="Microsoft.Build.Framework" Version="17.14.28" />
     <PackageVersion Update="Microsoft.Build.Tasks.Core" Version="17.14.28" />
     <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="17.14.28" />
+    <PackageVersion Update="System.Security.Cryptography.Xml" Version="9.0.15" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Update="Microsoft.Build" Version="17.11.48" />
     <PackageVersion Update="Microsoft.Build.Framework" Version="17.11.48" />
     <PackageVersion Update="Microsoft.Build.Tasks.Core" Version="17.11.48" />
     <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="17.11.48" />
+    <PackageVersion Update="System.Security.Cryptography.Xml" Version="8.0.3" />
   </ItemGroup>
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -57,6 +57,7 @@
     <PackageReference Include="linqtotwitter" Version="6.15.0" />
     <PackageReference Include="MQTTnet" Version="4.3.7.1207" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageDownload Include="Codecov.Tool" Version="[1.13.0]" />
     <PackageDownload Include="GitVersion.Tool" Version="[5.12.0]" />
     <PackageDownload Include="JetBrains.ReSharper.GlobalTools" Version="[2023.2.3]" />


### PR DESCRIPTION
Fixes #1591.

## Summary

- Pins `System.Security.Cryptography.Xml` transitively to 10.0.6 / 9.0.15 / 8.0.3 per TFM, fixing **CVE-2026-33116** (GHSA-37gx-xxp4-5rgx) and **CVE-2026-26171** (GHSA-w3x6-4m5h-cxqf).
- Bumps **Scriban** 6.2.1 → 7.1.0 (direct dep in `Nuke.SourceGenerators`), clearing 1 critical + 5 high + 3 moderate advisories. Scriban 7.1.0 still supports `netstandard2.0`.
- Enables `CentralPackageTransitivePinningEnabled` so CPM lifts vulnerable transitives centrally via `Directory.Packages.props` (follows the existing TFM-conditional `<PackageVersion Update=…>` pattern used for `Microsoft.Build.*`).
- Adds a direct `<PackageReference>` for `System.Security.Cryptography.Xml` in `build/_build.csproj` because it opts out of CPM (`ManagePackageVersionsCentrally=false`).

---

I confirm that the pull-request:

- [x] Follows the contribution guidelines
- [x] Is based on my own work
- [x] Is in compliance with my employer